### PR TITLE
docs: add jfox agent skills for AI assistants

### DIFF
--- a/skills-recommend/README.md
+++ b/skills-recommend/README.md
@@ -1,0 +1,66 @@
+# JFox Agent Skills
+
+为各类 AI 编程助手提供的 JFox 知识管理操作技能定义。
+
+## 目录结构
+
+```
+skills-recommend/
+└── claude-code/          # Claude Code 专用 SKILL.md 格式
+    ├── jfox-init/        # 知识库初始化
+    ├── jfox-search/      # 知识库搜索
+    ├── jfox-insert/      # 知识库插入笔记
+    ├── jfox-organize/    # 知识库整理
+    └── jfox-health/      # 知识库健康检查 / 腐化检测
+```
+
+## 使用方法
+
+### Claude Code
+
+直接复制到 `~/.claude/skills/` 即可使用：
+
+```bash
+# 复制全部 skills
+cp -r skills-recommend/claude-code/* ~/.claude/skills/
+
+# 或复制单个 skill
+cp -r skills-recommend/claude-code/jfox-search ~/.claude/skills/
+```
+
+复制后即可通过斜杠命令调用：
+- `/jfox-init` — 初始化知识库
+- `/jfox-search` — 搜索笔记
+- `/jfox-insert` — 添加笔记
+- `/jfox-organize` — 整理知识库
+- `/jfox-health` — 健康检查
+
+### OpenCode / Codex / Kimi CLI 等
+
+这些 Agent 的 skill/instruction 格式各不相同，但核心逻辑是通用的。参考 `claude-code/` 下的 SKILL.md 内容，将其适配为对应平台的格式：
+
+| 平台 | 适配方式 |
+|------|---------|
+| **OpenCode** | 将 SKILL.md 内容放入 agent 指令或 custom instruction |
+| **Codex** | 写入 `codex.md` 或 AGENTS.md 中的指令段落 |
+| **Kimi CLI** | 放入 `.claude/skills/` 目录（兼容 Claude Code 格式） |
+| **Cursor** | 写入 `.cursor/rules/` 下的 rule 文件 |
+| **其他** | 将命令参考和工作流提取为 system prompt 片段 |
+
+### 通用适配要点
+
+每个 skill 包含以下可复用信息：
+1. **触发条件** — 什么场景下使用该 skill
+2. **命令映射** — 用户意图对应的 jfox CLI 命令
+3. **工作流程** — 操作步骤和决策逻辑
+4. **命令参考** — 完整的 CLI 命令速查
+
+## 前置条件
+
+需要先安装 jfox CLI：
+
+```bash
+uv tool install jfox-cli
+```
+
+详见：https://github.com/zhuxixi/jfox

