### PR TITLE
fix: unify default KB path, add --kb to bulk-import, fix skill docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ htmlcov/
 # OS
 .DS_Store
 Thumbs.db
+
+# Project specific
+.zk/
+chroma_db/
+*.sqlite3
+cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Notes are Markdown files with YAML frontmatter stored under `~/.zettelkasten/not
 ### Multi-Knowledge Base
 
 - Global config: `~/.zk_config.json`
-- Default KB: `~/.zettelkasten`, named KB: `~/.zettelkasten-{name}`
+- Default KB: `~/.zettelkasten/default/`, named KB: `~/.zettelkasten/<name>/`
 - Switch at runtime with `--kb` flag or `use_kb()` context manager
 
 ## Testing Rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Windows full test: `.\run_full_test.ps1` or `.\run_full_test.ps1 -KeepData`
 
 ### Core Data Flow
 
-Notes are Markdown files with YAML frontmatter stored under `~/.zettelkasten/notes/{type}/`. The system has three layers:
+Notes are Markdown files with YAML frontmatter stored under `~/.zettelkasten/<kb-name>/notes/{type}/`. The system has three layers:
 
 1. **Storage** (`note.py`, `models.py`) — CRUD on Markdown files with YAML frontmatter. Note IDs are timestamps (`YYYYMMDDHHMMSS`).
 2. **Search Index** (`search_engine.py`) — Hybrid search combining BM25 (`bm25_index.py`) + semantic embeddings (`vector_store.py` + `embedding_backend.py`) via Reciprocal Rank Fusion.

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -98,7 +98,7 @@ def init(
     创建一个新的知识库并注册到全局配置。
     
     示例:
-        jfox init                          # 初始化默认知识库
+        jfox init                          # 初始化默认知识库（~/.zettelkasten/default/）
         jfox init --name work              # 创建名为 work 的知识库（~/.zettelkasten/work/）
         jfox init --name personal --desc "个人笔记"
     """
@@ -1812,6 +1812,7 @@ def bulk_import(
     file_path: str = typer.Argument(..., help="JSON 文件路径，包含笔记数据"),
     note_type: str = typer.Option("permanent", "--type", "-t", help="笔记类型"),
     batch_size: int = typer.Option(32, "--batch-size", "-b", help="批处理大小"),
+    kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
     json_output: bool = typer.Option(True, "--json/--no-json", help="JSON 输出"),
 ):
     """
@@ -1827,23 +1828,34 @@ def bulk_import(
     
     示例:
         jfox bulk-import notes.json --type permanent --batch-size 32
+        jfox bulk-import notes.json --kb work --type permanent
     """
     try:
         import json
-        
+
         # 读取文件
         with open(file_path, 'r', encoding='utf-8') as f:
             notes_data = json.load(f)
-        
+
         console.print(f"[yellow]Importing {len(notes_data)} notes...[/yellow]")
-        
-        # 批量导入
-        result = bulk_import_notes(
-            notes_data=notes_data,
-            note_type=note_type,
-            batch_size=batch_size,
-            show_progress=not json_output
-        )
+
+        # 如果指定了知识库，临时切换
+        if kb:
+            from .config import use_kb
+            with use_kb(kb):
+                result = bulk_import_notes(
+                    notes_data=notes_data,
+                    note_type=note_type,
+                    batch_size=batch_size,
+                    show_progress=not json_output
+                )
+        else:
+            result = bulk_import_notes(
+                notes_data=notes_data,
+                note_type=note_type,
+                batch_size=batch_size,
+                show_progress=not json_output
+            )
         
         if json_output:
             print(output_json(result))

--- a/jfox/config.py
+++ b/jfox/config.py
@@ -15,7 +15,7 @@ def get_default_kb_path() -> Path:
         from .global_config import get_global_config_manager
         return get_global_config_manager().get_default_kb_path()
     except Exception:
-        return Path.home() / ".zettelkasten"
+        return Path.home() / ".zettelkasten" / "default"
 
 
 @dataclass

--- a/jfox/global_config.py
+++ b/jfox/global_config.py
@@ -85,21 +85,53 @@ class GlobalConfigManager:
         """加载配置，如果不存在则创建默认配置"""
         if self._config is not None:
             return self._config
-        
+
         if self.config_path.exists():
             try:
                 with open(self.config_path, 'r', encoding='utf-8') as f:
                     data = json.load(f)
                 self._config = GlobalConfig.from_dict(data)
+                # 迁移旧版默认 KB 路径（~/.zettelkasten/ → ~/.zettelkasten/default/）
+                self._migrate_default_kb_path()
                 logger.debug(f"Loaded global config from {self.config_path}")
             except Exception as e:
                 logger.warning(f"Failed to load config: {e}, creating default")
                 self._config = self._create_default_config()
         else:
             self._config = self._create_default_config()
-        
+
         return self._config
-    
+
+    def _migrate_default_kb_path(self):
+        """迁移旧版默认 KB 路径：~/.zettelkasten/ → ~/.zettelkasten/default/"""
+        if self._config is None:
+            return
+        default_kb = self._config.knowledge_bases.get(DEFAULT_KB_NAME)
+        if default_kb is None:
+            return
+        old_path = DEFAULT_KB_PATH
+        new_path = DEFAULT_KB_PATH / "default"
+        # 检查当前路径是否是旧版路径（~/.zettelkasten/ 而非 ~/.zettelkasten/default/）
+        try:
+            current_resolved = Path(default_kb.path).expanduser().resolve()
+            if current_resolved == old_path.resolve():
+                # 迁移：将旧目录内容移到新路径
+                if old_path.exists() and not new_path.exists():
+                    import shutil
+                    new_path.mkdir(parents=True, exist_ok=True)
+                    # 移动 notes/ 和 .zk/ 目录
+                    for subdir in ["notes", ".zk"]:
+                        src = old_path / subdir
+                        if src.exists():
+                            shutil.move(str(src), str(new_path / subdir))
+                    logger.info(f"Migrated default KB from {old_path} to {new_path}")
+                # 更新配置中的路径
+                default_kb.path = str(new_path)
+                self._save()
+                logger.info(f"Updated default KB path to {new_path}")
+        except Exception as e:
+            logger.warning(f"Failed to migrate default KB path: {e}")
+
     def _save(self) -> bool:
         """保存配置到文件"""
         try:
@@ -116,7 +148,7 @@ class GlobalConfigManager:
         """创建默认配置"""
         default_kb = KnowledgeBaseEntry(
             name=DEFAULT_KB_NAME,
-            path=str(DEFAULT_KB_PATH),
+            path=str(DEFAULT_KB_PATH / "default"),
             created=datetime.now().isoformat(),
             description="Default knowledge base",
         )
@@ -150,7 +182,7 @@ class GlobalConfigManager:
             return Path(config.knowledge_bases[default_name].path)
         
         # 回退到默认路径
-        return DEFAULT_KB_PATH
+        return DEFAULT_KB_PATH / "default"
     
     def get_kb_path(self, name: str) -> Optional[Path]:
         """获取指定知识库的路径"""

--- a/jfox/kb_manager.py
+++ b/jfox/kb_manager.py
@@ -80,7 +80,7 @@ class KnowledgeBaseManager:
         # 确定路径（统一管理到 ~/.zettelkasten/ 下）
         if path is None:
             if name == "default":
-                path = DEFAULT_KB_PATH
+                path = DEFAULT_KB_PATH / "default"
             else:
                 path = DEFAULT_KB_PATH / name
 

--- a/skills-recommend/claude-code/jfox-health/SKILL.md
+++ b/skills-recommend/claude-code/jfox-health/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jfox-health
-description: Use when user wants to check knowledge base health, detect stale or decayed knowledge, audit the Zettelkasten. Triggers on "检查知识库健康", "腐化检测", "知识库状态", "health check", "decay detection", "audit knowledge base".
+description: Use when user wants to check knowledge base health, detect stale or decayed knowledge, audit the Zettelkasten. Triggers on "检查知识库健康", "腐化检测", "知识库状态", "知识库体检", "知识库诊断", "health check", "decay detection", "audit knowledge base", "orphan detection", "knowledge graph health".
 ---
 
 # JFox Knowledge Base Health Check
@@ -13,22 +13,25 @@ This skill composes multiple jfox commands to produce a comprehensive health rep
 
 ## Data Collection
 
-Run these 5 commands to gather all metrics:
+Run these 6 commands to gather all metrics:
 
 ```bash
 # 1. Overall KB status
 jfox status --format json
 
