### PR TITLE
fix: repair default KB deletion safety check broken by path change (#87)

### DIFF
--- a/jfox/kb_manager.py
+++ b/jfox/kb_manager.py
@@ -12,10 +12,11 @@ from pathlib import Path
 from typing import List, Optional, Dict, Any
 
 from .global_config import (
-    GlobalConfigManager, 
-    KnowledgeBaseEntry, 
+    GlobalConfigManager,
+    KnowledgeBaseEntry,
     get_global_config_manager,
-    DEFAULT_KB_PATH
+    DEFAULT_KB_PATH,
+    DEFAULT_KB_NAME,
 )
 from .config import ZKConfig
 
@@ -149,7 +150,7 @@ class KnowledgeBaseManager:
         # 删除数据（如果需要）
         if delete_data and path and path.exists():
             # 禁止删除 default KB 的数据目录，因为其他命名 KB 也在其中
-            if path.resolve() == DEFAULT_KB_PATH.resolve():
+            if name == DEFAULT_KB_NAME:
                 return (
                     True,
                     f"Removed knowledge base '{name}' from config, "

--- a/tests/unit/test_kb_manager.py
+++ b/tests/unit/test_kb_manager.py
@@ -266,7 +266,24 @@ class TestKnowledgeBaseManager:
         
         assert success is True  # 移除配置仍然成功
         assert "failed to delete data" in message
-    
+
+    def test_remove_default_kb_with_delete_data_protected(self, manager, mock_config_manager, tmp_path):
+        """测试删除 default KB 时保护数据目录不被删除"""
+        default_kb_path = tmp_path / "default"
+        default_kb_path.mkdir()
+        (default_kb_path / "notes").mkdir()
+
+        mock_config_manager.kb_exists.return_value = True
+        mock_config_manager.get_kb_path.return_value = default_kb_path
+        mock_config_manager.remove_knowledge_base.return_value = True
+
+        success, message = manager.remove(name="default", delete_data=True)
+
+        assert success is True
+        assert "cannot delete data" in message
+        # 数据目录应仍然存在
+        assert default_kb_path.exists()
+
     def test_rename_success(self, manager, mock_config_manager):
         """测试成功重命名知识库"""
         mock_config_manager.kb_exists.side_effect = lambda x: x == "old_name"


### PR DESCRIPTION
## Summary
- Fixes #87 — the safety guard in `kb_manager.py:remove()` that prevents deleting the default KB's data directory was broken after PR #85 moved the default KB to `~/.zettelkasten/default/`
- Changed from broken path comparison (`path.resolve() == DEFAULT_KB_PATH.resolve()`) to name-based check (`name == DEFAULT_KB_NAME`), which is simpler and immune to future path restructuring
- Added regression test `test_remove_default_kb_with_delete_data_protected`

## Test plan
- [x] `uv run pytest tests/unit/test_kb_manager.py -v` — 34/34 pass
- [ ] Manual: `jfox kb remove default --delete-data` should refuse to delete data

🤖 Generated with [Claude Code](https://claude.com/claude-code)