### PR TITLE
feat(#39): Create Knowledge Base Skills

### DIFF
--- a/skill/knowledge-base-notes/SKILL.md
+++ b/skill/knowledge-base-notes/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: knowledge-base-notes
+description: |
+  管理 Zettelkasten 笔记的全生命周期。
+  
+  触发场景：
+  - "记录一个想法", "帮我记个笔记", "添加笔记", "记一下..."
+  - "搜索 xxx", "找一下笔记", "笔记里有..."
+  - "删除笔记", "删掉这个笔记"
+  - "查看引用", "这个笔记被哪些引用", "引用关系"
+  - "推荐链接", "这个内容和哪些相关"
+  - "深度搜索", "语义+图谱搜索"
+  - "知识图谱", "孤立笔记", "图谱统计"
+  - "用 meeting 模板", "创建会议记录", "用 literature 模板"
+  
+  依赖：需要知道目标知识库（从上下文获取或询问用户）。
+---
+
+# Knowledge Base Notes
+
+管理笔记的全生命周期。需要目标知识库，从对话上下文中获取或询问用户。
+
+## 核心设计原则
+
+### 1. 依赖目标知识库
+
+每个操作都需要 `--kb` 参数：
+
+```python
+def execute(user_input):
+    # 1. 提取知识库（从用户输入或上下文）
+    kb = extract_kb(user_input) or get_context_kb() or ask_user()
+    
+    # 2. 执行命令（必须带 --kb）
+    result = run(f"zk {command} --kb {kb} --format json")
+    
+    return format_response(result)
+```
+
+### 2. 支持显式指定
+
+用户可以在输入中指定知识库：
+
+```
+"在 work 库中搜索 Python" → --kb work
+"personal 库添加笔记" → --kb personal
+```
+
+### 3. 回退到询问
+
+如果不确定知识库，主动询问：
+
+```
+"您想在哪个知识库操作？"
+1. work (当前上下文)
+2. personal
+3. default
+```
+
+## Available Tools
+
+### note_add
+添加笔记
+
+**触发**: "记录一个想法", "添加笔记"
+
+**参数**:
+- content (required): 内容
+- kb (required): 知识库
+- title (optional): 标题
+- note_type (optional): fleeting/literature/permanent
+- tags (optional): 标签列表
+
+**CLI**:
+```bash
+zk add "{content}" --kb {kb} [--title "{title}"] [--type {type}] [--tag {tag}] --format json
+```
+
+---
+
+### note_add_with_template
+使用模板创建笔记
+
+**触发**: "用 meeting 模板", "创建会议记录"
+
+**参数**:
+- content (required): 内容
+- template (required): quick/meeting/literature
+- kb (required): 知识库
+- title (optional): 标题
+
+**CLI**:
+```bash
+zk add "{content}" --kb {kb} --template {template} [--title "{title}"] --format json
+```
+
+---
+
+### note_search
+搜索笔记
+
+**触发**: "搜索", "找一下"
+
+**参数**:
+- query (required): 关键词
+- kb (required): 知识库
+- top_k (optional): 数量，默认 5
+- search_mode (optional): hybrid/semantic/keyword，默认 hybrid
+
+**CLI**:
+```bash
+zk search "{query}" --kb {kb} --format json [--top {n}] [--mode {mode}]
+```
+
+---
+
+### note_query
+深度搜索（语义+图谱）
+
+**触发**: "深度搜索", "查找关联内容"
+
+**参数**:
+- query (required): 关键词
+- kb (required): 知识库
+- top_k (optional): 默认 5
+- graph_depth (optional): 图谱深度，默认 2
+
+**CLI**:
+```bash
+zk query "{query}" --kb {kb} --format json [--top {n}] [--depth {d}]
+```
+
+---
+
+### note_delete
+删除笔记
+
+**触发**: "删除笔记"
+
+**参数**:
+- note_id (required): 笔记 ID
+- kb (required): 知识库
+- force (optional): 强制删除
+
+**CLI**:
+```bash
+zk delete {note_id} --kb {kb} [--force]
+```
+
+---
+
+### note_refs
+查看引用关系
+
+**触发**: "查看引用", "被哪些笔记引用"
+
+**参数**:
+- note_id (required): 笔记 ID
+- kb (required): 知识库
+
+**CLI**:
+```bash
+zk refs --kb {kb} --note {note_id} --format json
+```
+
+---
+
+### kb_suggest_links
+推荐相关笔记
+
+**触发**: "推荐链接", "和哪些笔记相关"
+
+**参数**:
+- content (required): 内容文本
+- kb (required): 知识库
+- top_k (optional): 默认 5
+- threshold (optional): 阈值 0-1，默认 0.6
+
+**CLI**:
+```bash
+zk suggest-links "{content}" --kb {kb} [--top {n}] [--threshold {t}]
+```
+
+---
+
+### kb_graph
+知识图谱分析
+
+**触发**: "知识图谱", "孤立笔记", "图谱统计"
+
+**模式**:
+- `--stats`: 统计信息
+- `--orphans`: 孤立笔记
+- `--note {id}`: 特定笔记的关联
+
+**CLI**:
+```bash
+zk graph --kb {kb} --format json [--stats | --orphans | --note {id}]
+```
+
+---
+
+### template_list
+列出可用模板
+
+**触发**: "有哪些模板", "可用模板"
+
+**CLI**:
+```bash
+zk template list
+```
+
+## 响应模板
+
+### 创建成功
+```
+✅ 笔记已创建
+   知识库: {kb}
+   标题: {title}
+   类型: {type}
+   ID: {id}
+   路径: {filepath}
+```
+
+### 搜索结果
+```
+🔍 找到 {count} 条相关笔记：
+
+{rank}. [{score}] {title}
+   类型: {type}
+   {preview}
+
+💡 使用 "zk show {id}" 查看完整内容
+```
+
+### 推荐链接
+```
+💡 推荐链接（相似度 > {threshold}）:
+
+{rank}. [{score}] {title}
+   匹配类型: {match_type}
+   
+使用 "zk add '... [[{title}]] ...'" 添加链接
+```
+
+## 与 Workspace Skill 协作
+
+```
+用户: "切换到 work 知识库"
+→ Workspace Skill
+→ 记住: current_kb = "work"
+
+用户: "记录一个想法：AI 发展很快"
+→ Notes Skill
+→ 获取 kb = "work"（从上下文）
+→ 执行: zk add "AI 发展很快" --kb work
+
+用户: "搜索 Python"
+→ Notes Skill
+→ 获取 kb = "work"
+→ 执行: zk search "Python" --kb work --format json
+```
+
+## 参考
+
+详细 CLI 命令参考：[references/commands.md](references/commands.md)

--- a/skill/knowledge-base-workspace/SKILL.md
+++ b/skill/knowledge-base-workspace/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: knowledge-base-workspace
+description: |
+  管理 Zettelkasten 知识库工作空间。在对话中维护当前知识库上下文。
+  
+  触发场景：
+  - "有哪些知识库", "列出知识库", "查看所有知识库"
+  - "切换到 xxx 知识库", "使用 xxx 库", "去 xxx 库"
+  - "创建知识库", "新建一个叫 xxx 的知识库"
+  - "删除 xxx 知识库", "移除知识库"
+  - "知识库状态", "查看状态", "知识库情况"
+  - "今天的笔记", "查看收件箱", "最近有什么笔记"
+  
+  重要：本 Skill 在对话中记住当前知识库，不使用全局默认配置。
+---
+
+# Knowledge Base Workspace
+
+管理你的知识库工作空间。在对话中维护当前知识库，所有操作都显式指定 `--kb`。
+
+## 核心设计原则
+
+### 1. 会话级上下文（对话记忆）
+
+在对话中记住当前知识库，不写入文件：
+
+```
+用户: "切换到 work 知识库"
+→ 记住: current_kb = "work"
+→ 后续操作自动使用 work
+
+用户: "切换到 personal"
+→ 更新: current_kb = "personal"
+→ 后续操作自动使用 personal
+```
+
+### 2. 显式 --kb 参数
+
+每个 CLI 命令都必须带上 `--kb` 参数：
+
+```bash
+# ✅ 正确
+zk status --kb work --format json
+
+# ❌ 错误（依赖全局默认，多实例会冲突）
+zk status --format json
+```
+
+### 3. 不使用 zk kb switch
+
+避免修改全局默认配置，只更新对话中的记忆。
+
+## 工作流程
+
+### 标准流程
+
+```python
+# 在对话中维护的上下文
+current_kb = None  # 当前选中的知识库
+
+def execute(user_input):
+    # 1. 识别意图
+    intent = recognize(user_input)
+    
+    # 2. 确定知识库
+    kb = extract_kb(user_input) or current_kb
+    
+    # 3. 执行命令（必须带 --kb）
+    result = run(f"zk {command} --kb {kb} --format json")
+    
+    # 4. 如果是切换操作，更新记忆
+    if intent == "kb_switch":
+        current_kb = kb
+    
+    # 5. 返回结果
+    return format_response(result)
+```
+
+## Available Tools
+
+### kb_list
+列出所有知识库
+
+**触发**: "有哪些知识库"
+
+**CLI**:
+```bash
+zk kb list --format json
+```
+
+**返回示例**:
+```json
+{
+  "current": "default",
+  "knowledge_bases": [
+    {"name": "default", "path": "~/.zettelkasten", "total_notes": 10, "is_current": true},
+    {"name": "work", "path": "~/.zettelkasten-work", "total_notes": 25}
+  ]
+}
+```
+
+---
+
+### kb_switch
+切换到指定知识库（只更新对话记忆）
+
+**触发**: "切换到 work", "使用 personal 库"
+
+**实现**:
+```python
+def kb_switch(name):
+    # 验证存在
+    result = run("zk kb list --format json")
+    kbs = json.loads(result)
+    
+    if name not in [kb["name"] for kb in kbs["knowledge_bases"]]:
+        return error(f"知识库 {name} 不存在")
+    
+    # 更新对话记忆（关键：不调用 zk kb switch）
+    current_kb = name
+    
+    return success(f"已切换到 {name}，后续操作将使用此知识库")
+```
+
+---
+
+### kb_create
+创建新知诖库
+
+**触发**: "创建知识库", "新建一个叫 study 的库"
+
+**CLI**:
+```bash
+zk init --name <name> [--path <path>] [--desc <description>]
+```
+
+---
+
+### kb_remove
+删除知识库
+
+**触发**: "删除知识库"
+
+**CLI**:
+```bash
+zk kb remove <name> --force
+```
+
+---
+
+### kb_status
+查看知识库状态
+
+**触发**: "知识库状态", "查看状态"
+
+**CLI**:
+```bash
+zk status --kb {current_kb} --format json
+```
+
+---
+
+### kb_daily_notes
+查看某天笔记（默认今天）
+
+**触发**: "今天的笔记", "昨天的笔记", "查看某天的笔记"
+
+**CLI**:
+```bash
+zk daily --kb {current_kb} [--date YYYY-MM-DD]
+```
+
+---
+
+### kb_inbox
+查看临时笔记
+
+**触发**: "查看收件箱", "最近的临时笔记"
+
+**CLI**:
+```bash
+zk inbox --kb {current_kb} [--limit N]
+```
+
+---
+
+### note_list
+列出笔记
+
+**触发**: "列出笔记", "最近的笔记", "查看笔记列表"
+
+**CLI**:
+```bash
+zk list --kb {current_kb} [--limit N] [--type TYPE] --format json
+```
+
+## 响应模板
+
+### 切换成功
+```
+✅ 已切换到 {name} 知识库
+
+后续操作将默认使用此知识库：
+- 添加笔记
+- 搜索内容  
+- 查看状态
+
+可用命令：
+- "记录一个想法..."
+- "搜索 xxx"
+- "查看状态"
+```
+
+### 知识库列表
+```
+您的知识库 ({count} 个):
+
+⭐ {current} (当前) - {path}
+   笔记: {total} | F/L/P: {fleeting}/{literature}/{permanent}
+
+   {name2} - {path2}
+   笔记: {total2}
+
+💡 使用 "切换到 {name}" 切换知识库
+```
+
+## 多实例说明
+
+多个 Kimi Code 实例同时使用时：
+- 每个实例有自己的对话记忆（current_kb）
+- 互不干扰，不会冲突
+- 每个命令都显式 `--kb`，不依赖全局默认
+
+## Windows 注意事项
+
+1. UTF-8 编码：`chcp 65001`
+2. 验证安装：`where zk`
+3. 表格乱码改用 JSON：`--format json`
+
+## 参考
+
+详细 CLI 命令参考：[references/commands.md](references/commands.md)


### PR DESCRIPTION
## Summary

创建两个 Knowledge Base Skills，支持自然语言管理 Zettelkasten 知识库。

## Changes

### knowledge-base-workspace
管理工作空间的 Skill，包含 8 个 Tools：
- kb_list - 列出知识库
- kb_switch - 切换知识库（会话级）
- kb_create - 创建知识库
- kb_remove - 删除知识库
- kb_status - 查看状态
- kb_daily_notes - 查看某天笔记
- kb_inbox - 查看收件箱
- 
ote_list - 列出笔记

### knowledge-base-notes
管理笔记的 Skill，包含 9 个 Tools：
- 
ote_add - 添加笔记
- 
ote_add_with_template - 模板创建
- 
ote_search - 搜索笔记
- 
ote_query - 深度搜索（语义+图谱）
- 
ote_delete - 删除笔记
- 
ote_refs - 查看引用关系
- kb_suggest_links - 推荐链接
- kb_graph - 知识图谱分析
- 	emplate_list - 列出模板

## Design Decisions

1. **会话级上下文**: 不使用持久化文件，依赖对话记忆
2. **显式 --kb**: 每个命令都带 --kb 参数，多实例安全
3. **不使用 zk kb switch**: 避免修改全局默认配置

## Testing

- [ ] 安装 Skills 到 Kimi
- [ ] 测试触发词
- [ ] 测试各个 Tools

Closes #39