-# 2. Graph metrics and orphans
-jfox graph --stats --orphans --json
+# 2. Graph metrics (note: --stats and --orphans are mutually exclusive, run separately)
+jfox graph --stats --json
 
-# 3. Index integrity
+# 3. Orphan list (separate from stats)
+jfox graph --orphans --json
+
+# 4. Index integrity
 jfox index verify
 
-# 4. Note inventory (for type distribution and date analysis)
+# 5. Note inventory (for type distribution and date analysis)
 jfox list --format json --limit 500
 
-# 5. Unprocessed inbox count
+# 6. Unprocessed inbox count
 jfox inbox --json --limit 100
 ```
 
@@ -42,7 +45,7 @@ Compute these metrics from the collected data:
 | **Avg degree** | `avg_degree` from graph stats | > 2.0 | 1.0-2.0 | < 1.0 |
 | **Inbox backlog** | Count of fleeting notes | < 10 | 10-30 | > 30 |
 | **Index integrity** | `jfox index verify` result | All valid | — | Any invalid |
-| **Cluster density** | `clusters / total_nodes` (if > 0) | > 0.1 | 0.05-0.1 | < 0.05 |
+| **Connectivity ratio** | `(total_nodes - isolated_nodes) / total_nodes` | > 0.8 | 0.6-0.8 | < 0.6 |
 | **Type balance** | fleeting vs permanent ratio | fleeting < 30% | 30-50% | > 50% |
 
 ## Decay Signal Detection
@@ -80,10 +83,10 @@ Compute an overall score (0-100):
 
 ```
 Score = 100
