### PR TITLE
fix: validate KB path in manager layer

### DIFF
--- a/zk-cli/tests/unit/test_kb_manager.py
+++ b/zk-cli/tests/unit/test_kb_manager.py
@@ -157,7 +157,7 @@ class TestKnowledgeBaseManager:
             assert call_args is not None
     
     def test_create_with_explicit_path(self, manager, mock_config_manager):
-        """测试用户显式指定路径（CLI 层负责验证，create 不再拒绝）"""
+        """测试用户显式指定管理目录下的路径"""
         mock_config_manager.kb_exists.return_value = False
         mock_config_manager.list_knowledge_bases.return_value = []
         mock_config_manager.add_knowledge_base.return_value = True
@@ -166,9 +166,31 @@ class TestKnowledgeBaseManager:
             mock_config_instance = Mock()
             mock_zk_config.return_value = mock_config_instance
 
-            success, message = manager.create(name="custom_kb", path=Path("/tmp/custom"))
+            success, message = manager.create(
+                name="custom_kb", path=DEFAULT_KB_PATH / "custom"
+            )
 
         assert success is True
+
+    def test_create_rejects_path_outside_managed_dir(self, manager, mock_config_manager):
+        """测试拒绝管理目录之外的路径"""
+        mock_config_manager.kb_exists.return_value = False
+
+        success, message = manager.create(name="custom_kb", path=Path("/tmp/custom"))
+
+        assert success is False
+        assert "outside managed directory" in message
+
+    def test_create_rejects_path_traversal(self, manager, mock_config_manager):
+        """测试拒绝路径遍历（..）逃逸管理目录"""
+        mock_config_manager.kb_exists.return_value = False
+
+        success, message = manager.create(
+            name="evil_kb", path=DEFAULT_KB_PATH / ".." / ".." / "etc"
+        )
+
+        assert success is False
+        assert "outside managed directory" in message
 
     def test_create_rejects_reserved_name(self, manager, mock_config_manager):
         """测试拒绝保留名称"""

--- a/zk-cli/zk/kb_manager.py
+++ b/zk-cli/zk/kb_manager.py
@@ -85,7 +85,18 @@ class KnowledgeBaseManager:
                 path = DEFAULT_KB_PATH / name
 
         path = path.expanduser().resolve()
-        
+
+        # 校验路径必须在统一管理目录下
+        kb_root = DEFAULT_KB_PATH.resolve()
+        try:
+            path.relative_to(kb_root)
+        except ValueError:
+            return (
+                False,
+                f"Path '{path}' is outside managed directory '{kb_root}'. "
+                f"All knowledge bases must be under {kb_root}/",
+            )
+
         # 检查路径是否已被其他知识库使用
         for kb in self.config_manager.list_knowledge_bases():
             if Path(kb.path) == path:


### PR DESCRIPTION
## Summary
- Move KB path validation from CLI-only into `kb_manager.create()`, rejecting paths outside `DEFAULT_KB_PATH`
- Protects direct API/test callers that bypass CLI validation
- Covers path traversal via `..` escape

## Test plan
- [x] 139 unit tests pass (including 3 new tests for path validation)
- [x] Pre-push hook: 119 fast unit tests passed
- [ ] CI fast tests pass on both Ubuntu and Windows

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)