### PR TITLE
fix: 修复知识库切换后向量存储未重置和链接匹配错误

### DIFF
--- a/zk-cli/zk/cli.py
+++ b/zk-cli/zk/cli.py
@@ -148,25 +148,31 @@ def extract_wiki_links(content: str) -> List[str]:
     return [m.strip() for m in matches]
 
 
-def find_note_id_by_title_or_id(title_or_id: str) -> Optional[str]:
-    """通过标题或ID查找笔记"""
-    all_notes = note.list_notes()
-    
+def find_note_id_by_title_or_id(
+    title_or_id: str, all_notes: Optional[list] = None
+) -> Optional[str]:
+    """通过标题或ID查找笔记
+
+    匹配优先级：精确ID → 精确标题 → 标题包含
+    """
+    if all_notes is None:
+        all_notes = note.list_notes()
+
     # 首先尝试精确匹配 ID
     for n in all_notes:
         if n.id == title_or_id:
             return n.id
-    
-    # 然后尝试标题包含匹配
-    for n in all_notes:
-        if title_or_id.lower() in n.title.lower():
-            return n.id
-    
-    # 最后尝试模糊匹配（标题相近）
+
+    # 然后尝试标题精确匹配
     for n in all_notes:
         if n.title.lower() == title_or_id.lower():
             return n.id
-    
+
+    # 最后尝试标题包含匹配（作为 fallback）
+    for n in all_notes:
+        if title_or_id.lower() in n.title.lower():
+            return n.id
+
     return None
 
 
@@ -223,9 +229,12 @@ def _add_note_impl(
     wiki_links = extract_wiki_links(content)
     resolved_links = []
     unresolved = []
-    
+
+    # 缓存笔记列表，避免每个链接重复加载
+    all_notes = note.list_notes() if wiki_links else []
+
     for link_text in wiki_links:
-        target_id = find_note_id_by_title_or_id(link_text)
+        target_id = find_note_id_by_title_or_id(link_text, all_notes=all_notes)
         if target_id:
             resolved_links.append(target_id)
         else:

--- a/zk-cli/zk/config.py
+++ b/zk-cli/zk/config.py
@@ -160,12 +160,14 @@ def use_kb(kb_name: Optional[str] = None):
         config.zk_dir = kb_path / ".zk"
         config.chroma_dir = config.zk_dir / "chroma_db"
         
-        # 重置 BM25 索引和搜索引擎（使用新的知识库路径）
+        # 重置索引和搜索引擎（使用新的知识库路径）
         try:
             from .bm25_index import reset_bm25_index
             from .search_engine import reset_search_engine
+            from .vector_store import reset_vector_store
             reset_bm25_index()
             reset_search_engine()
+            reset_vector_store()
         except Exception:
             pass  # 忽略重置错误
         

--- a/zk-cli/zk/vector_store.py
+++ b/zk-cli/zk/vector_store.py
@@ -192,3 +192,9 @@ def get_vector_store() -> VectorStore:
     if _vector_store is None:
         _vector_store = VectorStore()
     return _vector_store
+
+
+def reset_vector_store():
+    """重置全局向量存储实例（用于切换知识库时）"""
+    global _vector_store
+    _vector_store = None


### PR DESCRIPTION
## Summary

- **Fix #46**: `use_kb()` 切换知识库时未重置 VectorStore 单例，导致语义搜索仍查询旧库数据。新增 `reset_vector_store()` 并在 `use_kb()` 中与 BM25/搜索引擎一起调用
- **Fix #47**: `find_note_id_by_title_or_id` 匹配顺序错误（子串匹配优先于精确标题匹配），导致 `[[Python]]` 错误解析到 "Python vs Java" 等笔记。修正为 精确ID → 精确标题 → 标题包含；同时缓存笔记列表避免重复磁盘读取

## 改动文件

| 文件 | 改动 |
|------|------|
| `zk/vector_store.py` | 新增 `reset_vector_store()` 函数 |
| `zk/config.py` | `use_kb()` 中调用 `reset_vector_store()` |
| `zk/cli.py` | 修正匹配顺序 + `find_note_id_by_title_or_id` 支持 `all_notes` 参数缓存 |

## Test plan

- [x] `reset_vector_store()` 重置后获取新实例验证通过
- [x] 链接匹配顺序验证：`[[Python]]` 精确匹配到标题为 "Python" 的笔记
- [x] 已有测试 `test_formatters.py`、`test_template.py` 全部通过（43/43）

🤖 Generated with [Claude Code](https://claude.com/claude-code)