-- (orphan_ratio * 100)          # up to -40 points
-- (max(0, 2.0 - avg_degree) * 20)  # up to -20 points
-- (inbox_backlog > 10 ? (inbox - 10) : 0)  # up to -20 points
-- (index_issues * 20)            # up to -20 points
+- min(orphan_ratio * 100, 40)                        # up to -40 points
+- min(max(0, 2.0 - avg_degree) * 10, 20)             # up to -20 points
+- min(max(0, inbox_count - 10), 20)                   # up to -20 points
+- (0 if verify_result["healthy"] else 20)             # -20 if unhealthy
 ```
 
 Map score to grade:
@@ -114,7 +117,7 @@ Present the health report in this format:
 详细指标:
 - 集群数: {clusters}
 - Top hubs: {hub_list}
-- 集群密度: {density}
+- 连通率: {connectivity_ratio}
 
 建议操作:
 1. {最优先的操作}
@@ -131,12 +134,12 @@ Use emoji indicators:
 
 ```bash
 jfox status --format json                # KB 总体状态
-jfox graph --stats --orphans --json       # 图谱指标 + 孤立笔记
-jfox index verify                         # 索引完整性
-jfox index rebuild                        # 重建索引
-jfox list --format json --limit <N>       # 笔记列表
-jfox inbox --json --limit <N>             # 未处理笔记
-jfox daily --json                         # 今日笔记
+jfox graph --stats --json                # 图谱指标（与 --orphans 互斥，分开运行）
+jfox graph --orphans --json              # 孤立笔记列表
+jfox index verify                        # 索引完整性
+jfox index rebuild                       # 重建索引
+jfox list --format json --limit <N>      # 笔记列表
+jfox inbox --json --limit <N>            # 未处理笔记
 ```
 
 ## When to Run

--- a/skills-recommend/claude-code/jfox-init/SKILL.md
+++ b/skills-recommend/claude-code/jfox-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jfox-init
-description: Use when user wants to initialize, create, or set up a Zettelkasten knowledge base with jfox CLI. Triggers on "初始化知识库", "创建知识库", "新建知识库", "setup jfox", "init knowledge base".
+description: Use when user wants to initialize, create, or set up a Zettelkasten knowledge base with jfox CLI. Triggers on "初始化知识库", "创建知识库", "新建知识库", "知识库初始化", "配置 jfox", "setup jfox", "init knowledge base", "create knowledge base", "new knowledge base", "jfox init", "start using jfox".
 ---
 
 # JFox Knowledge Base Initialization
@@ -84,7 +84,8 @@ jfox kb list                        # 列出所有知识库
 jfox kb switch <name>               # 切换知识库
 jfox kb info <name> --format json   # 查看详情
 jfox kb current --format json       # 当前知识库
-jfox kb remove <name> --force       # 删除知识库
+jfox kb remove <name> --force       # ⚠️ 删除知识库（含笔记文件，不可恢复）
+jfox kb remove <name>               # 仅注销知识库，保留笔记文件
 jfox kb rename <old> <new>          # 重命名
 ```
 