--- a/skills-recommend/claude-code/jfox-health/SKILL.md
+++ b/skills-recommend/claude-code/jfox-health/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: jfox-health
+description: Use when user wants to check knowledge base health, detect stale or decayed knowledge, audit the Zettelkasten. Triggers on "检查知识库健康", "腐化检测", "知识库状态", "health check", "decay detection", "audit knowledge base".
+---
+
+# JFox Knowledge Base Health Check
+
+Detect knowledge decay and audit the overall health of the Zettelkasten.
+
+## Overview
+
+This skill composes multiple jfox commands to produce a comprehensive health report. There is no single "health" command — the skill collects metrics from several sources and synthesizes them.
+
+## Data Collection
+
+Run these 5 commands to gather all metrics:
+
+```bash
+# 1. Overall KB status
+jfox status --format json
+
+# 2. Graph metrics and orphans
+jfox graph --stats --orphans --json
+
+# 3. Index integrity
+jfox index verify
+
+# 4. Note inventory (for type distribution and date analysis)
+jfox list --format json --limit 500
+
+# 5. Unprocessed inbox count
+jfox inbox --json --limit 100
+```
+
+## Health Indicators
+
+Compute these metrics from the collected data:
+
+| Metric | Source Field | Healthy | Warning | Critical |
+|--------|-------------|---------|---------|----------|
+| **Orphan ratio** | `isolated_nodes / total_nodes` | < 20% | 20-40% | > 40% |
+| **Avg degree** | `avg_degree` from graph stats | > 2.0 | 1.0-2.0 | < 1.0 |
+| **Inbox backlog** | Count of fleeting notes | < 10 | 10-30 | > 30 |
+| **Index integrity** | `jfox index verify` result | All valid | — | Any invalid |
+| **Cluster density** | `clusters / total_nodes` (if > 0) | > 0.1 | 0.05-0.1 | < 0.05 |
+| **Type balance** | fleeting vs permanent ratio | fleeting < 30% | 30-50% | > 50% |
+
+## Decay Signal Detection
+
+Analyze the metrics for these specific decay patterns:
+
+### 1. Knowledge Silos (high orphan ratio)
+- **Signal**: > 40% of notes have zero links
+- **Cause**: Notes captured but never connected to existing knowledge
+- **Fix**: Run `/jfox-organize` to find and add links to orphans
+
+### 2. Inbox Accumulation (high fleeting count)
+- **Signal**: > 30 unprocessed fleeting notes
+- **Cause**: Capturing ideas but not reflecting and refining them
+- **Fix**: Run `/jfox-organize` Step 1 to process inbox
+
+### 3. Poor Connectivity (low avg degree)
+- **Signal**: Average links per note < 1.0
+- **Cause**: Not using `[[links]]` syntax when adding notes
+- **Fix**: Use `jfox suggest-links` to find connections for existing notes
+
+### 4. Stale Index (index out of sync)
+- **Signal**: `jfox index verify` reports mismatches
+- **Cause**: Files added/modified outside jfox CLI
+- **Fix**: `jfox index rebuild` to rebuild search index
+
+### 5. Hub Dependency (fragile graph)
+- **Signal**: Top 3 hubs hold > 50% of all edges
+- **Cause**: Over-reliance on a few "hub" notes
+- **Fix**: Create intermediate notes to distribute connections
+
+## Scoring
+
+Compute an overall score (0-100):
+
+```
+Score = 100
+- (orphan_ratio * 100)          # up to -40 points
+- (max(0, 2.0 - avg_degree) * 20)  # up to -20 points
+- (inbox_backlog > 10 ? (inbox - 10) : 0)  # up to -20 points
+- (index_issues * 20)            # up to -20 points
+```
+
+Map score to grade:
+
+| Score | Grade | Status |
+|-------|-------|--------|
+| 90-100 | A | Excellent — healthy, well-connected |
+| 75-89 | B | Good — minor issues to address |
+| 60-74 | C | Fair — some decay detected |
+| 40-59 | D | Poor — significant decay |
+| 0-39 | F | Critical — needs immediate attention |
+
+## Report Format
+
+Present the health report in this format:
+
+```
+📊 知识库健康报告
+
+总体评分: {grade} ({score}/100)
+
+✅ 索引完整性: {通过/未通过}
+✅ 笔记总数: {N} (permanent: {X}, literature: {Y}, fleeting: {Z})
+⚠️ 孤立笔记: {orphans}/{total} ({ratio}%) — {建议}
+⚠️ 平均连接度: {degree} — {建议}
+⚠️ 收件箱: {inbox_count} 条未处理 — {建议}
+
+详细指标:
+- 集群数: {clusters}
+- Top hubs: {hub_list}
+- 集群密度: {density}
+
+建议操作:
+1. {最优先的操作}
+2. {次要操作}
+3. {可选优化}
+```
+
+Use emoji indicators:
+- ✅ Healthy / passing
+- ⚠️ Warning / needs attention
+- ❌ Critical / failing
+
+## Command Reference
+
+```bash
+jfox status --format json                # KB 总体状态
+jfox graph --stats --orphans --json       # 图谱指标 + 孤立笔记
+jfox index verify                         # 索引完整性
+jfox index rebuild                        # 重建索引
+jfox list --format json --limit <N>       # 笔记列表
+jfox inbox --json --limit <N>             # 未处理笔记
+jfox daily --json                         # 今日笔记
+```
+
+## When to Run
+
+- **Weekly**: Quick health check as part of regular knowledge management routine
+- **After bulk import**: Verify index and connections are healthy
+- **Before organizing**: Identify priority areas to focus on
+- **When KB feels stale**: Detect specific decay patterns to address

