### PR TITLE
fix(ci): use setup-python cache and remove broken Codecov step

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -51,20 +51,14 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    
-    - name: Cache pip packages
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('zk-cli/pyproject.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-    
+        cache: 'pip'
+        cache-dependency-path: 'zk-cli/pyproject.toml'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
-    
+
     - name: Run fast tests (no embedding)
       run: |
         # 运行非 embedding 测试（单进程避免知识库冲突）
@@ -105,26 +99,20 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    
-    - name: Cache pip packages
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('zk-cli/pyproject.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-    
+        cache: 'pip'
+        cache-dependency-path: 'zk-cli/pyproject.toml'
+
     - name: Cache model
       uses: actions/cache@v4
       with:
         path: ~/.cache/torch/sentence_transformers
         key: ${{ runner.os }}-sentence-transformers-all-MiniLM-L6-v2
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
-    
+
     - name: Run core tests
       run: |
         # 只跑核心工作流测试，单进程避免模型加载冲突
@@ -164,26 +152,20 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    
-    - name: Cache pip packages
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('zk-cli/pyproject.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-    
+        cache: 'pip'
+        cache-dependency-path: 'zk-cli/pyproject.toml'
+
     - name: Cache model
       uses: actions/cache@v4
       with:
         path: ~/.cache/torch/sentence_transformers
         key: ${{ runner.os }}-sentence-transformers-all-MiniLM-L6-v2
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
-    
+
     - name: Run full test suite
       run: |
         # 全量测试，单进程（避免模型加载问题）
@@ -219,7 +201,9 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-    
+        cache: 'pip'
+        cache-dependency-path: 'zk-cli/pyproject.toml'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -229,14 +213,6 @@ jobs:
       run: |
         pytest tests/ -m "not embedding and not slow" --cov=zk --cov-report=xml --cov-report=html -v --timeout=300
       timeout-minutes: 25
-    
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
-      with:
-        file: ./zk-cli/coverage.xml
-        flags: integration
-        name: integration-tests
-        fail_ci_if_error: false
     
     - name: Upload coverage report
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Replace 3 manual `actions/cache` pip steps with `setup-python`'s built-in `cache: 'pip'` (fixes Windows runner cache path, #52)
- Remove `codecov/codecov-action@v4` step that silently fails without token (#51 already closed)

## Test plan
- [ ] CI passes on this PR (all 4 jobs should use new caching)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)