@@ -99,8 +100,9 @@ jfox kb rename <old> <new>          # 重命名
 ```bash
 # JSON backup
 jfox bulk-import /path/to/backup.json --type permanent --batch-size 32
+jfox bulk-import /path/to/backup.json --kb work --type permanent
 
-# Raw markdown files
-cp /path/to/notes/*.md ~/.zettelkasten/<kb-name>/notes/permanent/
+# Raw markdown files (default KB uses ~/.zettelkasten/default/, named KB uses ~/.zettelkasten/<name>/)
+cp /path/to/notes/*.md ~/.zettelkasten/default/notes/permanent/
 jfox index rebuild
 ```

--- a/skills-recommend/claude-code/jfox-insert/SKILL.md
+++ b/skills-recommend/claude-code/jfox-insert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jfox-insert
-description: Use when user wants to add, capture, or record a note into their Zettelkasten knowledge base. Triggers on "添加笔记", "记录", "记一下", "add note", "capture", "insert note".
+description: Use when user wants to add, capture, or record a note into their Zettelkasten knowledge base. Triggers on "添加笔记", "记录", "记一下", "写下", "新建笔记", "快速记录", "add note", "capture", "insert note", "create note", "new note", "quick note", "jot down".
 ---
 
 # JFox Knowledge Base Insert
@@ -28,7 +28,7 @@ Choose the note type based on the nature of the content:
 ### Step 1: Extract Note Components
 
 From the user's message, extract:
-- **title**: Summarize in a short phrase (required for literature/permanent)
+- **title**: Summarize in a short phrase (recommended for literature/permanent)
 - **content**: The actual note text
 - **tags**: Topics or categories mentioned
 - **source**: URL, book name, or reference (for literature notes)
@@ -36,7 +36,7 @@ From the user's message, extract:
 
 ### Step 2: Check for Link Opportunities
 
-Before inserting, find related existing notes:
+When content involves concepts that may relate to existing notes, find related notes:
 ```bash
 jfox suggest-links "<content>" --format json
 ```
@@ -69,7 +69,9 @@ jfox add "<content>" --kb <kb-name> --title "<title>"
 
 ### Step 4: Verify
 
-The command returns JSON with the created note's ID, title, type, and file path. Confirm success to the user.
+The command returns JSON with `id`, `title`, `type`, `filepath`, and `links` (resolved link IDs). If wiki links in content don't match existing notes, a `warnings` field lists unresolved links. Report any warnings to the user.
+
+> **Note**: `jfox add` and `jfox bulk-import` use `--json`/`--no-json` (default: on), NOT `--format json`. Do not append `--format json` to these commands.
 
 ## Link Syntax
 
