### PR TITLE
fix: 移除 Console 宽度硬编码 9999 (#49)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Worktrees directory
+.worktrees/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+dist/
+build/
+
+# Virtual environments
+venv/
+.venv/
+env/
+ENV/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/zk-cli/zk/cli.py
+++ b/zk-cli/zk/cli.py
@@ -50,7 +50,7 @@ app = typer.Typer(
 # 添加子命令
 app.add_typer(template_app, name="template", help="Manage note templates")
 
-console = Console(soft_wrap=False, width=9999, legacy_windows=False)
+console = Console(legacy_windows=False)
 
 
 def output_json(data: dict) -> str:

--- a/zk-cli/zk/template_cli.py
+++ b/zk-cli/zk/template_cli.py
@@ -13,7 +13,7 @@ from .config import config
 from .template import TemplateManager, TemplateError, TemplateNotFoundError
 
 
-console = Console(soft_wrap=False, width=9999)
+console = Console()
 
 # Create template subcommand app
 template_app = typer.Typer(


### PR DESCRIPTION
## Summary
- 移除 `cli.py` 和 `template_cli.py` 中 `Console(width=9999, soft_wrap=False)` 的硬编码参数
- 让 Rich 自动检测终端宽度，修复表格在真实终端（80-120 列）中渲染混乱的问题

Closes #49