### PR TITLE
feat: add edit command to modify existing notes

### DIFF
--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -999,7 +999,7 @@ def _edit_impl(
 
 @app.command()
 def edit(
-    note_id: str = typer.Argument(..., help="笔记 ID 或标题"),
+    note_id: str = typer.Argument(..., help="笔记 ID"),
     content: Optional[str] = typer.Option(None, "--content", "-c", help="新内容"),
     title: Optional[str] = typer.Option(None, "--title", "-t", help="新标题"),
     tags: Optional[List[str]] = typer.Option(None, "--tag", help="新标签（替换全部）"),

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -890,6 +890,147 @@ def delete(
         raise typer.Exit(1)
 
 
+def _edit_impl(
+    note_id: str,
+    content: Optional[str],
+    title: Optional[str],
+    tags: Optional[List[str]],
+    note_type: Optional[str],
+    source: Optional[str],
+    json_output: bool,
+):
+    """编辑笔记的内部实现"""
+    # 验证：至少指定一个编辑字段
+    if all(v is None for v in [content, title, tags, note_type, source]):
+        raise ValueError("至少指定一个要编辑的字段 (--content, --title, --tags, --type, --source)")
+
+    # 加载笔记
+    n = note.load_note_by_id(note_id)
+    if not n:
+        raise ValueError(f"笔记不存在: {note_id}")
+
+    old_title = n.title
+    old_links = set(n.links)
+
+    # 更新字段
+    if content is not None:
+        n.content = content
+    if title is not None:
+        n.title = title
+    if tags is not None:
+        n.tags = tags
+    if source is not None:
+        n.source = source if source else None  # 空字符串清除 source
+    if note_type is not None:
+        try:
+            new_type = NoteType(note_type.lower())
+        except ValueError:
+            raise ValueError(
+                f"Invalid note type: {note_type}. Use: fleeting, literature, permanent"
+            )
+        n.type = new_type
+
+    # 如果内容被更新，解析 wiki links
+    if content is not None:
+        wiki_links = extract_wiki_links(content)
+        resolved_links = []
+        unresolved = []
+
+        all_notes = note.list_notes() if wiki_links else []
+        for link_text in wiki_links:
+            target_id = find_note_id_by_title_or_id(link_text, all_notes=all_notes)
+            if target_id:
+                resolved_links.append(target_id)
+            else:
+                unresolved.append(link_text)
+
+        n.links = resolved_links
+    else:
+        unresolved = []
+
+    # 保存更新
+    if note.update_note(n):
+        # 更新反向链接
+        new_links = set(n.links)
+
+        # 新增的链接 → 添加反向链接
+        added_links = new_links - old_links
+        for target_id in added_links:
+            target_note = note.load_note_by_id(target_id)
+            if target_note and n.id not in target_note.backlinks:
+                target_note.backlinks.append(n.id)
+                note.save_note(target_note, add_to_index=False)
+
+        # 移除的链接 → 删除反向链接
+        removed_links = old_links - new_links
+        for target_id in removed_links:
+            target_note = note.load_note_by_id(target_id)
+            if target_note and n.id in target_note.backlinks:
+                target_note.backlinks.remove(n.id)
+                note.save_note(target_note, add_to_index=False)
+
+        result = {
+            "success": True,
+            "note": {
+                "id": n.id,
+                "title": n.title,
+                "type": n.type.value,
+                "filepath": str(n.filepath),
+            },
+        }
+        if old_title != n.title:
+            result["title_changed"] = {"old": old_title, "new": n.title}
+        if unresolved:
+            result["warnings"] = f"Unresolved links: {', '.join(unresolved)}"
+
+        if json_output:
+            print(output_json(result))
+        else:
+            console.print(f"[green]✓[/green] Note updated: {n.title}")
+            if old_title != n.title:
+                console.print(f"  Title: {old_title} → {n.title}")
+            if unresolved:
+                console.print(
+                    f"  [yellow]Warning: Unresolved links - {', '.join(unresolved)}[/yellow]"
+                )
+    else:
+        raise Exception("Failed to update note")
+
+
+@app.command()
+def edit(
+    note_id: str = typer.Argument(..., help="笔记 ID 或标题"),
+    content: Optional[str] = typer.Option(None, "--content", "-c", help="新内容"),
+    title: Optional[str] = typer.Option(None, "--title", "-t", help="新标题"),
+    tags: Optional[List[str]] = typer.Option(None, "--tag", help="新标签（替换全部）"),
+    note_type: Optional[str] = typer.Option(
+        None, "--type", help="新类型 (fleeting/literature/permanent)"
+    ),
+    source: Optional[str] = typer.Option(None, "--source", "-s", help="新来源"),
+    kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
+    json_output: bool = typer.Option(True, "--json/--no-json", help="JSON 输出"),
+):
+    """编辑已有笔记（保留 ID 和创建时间）"""
+    try:
+        if kb:
+            from .config import use_kb
+
+            with use_kb(kb):
+                _edit_impl(note_id, content, title, tags, note_type, source, json_output)
+        else:
+            _edit_impl(note_id, content, title, tags, note_type, source, json_output)
+    except Exception as e:
+        result = {
+            "success": False,
+            "error": str(e),
+        }
+        if json_output:
+            print(output_json(result))
+        else:
+            console.print(f"[red]✗[/red] Error: {e}")
+        raise typer.Exit(1)
+
+
 def _query_impl(
     query_str: str,
     top: int,

--- a/jfox/note.py
+++ b/jfox/note.py
@@ -238,9 +238,12 @@ def update_note(note_obj: Note, add_to_index: bool = True) -> bool:
         # 更新索引
         if add_to_index:
             # 先删除旧索引，再添加新索引
-            vector_store = get_vector_store()
-            vector_store.delete_note(note_obj.id)
-            vector_store.add_note(note_obj)
+            try:
+                vector_store = get_vector_store()
+                vector_store.delete_note(note_obj.id)
+                vector_store.add_note(note_obj)
+            except Exception as e:
+                logger.warning(f"Failed to update vector store index: {e}")
 
             try:
                 from .bm25_index import get_bm25_index

--- a/jfox/note.py
+++ b/jfox/note.py
@@ -200,6 +200,64 @@ def delete_note(note_id: str) -> bool:
         return False
 
 
+def update_note(note_obj: Note, add_to_index: bool = True) -> bool:
+    """
+    更新已有笔记
+
+    处理：查找旧文件 → 更新 updated 时间戳 → 写入新文件 → 删除旧文件（如路径变化）→ 更新索引
+
+    Args:
+        note_obj: 已修改的 Note 对象（必须已有 id）
+        add_to_index: 是否更新搜索索引
+
+    Returns:
+        是否更新成功
+    """
+    # 查找当前文件路径（可能标题改了，按 ID 查）
+    old_filepath = find_note_file(config, note_obj.id)
+    if not old_filepath:
+        logger.warning(f"Note {note_obj.id} file not found on disk")
+        return False
+
+    try:
+        # 更新时间戳
+        note_obj.updated = datetime.now()
+
+        # 写入新文件（filepath 属性根据当前字段生成）
+        note_obj.filepath.parent.mkdir(parents=True, exist_ok=True)
+        with open(note_obj.filepath, 'w', encoding='utf-8') as f:
+            f.write(note_obj.to_markdown())
+
+        # 如果文件路径变了（标题修改导致重命名），删除旧文件
+        if old_filepath != note_obj.filepath and old_filepath.exists():
+            old_filepath.unlink()
+            logger.info(f"Renamed note file: {old_filepath} -> {note_obj.filepath}")
+
+        logger.info(f"Updated note {note_obj.id}")
+
+        # 更新索引
+        if add_to_index:
+            # 先删除旧索引，再添加新索引
+            vector_store = get_vector_store()
+            vector_store.delete_note(note_obj.id)
+            vector_store.add_note(note_obj)
+
+            try:
+                from .bm25_index import get_bm25_index
+                bm25_index = get_bm25_index()
+                bm25_index.remove_document(note_obj.id)
+                content = f"{note_obj.title} {note_obj.content}"
+                bm25_index.add_document(note_obj.id, content)
+            except Exception as e:
+                logger.warning(f"Failed to update BM25 index: {e}")
+
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to update note {note_obj.id}: {e}")
+        return False
+
+
 def get_stats(cfg: Optional[ZKConfig] = None) -> Dict[str, Any]:
     """
     获取知识库统计

--- a/tests/unit/test_edit.py
+++ b/tests/unit/test_edit.py
@@ -1,0 +1,122 @@
+"""
+测试类型: 单元测试
+目标模块: jfox.note (update_note 函数)
+预估耗时: < 1秒
+依赖要求: 无外部依赖
+"""
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+
+from jfox.models import Note, NoteType
+from jfox.note import update_note, create_note, save_note, load_note_by_id
+from jfox.config import ZKConfig
+
+
+class TestUpdateNote:
+    """测试 update_note 函数"""
+
+    def _make_config(self, tmp_path):
+        """创建临时配置"""
+        cfg = ZKConfig(base_dir=tmp_path)
+        cfg.ensure_dirs()
+        return cfg
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_update_content_preserves_id_and_created(
+        self, mock_global_config, mock_note_config, tmp_path
+    ):
+        """更新内容时保留 ID 和创建时间"""
+        cfg = self._make_config(tmp_path)
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        # 创建笔记
+        n = create_note("original content", title="Test", note_type=NoteType.PERMANENT)
+        save_note(n, add_to_index=False)
+
+        original_id = n.id
+        original_created = n.created
+
+        # 更新内容
+        n.content = "updated content"
+        updated = update_note(n, add_to_index=False)
+
+        assert updated is True
+        # 重新加载验证
+        loaded = load_note_by_id(original_id, cfg=cfg)
+        assert loaded is not None
+        assert loaded.id == original_id
+        assert loaded.created == original_created
+        assert loaded.content == "updated content"
+        assert loaded.updated > original_created
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_update_title_renames_file(
+        self, mock_global_config, mock_note_config, tmp_path
+    ):
+        """更新标题时重命名文件"""
+        cfg = self._make_config(tmp_path)
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        n = create_note("content", title="Old Title", note_type=NoteType.PERMANENT)
+        save_note(n, add_to_index=False)
+
+        # 记录旧路径
+        old_filepath = n.filepath
+        assert old_filepath.exists()
+
+        # 修改标题
+        n.title = "New Title"
+
+        updated = update_note(n, add_to_index=False)
+        assert updated is True
+
+        # 旧文件应该不存在
+        assert not old_filepath.exists()
+        # 新文件应该存在
+        loaded = load_note_by_id(n.id, cfg=cfg)
+        assert loaded is not None
+        assert loaded.title == "New Title"
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_update_tags(self, mock_global_config, mock_note_config, tmp_path):
+        """更新标签"""
+        cfg = self._make_config(tmp_path)
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        n = create_note(
+            "content", title="Test", note_type=NoteType.PERMANENT, tags=["old"]
+        )
+        save_note(n, add_to_index=False)
+
+        n.tags = ["new1", "new2"]
+        updated = update_note(n, add_to_index=False)
+        assert updated is True
+
+        loaded = load_note_by_id(n.id, cfg=cfg)
+        assert loaded.tags == ["new1", "new2"]
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_update_nonexistent_note_returns_false(
+        self, mock_global_config, mock_note_config, tmp_path
+    ):
+        """更新不存在的笔记返回 False"""
+        cfg = self._make_config(tmp_path)
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        n = create_note("content", title="Ghost", note_type=NoteType.PERMANENT)
+        # 不调用 save_note，文件不存在
+
+        updated = update_note(n, add_to_index=False)
+        assert updated is False

--- a/tests/unit/test_edit.py
+++ b/tests/unit/test_edit.py
@@ -229,7 +229,7 @@ class TestEditImpl:
         mock_global_config.notes_dir = cfg.notes_dir
         mock_note_config.notes_dir = cfg.notes_dir
 
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError, match="笔记不存在"):
             _edit_impl(
                 note_id="9999999999999999",
                 content="x",

--- a/tests/unit/test_edit.py
+++ b/tests/unit/test_edit.py
@@ -120,3 +120,184 @@ class TestUpdateNote:
 
         updated = update_note(n, add_to_index=False)
         assert updated is False
+
+
+class TestEditImpl:
+    """测试 _edit_impl 内部实现"""
+
+    def _make_config(self, tmp_path):
+        """创建临时配置"""
+        cfg = ZKConfig(base_dir=tmp_path)
+        cfg.ensure_dirs()
+        return cfg
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_edit_content(self, mock_global_config, mock_note_config, tmp_path):
+        """通过 --content 编辑笔记内容"""
+        from jfox.cli import _edit_impl
+
+        cfg = self._make_config(tmp_path)
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        # 创建笔记
+        n = create_note("original", title="EditMe", note_type=NoteType.PERMANENT)
+        save_note(n, add_to_index=False)
+
+        _edit_impl(
+            note_id=n.id,
+            content="updated content",
+            title=None,
+            tags=None,
+            note_type=None,
+            source=None,
+            json_output=True,
+        )
+
+        loaded = load_note_by_id(n.id, cfg=cfg)
+        assert loaded is not None
+        assert loaded.content == "updated content"
+        assert loaded.id == n.id
+        assert loaded.title == "EditMe"
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_edit_title(self, mock_global_config, mock_note_config, tmp_path):
+        """编辑笔记标题"""
+        from jfox.cli import _edit_impl
+
+        cfg = self._make_config(tmp_path)
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        n = create_note("content", title="OldTitle", note_type=NoteType.PERMANENT)
+        save_note(n, add_to_index=False)
+
+        _edit_impl(
+            note_id=n.id,
+            content=None,
+            title="NewTitle",
+            tags=None,
+            note_type=None,
+            source=None,
+            json_output=True,
+        )
+
+        loaded = load_note_by_id(n.id, cfg=cfg)
+        assert loaded is not None
+        assert loaded.title == "NewTitle"
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_edit_multiple_fields(self, mock_global_config, mock_note_config, tmp_path):
+        """同时编辑多个字段"""
+        from jfox.cli import _edit_impl
+
+        cfg = self._make_config(tmp_path)
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        n = create_note("old content", title="Old", note_type=NoteType.LITERATURE, tags=["a"])
+        save_note(n, add_to_index=False)
+
+        _edit_impl(
+            note_id=n.id,
+            content="new content",
+            title="New Title",
+            tags=["x", "y"],
+            note_type="permanent",
+            source="book",
+            json_output=True,
+        )
+
+        loaded = load_note_by_id(n.id, cfg=cfg)
+        assert loaded is not None
+        assert loaded.content == "new content"
+        assert loaded.title == "New Title"
+        assert loaded.tags == ["x", "y"]
+        assert loaded.type == NoteType.PERMANENT
+        assert loaded.source == "book"
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_edit_nonexistent_note_raises(self, mock_global_config, mock_note_config, tmp_path):
+        """编辑不存在的笔记抛出异常"""
+        from jfox.cli import _edit_impl
+
+        cfg = self._make_config(tmp_path)
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        with pytest.raises(Exception):
+            _edit_impl(
+                note_id="9999999999999999",
+                content="x",
+                title=None,
+                tags=None,
+                note_type=None,
+                source=None,
+                json_output=True,
+            )
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_edit_no_fields_specified_raises(self, mock_global_config, mock_note_config, tmp_path):
+        """未指定任何编辑字段时抛出异常"""
+        from jfox.cli import _edit_impl
+
+        cfg = self._make_config(tmp_path)
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        n = create_note("content", title="NoEdit", note_type=NoteType.PERMANENT)
+        save_note(n, add_to_index=False)
+
+        with pytest.raises(ValueError, match="至少指定一个"):
+            _edit_impl(
+                note_id=n.id,
+                content=None,
+                title=None,
+                tags=None,
+                note_type=None,
+                source=None,
+                json_output=True,
+            )
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_edit_with_wiki_links_resolves(self, mock_global_config, mock_note_config, tmp_path):
+        """编辑内容中的 [[链接]] 被解析"""
+        from jfox.cli import _edit_impl
+
+        cfg = self._make_config(tmp_path)
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        # 创建目标笔记
+        target = create_note("target note", title="TargetNote", note_type=NoteType.PERMANENT)
+        save_note(target, add_to_index=False)
+
+        # 创建源笔记
+        source = create_note("source note", title="SourceNote", note_type=NoteType.PERMANENT)
+        save_note(source, add_to_index=False)
+
+        # 编辑源笔记，添加 wiki link
+        _edit_impl(
+            note_id=source.id,
+            content="see [[TargetNote]] for details",
+            title=None,
+            tags=None,
+            note_type=None,
+            source=None,
+            json_output=True,
+        )
+
+        loaded = load_note_by_id(source.id, cfg=cfg)
+        assert loaded is not None
+        assert target.id in loaded.links
+
+        # 验证反向链接
+        target_loaded = load_note_by_id(target.id, cfg=cfg)
+        assert target_loaded is not None
+        assert source.id in target_loaded.backlinks

--- a/tests/unit/test_edit.py
+++ b/tests/unit/test_edit.py
@@ -301,3 +301,89 @@ class TestEditImpl:
         target_loaded = load_note_by_id(target.id, cfg=cfg)
         assert target_loaded is not None
         assert source.id in target_loaded.backlinks
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_edit_removes_backlink_when_link_removed(self, mock_global_config, mock_note_config, tmp_path):
+        """编辑内容移除 [[链接]] 时，反向链接也被移除"""
+        from jfox.cli import _edit_impl
+
+        cfg = self._make_config(tmp_path)
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        # 创建目标笔记
+        target = create_note("target note", title="TargetNote", note_type=NoteType.PERMANENT)
+        save_note(target, add_to_index=False)
+
+        # 创建源笔记，带链接
+        source = create_note(
+            "see [[TargetNote]] for details",
+            title="SourceNote",
+            note_type=NoteType.PERMANENT,
+            links=[target.id],
+        )
+        save_note(source, add_to_index=False)
+
+        # 给目标笔记添加反向链接
+        target.backlinks.append(source.id)
+        save_note(target, add_to_index=False)
+
+        # 编辑源笔记，移除链接
+        _edit_impl(
+            note_id=source.id,
+            content="no more links here",
+            title=None,
+            tags=None,
+            note_type=None,
+            source=None,
+            json_output=True,
+        )
+
+        loaded = load_note_by_id(source.id, cfg=cfg)
+        assert loaded is not None
+        assert target.id not in loaded.links
+
+        # 验证反向链接也被移除
+        target_loaded = load_note_by_id(target.id, cfg=cfg)
+        assert target_loaded is not None
+        assert source.id not in target_loaded.backlinks
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_edit_type_changes_directory(self, mock_global_config, mock_note_config, tmp_path):
+        """编辑笔记类型时文件移动到新目录"""
+        from jfox.cli import _edit_impl
+
+        cfg = self._make_config(tmp_path)
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        # 创建 literature 笔记
+        n = create_note("some content", title="DirMove", note_type=NoteType.LITERATURE)
+        save_note(n, add_to_index=False)
+
+        old_filepath = load_note_by_id(n.id, cfg=cfg).filepath
+        assert old_filepath.exists()
+        assert "literature" in str(old_filepath)
+
+        # 修改类型为 permanent
+        _edit_impl(
+            note_id=n.id,
+            content=None,
+            title=None,
+            tags=None,
+            note_type="permanent",
+            source=None,
+            json_output=True,
+        )
+
+        # 旧文件应该不存在
+        assert not old_filepath.exists()
+
+        # 新文件应该在 permanent 目录
+        loaded = load_note_by_id(n.id, cfg=cfg)
+        assert loaded is not None
+        assert loaded.type == NoteType.PERMANENT
+        assert "permanent" in str(loaded.filepath)
+        assert loaded.filepath.exists()

--- a/tests/utils/jfox_cli.py
+++ b/tests/utils/jfox_cli.py
@@ -229,9 +229,44 @@ class ZKCLI:
         args = [note_id]
         if force:
             args.append("--force")
-        
+
         return self._run("delete", *args)
-    
+
+    def edit(
+        self,
+        note_id: str,
+        content: Optional[str] = None,
+        title: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        note_type: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> CLIResult:
+        """
+        编辑笔记
+
+        Args:
+            note_id: 笔记 ID
+            content: 新内容
+            title: 新标题
+            tags: 新标签列表（替换全部）
+            note_type: 新类型 (fleeting/literature/permanent)
+            source: 新来源
+        """
+        args = [note_id]
+        if content:
+            args.extend(["--content", content])
+        if title:
+            args.extend(["--title", title])
+        if tags:
+            for tag in tags:
+                args.extend(["--tag", tag])
+        if note_type:
+            args.extend(["--type", note_type])
+        if source:
+            args.extend(["--source", source])
+
+        return self._run("edit", *args)
+
     def status(self) -> CLIResult:
         """查看知识库状态"""
         return self._run("status")

--- a/uv.lock
+++ b/uv.lock
@@ -851,7 +851,7 @@ wheels = [
 
 [[package]]
 name = "jfox-cli"
-version = "0.1.0"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

- Add `jfox edit <note_id>` command for modifying existing notes while preserving ID and creation timestamp
- New `update_note()` storage function in `note.py` handles file rename on title change, directory move on type change, and index reindexing (vector + BM25)
- CLI supports partial field updates: `--content/-c`, `--title/-t`, `--tag`, `--type`, `--source/-s`
- Wiki-link resolution (`[[Note Title]]`) with full backlink maintenance (both add and remove)
- 12 unit tests covering: content/title/tags/type updates, file rename, directory move, backlink add/remove, validation errors

Closes #93

## Test plan

- [x] `uv run pytest tests/unit/test_edit.py -v` — 12/12 passing
- [x] `uv run jfox edit --help` — shows correct options
- [ ] Full test suite: `uv run pytest tests/ -v` (run manually to verify no regressions)
- [ ] Manual smoke test: create note, edit content, verify ID/timestamp preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)