@@ -83,19 +85,19 @@ jfox add "React 的状态管理可以参考 [[Redux 设计模式]] 和 [[Context
 For inserting multiple notes at once:
 
 **Step 1: Create JSON file**
-```bash
-cat > /tmp/notes.json << 'EOF'
+```json
 [
   {"title": "笔记1", "content": "内容1", "tags": ["tag1", "tag2"]},
   {"title": "笔记2", "content": "内容2"},
   {"title": "笔记3", "content": "带有 [[笔记1]] 链接", "tags": ["tag3"]}
 ]
-EOF
 ```
+Save to a temporary file (use a cross-platform path).
 
 **Step 2: Import**
 ```bash
-jfox bulk-import /tmp/notes.json --type permanent --batch-size 32
+jfox bulk-import <path-to-file.json> --type permanent --batch-size 32
+jfox bulk-import <path-to-file.json> --kb work --type permanent
 ```
 
 ## Command Reference
@@ -119,6 +121,8 @@ jfox suggest-links "<content>" --top 5 --threshold 0.6 --format json
 
 ## Error Handling
 
-- **"Notes directory not found"**: Run `jfox init` first.
+- **"Notes directory not found"** / **KB not initialized**: Run `jfox init` first.
+- **"Invalid note type"**: Must be `fleeting`, `literature`, or `permanent`.
+- **"Template not found"**: Check available templates with `jfox template list`.
 - **Content too short**: Jfox accepts any content length, but recommend at least a sentence.
 - **Tag not found**: Tags are auto-created, no pre-registration needed.

--- a/skills-recommend/claude-code/jfox-organize/SKILL.md
+++ b/skills-recommend/claude-code/jfox-organize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jfox-organize
-description: Use when user wants to organize, tidy up, or review their Zettelkasten knowledge base. Triggers on "整理知识库", "清理", "看看inbox", "organize notes", "tidy up", "review inbox".
+description: Use when user wants to organize, tidy up, or review their Zettelkasten knowledge base. Triggers on "整理知识库", "整理笔记", "清理", "清理收件箱", "看看inbox", "处理临时笔记", "organize notes", "tidy up", "review inbox", "find orphans", "知识库维护".
 ---
 
 # JFox Knowledge Base Organization
@@ -31,7 +31,7 @@ List all fleeting (unprocessed) notes. For each note, decide:
 2. Help the user refine and expand the content into a well-structured permanent note
 3. Insert the refined note:
    ```bash
-   jfox add "<refined content>" --title "<title>" --type permanent --tag <tags>
+   jfox add "<refined content>" --title "<title>" --type permanent --tag <tag1> --tag <tag2>
    ```
 4. Delete the original fleeting note:
    ```bash
@@ -52,7 +52,7 @@ For each orphan:
    ```bash
    jfox suggest-links "<content>" --format json
    ```
-3. If good matches found (score >= 0.5), suggest adding `[[links]]` to connect the note
+3. If good matches found (score >= 0.6), suggest adding `[[links]]` to connect the note
 
 ### Step 3: Analyze Graph Connectivity
 

--- a/skills-recommend/claude-code/jfox-search/SKILL.md
+++ b/skills-recommend/claude-code/jfox-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jfox-search
-description: Use when user wants to search notes, find information, look up knowledge in their Zettelkasten. Triggers on "搜索", "查找", "找一下", "search notes", "look up", "find".
+description: Use when user wants to search notes, find information, look up knowledge in their Zettelkasten. Triggers on "搜索", "查找", "找一下", "查一下", "搜一下", "帮我找", "有没有关于", "search notes", "look up", "find", "find related notes", "search knowledge base", "notes about".
 ---
 
 # JFox Knowledge Base Search
@@ -67,10 +67,10 @@ jfox refs --search "<title>" --format json
 
 To find notes that should be linked from given content:
 ```bash
-jfox suggest-links "<content>" --top 10 --threshold 0.5 --format json
+jfox suggest-links "<content>" --top 10 --threshold 0.6 --format json
 ```
 
