### PR TITLE
fix: 修复知识图谱双向边破坏聚类和枢纽分析

### DIFF
--- a/zk-cli/zk/graph.py
+++ b/zk-cli/zk/graph.py
@@ -3,7 +3,6 @@ Knowledge graph module using NetworkX for Zettelkasten notes.
 
 Provides:
 - Link graph construction from note relationships
-- Backlink auto-generation
 - Graph traversal and path finding
 - Hub and authority analysis
 """

--- a/zk-cli/zk/graph.py
+++ b/zk-cli/zk/graph.py
@@ -90,14 +90,12 @@ class KnowledgeGraph:
             except Exception as e:
                 console.print(f"[red]Error parsing {note_file}: {e}[/red]")
         
-        # Second pass: add edges from frontmatter links
+        # Second pass: add edges from frontmatter links (one directed edge per link)
         for note_id, note in self._note_cache.items():
             for linked_id in note.links:
                 if linked_id in self._note_cache:
                     self.graph.add_edge(note_id, linked_id, type="links")
-                    # Auto-generate backlink
-                    self.graph.add_edge(linked_id, note_id, type="backlink")
-        
+
         # Third pass: extract and add wiki links from content [[...]]
         for note_id, note in self._note_cache.items():
             wiki_links = self._extract_wiki_links(note.content)
@@ -107,7 +105,6 @@ class KnowledgeGraph:
                     # Add edge if not already exists
                     if not self.graph.has_edge(note_id, linked_id):
                         self.graph.add_edge(note_id, linked_id, type="wiki_link")
-                        self.graph.add_edge(linked_id, note_id, type="backlink")
         
         return self
     
@@ -122,14 +119,17 @@ class KnowledgeGraph:
         # First try exact ID match
         if link_text in self._note_cache:
             return link_text
-        
-        # Then try title match
+
+        # Then try exact title match
+        for note_id, note in self._note_cache.items():
+            if note.title.lower() == link_text.lower():
+                return note_id
+
+        # Finally try substring match as fallback
         for note_id, note in self._note_cache.items():
             if link_text.lower() in note.title.lower():
                 return note_id
-            if note.title.lower() == link_text.lower():
-                return note_id
-        
+
         return None
     
     def _parse_note_file(self, file_path: Path) -> Optional[Note]:
@@ -214,8 +214,8 @@ class KnowledgeGraph:
         return related
     
     def find_clusters(self) -> List[Set[str]]:
-        """Find clusters of strongly connected notes."""
-        clusters = list(nx.strongly_connected_components(self.graph))
+        """Find clusters of connected notes (weakly connected components)."""
+        clusters = list(nx.weakly_connected_components(self.graph))
         # Filter out singletons and sort by size
         clusters = [c for c in clusters if len(c) > 1]
         clusters.sort(key=len, reverse=True)
@@ -224,14 +224,19 @@ class KnowledgeGraph:
     def get_hubs(self, top_n: int = 10) -> List[Tuple[str, int]]:
         """
         Get the most connected notes (hubs).
-        
+
+        Degree counts both outgoing links and incoming backlinks.
+
         Args:
             top_n: Number of top hubs to return
-            
+
         Returns:
             List of (note_id, degree) tuples
         """
-        degrees = [(n, self.graph.degree(n)) for n in self.graph.nodes()]
+        degrees = [
+            (n, self.graph.in_degree(n) + self.graph.out_degree(n))
+            for n in self.graph.nodes()
+        ]
         degrees.sort(key=lambda x: x[1], reverse=True)
         return degrees[:top_n]
     


### PR DESCRIPTION
## Summary

Fixes #48. 之前每条链接都创建 A→B 和 B→A 两条有向边（正向 link + 反向 backlink），导致所有链接对都是强连通的，图谱分析功能基本失效。

## 改动

| 文件 | 改动 |
|------|------|
| `zk/graph.py` L93-109 | 移除自动添加 backlink 反向边，每条链接只保留一条有向边 |
| `zk/graph.py` L214-221 | `find_clusters` 改用 `weakly_connected_components` |
| `zk/graph.py` L224-239 | `get_hubs` 显式统计 `in_degree + out_degree` |
| `zk/graph.py` L120-133 | 顺带修复 `_resolve_link` 匹配顺序（精确标题→子串） |

## Test plan

- [x] 4 节点链式图：A→B→C + D 隔离
  - 边数 = 2（非 6）
  - 聚类 = 1 组 {A,B,C}（非 3 组各 1 节点）
  - 枢纽 = B(degree=2) > A,C(degree=1) > D(degree=0)（非全部翻倍）
  - 孤儿 = [D]

🤖 Generated with [Claude Code](https://claude.com/claude-code)