### PR TITLE
fix: reset stale singletons after use_kb() context exit

### DIFF
--- a/jfox/config.py
+++ b/jfox/config.py
@@ -120,6 +120,21 @@ def get_config() -> ZKConfig:
 config = get_config()
 
 
+def _reset_singletons():
+    """重置所有缓存的单例（搜索引擎、向量存储、BM25 索引）"""
+    import importlib
+    for module_name, fn_name in [
+        (".bm25_index", "reset_bm25_index"),
+        (".search_engine", "reset_search_engine"),
+        (".vector_store", "reset_vector_store"),
+    ]:
+        try:
+            module = importlib.import_module(module_name, package="jfox")
+            getattr(module, fn_name)()
+        except Exception:
+            pass
+
+
 @contextmanager
 def use_kb(kb_name: Optional[str] = None):
     """
@@ -161,16 +176,8 @@ def use_kb(kb_name: Optional[str] = None):
         config.chroma_dir = config.zk_dir / "chroma_db"
         
         # 重置索引和搜索引擎（使用新的知识库路径）
-        try:
-            from .bm25_index import reset_bm25_index
-            from .search_engine import reset_search_engine
-            from .vector_store import reset_vector_store
-            reset_bm25_index()
-            reset_search_engine()
-            reset_vector_store()
-        except Exception:
-            pass  # 忽略重置错误
-        
+        _reset_singletons()
+
         yield
     finally:
         # 恢复原始配置
@@ -178,3 +185,6 @@ def use_kb(kb_name: Optional[str] = None):
         config.notes_dir = original_notes_dir
         config.zk_dir = original_zk_dir
         config.chroma_dir = original_chroma_dir
+
+        # 重置单例，下次访问会用恢复后的配置重建
+        _reset_singletons()

--- a/tests/test_config_unit.py
+++ b/tests/test_config_unit.py
@@ -212,32 +212,41 @@ class TestUseKB:
     def test_use_kb_resets_search_indices(self):
         """测试 use_kb 重置搜索索引"""
         from jfox.config import config
-        
+
         with patch('jfox.kb_manager.get_kb_manager') as mock_get_manager:
             mock_manager = Mock()
             mock_manager.config_manager.kb_exists.return_value = True
             mock_manager.config_manager.get_kb_path.return_value = Path("/test/kb")
             mock_get_manager.return_value = mock_manager
-            
-            with patch('jfox.bm25_index.reset_bm25_index') as mock_reset_bm25:
-                with patch('jfox.search_engine.reset_search_engine') as mock_reset_search:
-                    with use_kb("test_kb"):
-                        pass
-                    
-                    mock_reset_bm25.assert_called_once()
-                    mock_reset_search.assert_called_once()
-    
+
+            with patch('jfox.bm25_index.reset_bm25_index') as mock_reset_bm25, \
+                 patch('jfox.search_engine.reset_search_engine') as mock_reset_search, \
+                 patch('jfox.vector_store.reset_vector_store') as mock_reset_vector:
+                with use_kb("test_kb"):
+                    pass
+
+                # entry 和 exit 各调用一次
+                assert mock_reset_bm25.call_count == 2
+                assert mock_reset_search.call_count == 2
+                assert mock_reset_vector.call_count == 2
+
     def test_use_kb_handles_reset_errors(self):
-        """测试 use_kb 处理重置索引错误"""
+        """测试 use_kb 处理重置索引错误（单个失败不影响其他）"""
         from jfox.config import config
-        
+
         with patch('jfox.kb_manager.get_kb_manager') as mock_get_manager:
             mock_manager = Mock()
             mock_manager.config_manager.kb_exists.return_value = True
             mock_manager.config_manager.get_kb_path.return_value = Path("/test/kb")
             mock_get_manager.return_value = mock_manager
-            
-            with patch('jfox.bm25_index.reset_bm25_index', side_effect=Exception("Reset error")):
+
+            with patch('jfox.bm25_index.reset_bm25_index', side_effect=Exception("Reset error")), \
+                 patch('jfox.search_engine.reset_search_engine') as mock_reset_search, \
+                 patch('jfox.vector_store.reset_vector_store') as mock_reset_vector:
                 # 应该不抛出异常
                 with use_kb("test_kb"):
                     pass
+
+                # 即使 bm25 重置失败，search_engine 和 vector_store 仍然被调用
+                assert mock_reset_search.call_count == 2
+                assert mock_reset_vector.call_count == 2


### PR DESCRIPTION
## Summary
- Fix `use_kb()` finally block to reset cached singletons (`_search_engine`, `_vector_store`, `_bm25_index`) after restoring config paths, so subsequent operations use the correct KB
- Extract `_reset_singletons()` helper with independent try/except per reset (one failure doesn't prevent others)
- Update tests to verify all 3 singletons are reset on both entry and exit

Closes #86

## Test plan
- [x] `uv run pytest tests/test_config_unit.py -v` — 17/17 passed
- [ ] `uv run pytest tests/ -v` — full test suite (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)