-Lower `--threshold` (0.3-0.5) for broader suggestions, higher (0.6-0.8) for stricter matching.
+Default threshold is `0.6`. Lower to `0.3-0.5` for broader suggestions, raise to `0.7-0.8` for stricter matching.
 
 ## All Search Commands Reference
 
@@ -78,7 +78,7 @@ Lower `--threshold` (0.3-0.5) for broader suggestions, higher (0.6-0.8) for stri
 # Basic search
 jfox search "<query>" --mode <hybrid|keyword|semantic> --top <N> --format json
 
-# Filter by note type
+# Filter by note type (fleeting|literature|permanent)
 jfox search "<query>" --type permanent --format json
 
 # Graph query with traversal

--- a/tests/test_config_unit.py
+++ b/tests/test_config_unit.py
@@ -33,7 +33,7 @@ class TestGetDefaultKBPath:
             
             result = get_default_kb_path()
             
-            assert result == Path.home() / ".zettelkasten"
+            assert result == Path.home() / ".zettelkasten" / "default"
 
 
 class TestZKConfig:

--- a/tests/unit/test_global_config.py
+++ b/tests/unit/test_global_config.py
@@ -264,7 +264,7 @@ class TestGlobalConfigManager:
         
         result = manager.get_default_kb_path()
         
-        assert result == DEFAULT_KB_PATH
+        assert result == DEFAULT_KB_PATH / "default"
     
     def test_get_kb_path_existing(self, manager):
         """测试获取存在的知识库路径"""


### PR DESCRIPTION
## Summary
- **Default KB path**: Change from `~/.zettelkasten/` to `~/.zettelkasten/default/` for consistency with named KBs (`~/.zettelkasten/<name>/`). Includes auto-migration for existing users.
- **`bulk-import --kb`**: Add `--kb` flag to `bulk-import` command, consistent with `add`/`search`/`list` commands.
- **Skill docs fixes**: Based on 5 parallel skill-reviewer agent reviews — split mutually exclusive `--stats`/`--orphans`, fix scoring formula, correct threshold defaults (0.5→0.6), expand trigger phrases, add `--json` vs `--format json` clarification.

## Changes

### CLI (4 files)
- `jfox/kb_manager.py`: Default KB path `DEFAULT_KB_PATH` → `DEFAULT_KB_PATH / "default"`
- `jfox/global_config.py`: Updated default config path + `_migrate_default_kb_path()` for existing users + fixed fallback path
- `jfox/config.py`: Fixed fallback path to `DEFAULT_KB_PATH / "default"`
- `jfox/cli.py`: Added `--kb` flag to `bulk-import`; updated init help text

### Skill docs (5 files)
- `jfox-health`: Split `--stats`/`--orphans` (mutually exclusive), fixed scoring formula with `min()` caps, replaced "cluster density" with "connectivity ratio", removed unused `jfox daily`
- `jfox-init`: Updated paths, clarified `kb remove --force` deletes data, added `--kb` import examples
- `jfox-insert`: Added `--json` note, expanded triggers, fixed bulk-import section, added error cases
- `jfox-search`: Fixed threshold default (0.5→0.6), expanded triggers
- `jfox-organize`: Fixed threshold (0.5→0.6), fixed `--tag` syntax

### Config
- `CLAUDE.md`: Updated multi-KB path docs
- `.gitignore`: Added `.zk/`, `chroma_db/`, `*.sqlite3`, `cache/`

## Test plan
- [ ] Verify `jfox init` creates `~/.zettelkasten/default/` structure
- [ ] Verify `jfox init --name test` creates `~/.zettelkasten/test/`
- [ ] Verify `jfox bulk-import --help` shows `--kb` flag
- [ ] Verify existing default KB auto-migrates on first load
- [ ] Run `uv run pytest tests/ -m "not embedding and not slow"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)