### PR TITLE
ci: add PyPI publish workflow (#79)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi-publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - uses: astral-sh/setup-uv@v4
+      with:
+        version: "latest"
+
+    - name: Build package
+      run: uv build
+
+    - name: Publish to PyPI
+      run: uv publish


### PR DESCRIPTION
## Summary
- Add `.github/workflows/publish.yml` for PyPI publishing via Trusted Publisher (OIDC)
- Triggered on GitHub Release creation
- Build verified locally: produces `jfox_cli-0.1.0.tar.gz` + `.whl`

## Test plan
- [x] `uv build` succeeds locally
- [ ] Create a GitHub Release → verify workflow triggers and publishes to PyPI

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)