--- a/skills-recommend/claude-code/jfox-init/SKILL.md
+++ b/skills-recommend/claude-code/jfox-init/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: jfox-init
+description: Use when user wants to initialize, create, or set up a Zettelkasten knowledge base with jfox CLI. Triggers on "初始化知识库", "创建知识库", "新建知识库", "setup jfox", "init knowledge base".
+---
+
+# JFox Knowledge Base Initialization
+
+Initialize a new Zettelkasten knowledge base using the jfox CLI.
+
+## Prerequisites
+
+Verify jfox is installed:
+```bash
+jfox --version
+```
+If not installed: `uv tool install jfox-cli`
+
+## Knowledge Base Path Convention
+
+All knowledge bases live under `~/.zettelkasten/`:
+
+| Command | KB Name | Path |
+|---------|---------|------|
+| `jfox init` | default | `~/.zettelkasten/default/` |
+| `jfox init --name work` | work | `~/.zettelkasten/work/` |
+| `jfox init --name research` | research | `~/.zettelkasten/research/` |
+
+Custom paths via `--path` must be under `~/.zettelkasten/` (enforced by CLI).
+
+## Workflow
+
+### Step 1: Check Existing Knowledge Bases
+
+```bash
+jfox kb list --format json
+```
+
+If KBs already exist, inform user and ask whether to use an existing one or create new.
+
+### Step 2: Create Knowledge Base
+
+**Default KB (first-time users):**
+```bash
+jfox init
+```
+
+**Named KB:**
+```bash
+jfox init --name <name> --desc "<description>"
+```
+
+Examples:
+```bash
+jfox init --name work --desc "工作笔记"
+jfox init --name research --desc "研究笔记"
+jfox init --name personal --desc "个人知识库"
+```
+
+**With custom path (must be under ~/.zettelkasten/):**
+```bash
+jfox init --name <name> --path ~/.zettelkasten/<custom-path>
+```
+
+### Step 3: Verify Initialization
+
+```bash
+jfox kb current --format json
+jfox status --format json
+```
+
+Confirm KB is registered, directory structure created, and status shows 0 notes.
+
+### Step 4: Suggest First Note
+
+```
+知识库已初始化！建议创建第一条笔记：
+  jfox add "我的第一个想法" --title "开始使用 JFox" --type fleeting
+```
+
+## Multi-KB Management
+
+```bash
+jfox kb list                        # 列出所有知识库
+jfox kb switch <name>               # 切换知识库
+jfox kb info <name> --format json   # 查看详情
+jfox kb current --format json       # 当前知识库
+jfox kb remove <name> --force       # 删除知识库
+jfox kb rename <old> <new>          # 重命名
+```
+
+## Error Handling
+
+- **"Knowledge base already exists"**: Use `jfox kb switch <name>` or create with a different name.
+- **"Path is outside managed directory"**: All KBs must be under `~/.zettelkasten/`.
+- **Command not found**: Install with `uv tool install jfox-cli`.
+
+## Import Existing Notes
+
+```bash
+# JSON backup
+jfox bulk-import /path/to/backup.json --type permanent --batch-size 32
+
+# Raw markdown files
+cp /path/to/notes/*.md ~/.zettelkasten/<kb-name>/notes/permanent/
+jfox index rebuild
+```

--- a/skills-recommend/claude-code/jfox-insert/SKILL.md
+++ b/skills-recommend/claude-code/jfox-insert/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: jfox-insert
+description: Use when user wants to add, capture, or record a note into their Zettelkasten knowledge base. Triggers on "添加笔记", "记录", "记一下", "add note", "capture", "insert note".
+---
+
+# JFox Knowledge Base Insert
+
+Add notes to the Zettelkasten knowledge base.
+
+## Prerequisites
+
+Knowledge base must be initialized (`jfox init`).
+
+## Note Type Selection
+
+Choose the note type based on the nature of the content:
+
+| Type | Flag | When to Use | Example |
+|------|------|-------------|---------|
+| **fleeting** | `--type fleeting` | Quick thought, temporary capture, idea | "突然想到一个API设计思路" |
+| **literature** | `--type literature` | Notes from reading, with a source | "读了某篇文章，记下要点" |
+| **permanent** | `--type permanent` | Refined knowledge, lasting insight | "总结出一条设计原则" |
+
+**Default**: `fleeting` (quick capture, process later with `/jfox-organize`).
+
+## Workflow
+
+### Step 1: Extract Note Components
+
+From the user's message, extract:
+- **title**: Summarize in a short phrase (required for literature/permanent)
+- **content**: The actual note text
+- **tags**: Topics or categories mentioned
+- **source**: URL, book name, or reference (for literature notes)
+- **links**: Mentions of existing concepts → `[[Note Title]]`
+
+### Step 2: Check for Link Opportunities
+
+Before inserting, find related existing notes:
+```bash
+jfox suggest-links "<content>" --format json
+```
+
+If matches with score >= 0.6 are found, suggest adding `[[Note Title]]` links in the content.
+
+### Step 3: Insert the Note
+
+**Single note:**
+```bash
+jfox add "<content>" --title "<title>" --type <type> --tag <tag1> --tag <tag2>
+```
+
+**With source (literature notes):**
+```bash
+jfox add "<content>" --title "<title>" --type literature --source "<source>"
+```
+
+**With template:**
+```bash
+jfox add "<content>" --template quick
+jfox add "<content>" --template meeting
+jfox add "<content>" --template literature
+```
+
+**To a specific knowledge base:**
+```bash
+jfox add "<content>" --kb <kb-name> --title "<title>"
+```
+
+### Step 4: Verify
+
+The command returns JSON with the created note's ID, title, type, and file path. Confirm success to the user.
+
+## Link Syntax
+
+Use `[[Note Title]]` within content to create bidirectional links:
+```bash
+jfox add "React 的状态管理可以参考 [[Redux 设计模式]] 和 [[Context API 对比]]" --title "React 状态管理" --type permanent
+```
+
+## Bulk Import
+
+For inserting multiple notes at once:
+
+**Step 1: Create JSON file**
+```bash
+cat > /tmp/notes.json << 'EOF'
+[
+  {"title": "笔记1", "content": "内容1", "tags": ["tag1", "tag2"]},
+  {"title": "笔记2", "content": "内容2"},
+  {"title": "笔记3", "content": "带有 [[笔记1]] 链接", "tags": ["tag3"]}
+]
+EOF
+```
+
+**Step 2: Import**
+```bash
+jfox bulk-import /tmp/notes.json --type permanent --batch-size 32
+```
+
+## Command Reference
+
+```bash
+# Single note
+jfox add "<content>" --title "<title>" --type <fleeting|literature|permanent> --tag <tag>
+
+# With source
+jfox add "<content>" --source "<source>" --type literature
+
+# With template
+jfox add "<content>" --template <quick|meeting|literature>
+
+# Bulk
+jfox bulk-import <file.json> --type <type> --batch-size <N>
+
+# Link suggestions before insert
+jfox suggest-links "<content>" --top 5 --threshold 0.6 --format json
+```
+
+## Error Handling
+
+- **"Notes directory not found"**: Run `jfox init` first.
+- **Content too short**: Jfox accepts any content length, but recommend at least a sentence.
+- **Tag not found**: Tags are auto-created, no pre-registration needed.

--- a/skills-recommend/claude-code/jfox-organize/SKILL.md
+++ b/skills-recommend/claude-code/jfox-organize/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: jfox-organize
+description: Use when user wants to organize, tidy up, or review their Zettelkasten knowledge base. Triggers on "整理知识库", "清理", "看看inbox", "organize notes", "tidy up", "review inbox".
+---
+
+# JFox Knowledge Base Organization
+
+Review, organize, and connect notes in the Zettelkasten knowledge base.
+
+## Prerequisites
+
+Knowledge base must have notes (`jfox init` + some `jfox add` operations).
+
+## 4-Step Organization Process
+
+### Step 1: Inbox Review — Process Fleeting Notes
+
+```bash
+jfox inbox --json --limit 50
+```
+
+List all fleeting (unprocessed) notes. For each note, decide:
+
+1. **Convert to permanent** — The idea is mature enough to become lasting knowledge
+2. **Convert to literature** — It's a reading/learning note with a source
+3. **Delete** — No longer relevant
+4. **Keep as fleeting** — Still needs time to develop
+
+**Conversion workflow (fleeting → permanent):**
+1. Note the original content and ID from the inbox listing
+2. Help the user refine and expand the content into a well-structured permanent note
+3. Insert the refined note:
+   ```bash
+   jfox add "<refined content>" --title "<title>" --type permanent --tag <tags>
+   ```
+4. Delete the original fleeting note:
+   ```bash
+   jfox delete <original-id> --force
+   ```
+
+### Step 2: Find Orphaned Notes
+
+```bash
+jfox graph --orphans --json
+```
+
+Notes with zero links are orphans — disconnected from the knowledge graph.
+
+For each orphan:
+1. Get its content from the listing output
+2. Find potential connections:
+   ```bash
+   jfox suggest-links "<content>" --format json
+   ```
+3. If good matches found (score >= 0.5), suggest adding `[[links]]` to connect the note
+
+### Step 3: Analyze Graph Connectivity
+
+```bash
+jfox graph --stats --json
+```
+
+Key metrics to interpret:
+
+| Metric | Meaning | Target |
+|--------|---------|--------|
+| `total_nodes` | Total notes | Growing over time |
+| `total_edges` | Total links | Should grow with nodes |
+| `avg_degree` | Average links per note | > 2.0 (healthy connectivity) |
+| `isolated_nodes` | Notes with no links | < 20% of total |
+| `clusters` | Topic groups | Natural grouping |
+| `top_hubs` | Most-connected notes | Core knowledge anchors |
+
+**Health signals:**
+- High `isolated_nodes` → needs more linking (go to Step 2)
+- Low `avg_degree` (< 1.5) → add more `[[links]]` between notes
+- Few `clusters` → knowledge may be too fragmented or too uniform
+
+### Step 4: Process Recommendations
+
+For each actionable item from Steps 1-3, present to the user:
+
+```
+整理建议：
+
+📥 收件箱: 23 条未处理的临时笔记
+   → 建议: 逐条处理，转化为 permanent 或删除
+
+🔗 孤立笔记: 15 条没有链接的笔记
+   → 建议: 为每条找到相关笔记并添加 [[链接]]
+
+📊 图谱指标:
+   平均连接度: 1.3 (偏低)
+   → 建议: 在笔记中多使用 [[链接]] 语法连接相关概念
+```
+
+## Note Type Reference
+
+| Type | Path | Purpose |
+|------|------|---------|
+| `fleeting` | `notes/fleeting/` | Quick capture, to be processed |
+| `literature` | `notes/literature/` | Reading notes with source |
+| `permanent` | `notes/permanent/` | Refined, lasting knowledge |
+
+## Command Reference
+
+```bash
+jfox inbox --json --limit <N>              # 查看临时笔记
+jfox graph --orphans --json                 # 查找孤立笔记
+jfox graph --stats --json                   # 图谱统计
+jfox suggest-links "<content>" --format json # 推荐链接
+jfox refs --search "<title>" --format json  # 查看引用关系
+jfox list --format json --limit <N>         # 列出笔记
+jfox add "<content>" --type permanent       # 添加精炼笔记
+jfox delete <id> --force                    # 删除原始笔记
+jfox daily --json                           # 查看今天的笔记
+```
+
+## Tips
+
+- **Process inbox weekly**: Don't let fleeting notes accumulate past 30.
+- **Link liberally**: The value of Zettelkasten is in connections, not volume.
+- **Convert, don't edit**: Instead of editing fleeting notes in-place, create a new permanent note and delete the fleeting original. This preserves the audit trail.
+- **Use tags for topics, links for ideas**: Tags group by topic; `[[links]]` connect by thought.

--- a/skills-recommend/claude-code/jfox-search/SKILL.md
+++ b/skills-recommend/claude-code/jfox-search/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: jfox-search
+description: Use when user wants to search notes, find information, look up knowledge in their Zettelkasten. Triggers on "搜索", "查找", "找一下", "search notes", "look up", "find".
+---
+
+# JFox Knowledge Base Search
+
+Search and retrieve notes from the Zettelkasten knowledge base.
+
+## Prerequisites
+
+Knowledge base must be initialized (`jfox init`). If search index is stale, run `jfox index rebuild` first.
+
+## Search Strategy Selection
+
+Choose the right search approach based on user intent:
+
+| User Intent | Strategy | Command |
+|-------------|----------|---------|
+| Exact keyword or term | Keyword (BM25) | `jfox search "<keyword>" --mode keyword --format json` |
+| Concept or idea (fuzzy) | Hybrid (BM25+semantic) | `jfox search "<concept>" --mode hybrid --format json` |
+| Pure semantic similarity | Semantic | `jfox search "<idea>" --mode semantic --format json` |
+| Explore related topics | Graph traversal | `jfox query "<topic>" --depth 2 --json` |
+| What links to note X | Backlinks | `jfox refs --search "<title>" --format json` |
+| What should I link to | Link suggestions | `jfox suggest-links "<content>" --format json` |
+
+**Default strategy**: `--mode hybrid` (best balance of precision and recall).
+
+## Workflow
+
+### Single Search
+
+```bash
+jfox search "<query>" --mode hybrid --top 10 --format json
+```
+
+Parse the JSON output and present results as:
+
+```
+找到 N 条相关笔记：
+
+1. [标题] (score: 0.85)
+   类型: permanent | 标签: tag1, tag2
+   摘要: 前100字...
+
+2. [标题] (score: 0.72)
+   ...
+```
+
+### Graph-Aware Search
+
+For exploring connections around a topic:
+```bash
+jfox query "<topic>" --top 10 --depth 2 --json
+```
+
+This returns both search results AND their graph neighbors, giving a broader view of the knowledge landscape.
+
+### Backlink Discovery
+
+To find what references a specific note:
+```bash
+jfox refs --search "<title>" --format json
+```
+
+### Link Recommendations
+
+To find notes that should be linked from given content:
+```bash
+jfox suggest-links "<content>" --top 10 --threshold 0.5 --format json
+```
+
+Lower `--threshold` (0.3-0.5) for broader suggestions, higher (0.6-0.8) for stricter matching.
+
+## All Search Commands Reference
+
+```bash
+# Basic search
+jfox search "<query>" --mode <hybrid|keyword|semantic> --top <N> --format json
+
+# Filter by note type
+jfox search "<query>" --type permanent --format json
+
+# Graph query with traversal
+jfox query "<query>" --top <N> --depth <D> --json
+
+# Link suggestions
+jfox suggest-links "<content>" --top <N> --threshold <T> --format json
+
+# Backlinks/references
+jfox refs --search "<title>" --format json
+jfox refs --note "<note-id>" --format json
+```
+
+## Multi-KB Search
+
+All search commands support `--kb <name>` to target a specific knowledge base:
+```bash
+jfox search "<query>" --kb work --format json
+```
+
+## Error Handling
+
+- **"Index not found"**: Run `jfox index rebuild` to build the search index.
+- **Empty results**: Try broader query, switch mode to `hybrid`, or lower `--threshold`.
+- **Slow search**: First search loads embedding model (30-60s). Subsequent searches are fast.


### PR DESCRIPTION
## Summary
- Add 5 Claude Code skills (init, search, insert, organize, health) under `skills-recommend/claude-code/`
- Include README with usage instructions and adaptation guide for OpenCode, Codex, Kimi CLI, Cursor, etc.
- Skills define triggers, command mappings, workflows, and CLI reference for each jfox operation

## Skills Overview

| Skill | Slash Command | Purpose |
|-------|--------------|---------|
| jfox-init | `/jfox-init` | Initialize knowledge base |
| jfox-search | `/jfox-search` | Search notes (hybrid/keyword/semantic/graph) |
| jfox-insert | `/jfox-insert` | Add notes with auto-link suggestions |
| jfox-organize | `/jfox-organize` | Review inbox, find orphans, suggest connections |
| jfox-health | `/jfox-health` | Decay detection and health audit |

## Test plan
- [x] All jfox CLI commands referenced in skills match actual `--help` output
- [x] File structure and content verified (6 files, 673 lines)
- [ ] Manual test: copy skills to `~/.claude/skills/` and invoke via slash commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)