### PR TITLE
fix: update BM25 index during bulk import

### DIFF
--- a/jfox/bm25_index.py
+++ b/jfox/bm25_index.py
@@ -269,6 +269,7 @@ class BM25Index:
         saved_docs = list(self.documents)
         saved_ids = list(self.doc_ids)
         saved_mapping = dict(self.doc_mapping)
+        saved_bm25 = self.bm25
 
         try:
             for note_id, content in documents:
@@ -296,8 +297,14 @@ class BM25Index:
             # 一次性重建索引
             self._rebuild_index()
 
-            # 一次性保存
-            self._save()
+            # 一次性保存，失败时回滚
+            if not self._save():
+                self.documents = saved_docs
+                self.doc_ids = saved_ids
+                self.doc_mapping = saved_mapping
+                self.bm25 = saved_bm25
+                logger.error("Failed to persist BM25 index after batch add, rolled back")
+                return False
 
             logger.info(f"Batch added {len(documents)} documents to BM25 index")
             return True
@@ -307,7 +314,11 @@ class BM25Index:
             self.documents = saved_docs
             self.doc_ids = saved_ids
             self.doc_mapping = saved_mapping
-            logger.error(f"Failed to batch add documents: {e}")
+            self.bm25 = saved_bm25
+            logger.error(
+                f"Failed to batch add {len(documents)} documents to BM25 index",
+                exc_info=True,
+            )
             return False
 
     def search(self, query: str, top_k: int = 5) -> List[Dict]:

--- a/jfox/bm25_index.py
+++ b/jfox/bm25_index.py
@@ -249,6 +249,67 @@ class BM25Index:
             logger.error(f"Failed to remove document {note_id}: {e}")
             return False
     
+    def add_documents_batch(self, documents: List[Tuple[str, str]]) -> bool:
+        """
+        批量添加文档到索引（高效版本）
+
+        与逐条调用 add_document() 不同，此方法收集所有文档后只执行一次索引重建和保存。
+        适用于批量导入场景。
+
+        Args:
+            documents: [(note_id, content), ...] 列表
+
+        Returns:
+            是否成功添加
+        """
+        if not documents:
+            return True
+
+        # 快照当前状态，失败时恢复
+        saved_docs = list(self.documents)
+        saved_ids = list(self.doc_ids)
+        saved_mapping = dict(self.doc_mapping)
+
+        try:
+            for note_id, content in documents:
+                # 如果已存在，先移除
+                if note_id in self.doc_mapping:
+                    # 内联移除逻辑，避免触发 rebuild/save
+                    idx = self.doc_mapping[note_id]
+                    self.documents.pop(idx)
+                    self.doc_ids.pop(idx)
+                    del self.doc_mapping[note_id]
+                    # 更新后续索引
+                    self.doc_mapping = {}
+                    for i, doc_id in enumerate(self.doc_ids):
+                        self.doc_mapping[doc_id] = i
+
+                # 分词并添加
+                tokens = self._tokenize(content)
+                if not tokens:
+                    continue  # 跳过分词结果为空的文档
+                idx = len(self.documents)
+                self.documents.append(tokens)
+                self.doc_ids.append(note_id)
+                self.doc_mapping[note_id] = idx
+
+            # 一次性重建索引
+            self._rebuild_index()
+
+            # 一次性保存
+            self._save()
+
+            logger.info(f"Batch added {len(documents)} documents to BM25 index")
+            return True
+
+        except Exception as e:
+            # 恢复到批次前的状态
+            self.documents = saved_docs
+            self.doc_ids = saved_ids
+            self.doc_mapping = saved_mapping
+            logger.error(f"Failed to batch add documents: {e}")
+            return False
+
     def search(self, query: str, top_k: int = 5) -> List[Dict]:
         """
         搜索文档

--- a/jfox/performance.py
+++ b/jfox/performance.py
@@ -188,6 +188,7 @@ def bulk_import_notes(
     from . import note as note_module
     from .embedding_backend import get_backend
     from .vector_store import get_vector_store
+    from .bm25_index import get_bm25_index
     
     nt = NoteType(note_type.lower())
     backend = get_backend()
@@ -264,6 +265,12 @@ def bulk_import_notes(
                     embeddings=embeddings,
                     metadatas=metadatas
                 )
+
+                # 批量添加到 BM25 索引
+                bm25 = get_bm25_index()
+                bm25_docs = [(n.id, f"{n.title} {n.content}") for n in notes]
+                bm25.add_documents_batch(bm25_docs)
+
             except Exception as e:
                 logger.warning(f"Failed to index batch: {e}")
             

--- a/tests/unit/test_bm25_batch.py
+++ b/tests/unit/test_bm25_batch.py
@@ -97,3 +97,143 @@ class TestAddDocumentsBatch:
         results_gamma = bm25.search("gamma", top_k=2)
         assert any(r["note_id"] == "id1" for r in results_alpha)
         assert any(r["note_id"] == "id2" for r in results_gamma)
+
+
+class TestBulkImportBM25Integration:
+    """测试 bulk_import_notes 是否正确调用 BM25 索引"""
+
+    @patch("jfox.bm25_index.get_bm25_index")
+    @patch("jfox.vector_store.get_vector_store")
+    @patch("jfox.embedding_backend.get_backend")
+    @patch("jfox.note.create_note")
+    def test_bulk_import_calls_bm25_batch(
+        self, mock_create_note, mock_get_backend, mock_get_vs, mock_get_bm25, tmp_path
+    ):
+        """bulk_import_notes 应调用 add_documents_batch 更新 BM25 索引"""
+        import numpy as np
+        from jfox.performance import bulk_import_notes
+        from jfox.models import Note, NoteType
+
+        # 准备 mock note
+        mock_note = MagicMock(spec=Note)
+        mock_note.id = "20260411120000"
+        mock_note.title = "测试笔记"
+        mock_note.content = "这是测试内容"
+        mock_note.type = NoteType.PERMANENT
+        mock_note.tags = []
+        mock_note.filepath = tmp_path / "notes" / "permanent" / "test.md"
+        mock_note.to_markdown.return_value = "# 测试笔记\n这是测试内容"
+        mock_create_note.return_value = mock_note
+
+        # mock embedding backend
+        mock_backend = MagicMock()
+        mock_backend.model = MagicMock()
+        mock_backend.encode.return_value = np.array([[0.1] * 384])
+        mock_get_backend.return_value = mock_backend
+
+        # mock vector store
+        mock_vs = MagicMock()
+        mock_vs.collection = MagicMock()
+        mock_get_vs.return_value = mock_vs
+
+        # mock BM25
+        mock_bm25 = MagicMock()
+        mock_bm25.add_documents_batch.return_value = True
+        mock_get_bm25.return_value = mock_bm25
+
+        notes_data = [{"title": "测试笔记", "content": "这是测试内容"}]
+        result = bulk_import_notes(notes_data, show_progress=False)
+
+        # 验证 BM25 batch 被调用
+        mock_bm25.add_documents_batch.assert_called_once()
+        call_args = mock_bm25.add_documents_batch.call_args[0][0]
+        assert len(call_args) == 1
+        assert call_args[0] == ("20260411120000", "测试笔记 这是测试内容")
+
+    @patch("jfox.bm25_index.get_bm25_index")
+    @patch("jfox.vector_store.get_vector_store")
+    @patch("jfox.embedding_backend.get_backend")
+    @patch("jfox.note.create_note")
+    def test_bulk_import_bm25_failure_does_not_fail_import(
+        self, mock_create_note, mock_get_bm25, mock_get_backend, mock_get_vs, tmp_path
+    ):
+        """BM25 更新失败不应导致整个导入失败"""
+        import numpy as np
+        from jfox.performance import bulk_import_notes
+        from jfox.models import Note, NoteType
+
+        mock_note = MagicMock(spec=Note)
+        mock_note.id = "20260411120001"
+        mock_note.title = "测试"
+        mock_note.content = "内容"
+        mock_note.type = NoteType.PERMANENT
+        mock_note.tags = []
+        mock_note.filepath = tmp_path / "notes" / "permanent" / "test.md"
+        mock_note.to_markdown.return_value = "# 测试\n内容"
+        mock_create_note.return_value = mock_note
+
+        mock_backend = MagicMock()
+        mock_backend.model = MagicMock()
+        mock_backend.encode.return_value = np.array([[0.1] * 384])
+        mock_get_backend.return_value = mock_backend
+
+        mock_vs = MagicMock()
+        mock_vs.collection = MagicMock()
+        mock_get_vs.return_value = mock_vs
+
+        # BM25 抛异常
+        mock_bm25 = MagicMock()
+        mock_bm25.add_documents_batch.side_effect = Exception("BM25 error")
+        mock_get_bm25.return_value = mock_bm25
+
+        notes_data = [{"title": "测试", "content": "内容"}]
+        result = bulk_import_notes(notes_data, show_progress=False)
+
+        # 导入仍然成功（BM25 错误被 try/except 包裹）
+        assert result["imported"] == 1
+
+    @patch("jfox.bm25_index.get_bm25_index")
+    @patch("jfox.vector_store.get_vector_store")
+    @patch("jfox.embedding_backend.get_backend")
+    @patch("jfox.note.create_note")
+    def test_bulk_import_multi_batch_calls_bm25_per_batch(
+        self, mock_create_note, mock_get_backend, mock_get_vs, mock_get_bm25, tmp_path
+    ):
+        """多批次导入时，每批都应调用 BM25 batch 更新"""
+        import numpy as np
+        from jfox.performance import bulk_import_notes
+        from jfox.models import Note, NoteType
+
+        notes = []
+        for i in range(5):
+            n = MagicMock(spec=Note)
+            n.id = f"2026041112000{i}"
+            n.title = f"笔记{i}"
+            n.content = f"内容{i}"
+            n.type = NoteType.PERMANENT
+            n.tags = []
+            n.filepath = tmp_path / "notes" / "permanent" / f"test{i}.md"
+            n.to_markdown.return_value = f"# 笔记{i}\n内容{i}"
+            notes.append(n)
+
+        mock_create_note.side_effect = notes
+
+        mock_backend = MagicMock()
+        mock_backend.model = MagicMock()
+        mock_backend.encode.return_value = np.array([[0.1] * 384] * 3)
+        mock_get_backend.return_value = mock_backend
+
+        mock_vs = MagicMock()
+        mock_vs.collection = MagicMock()
+        mock_get_vs.return_value = mock_vs
+
+        mock_bm25 = MagicMock()
+        mock_bm25.add_documents_batch.return_value = True
+        mock_get_bm25.return_value = mock_bm25
+
+        notes_data = [{"title": f"笔记{i}", "content": f"内容{i}"} for i in range(5)]
+        result = bulk_import_notes(notes_data, batch_size=3, show_progress=False)
+
+        # batch_size=3, 5 notes = 2 batches
+        assert result["imported"] == 5
+        assert mock_bm25.add_documents_batch.call_count == 2

--- a/tests/unit/test_bm25_batch.py
+++ b/tests/unit/test_bm25_batch.py
@@ -78,14 +78,38 @@ class TestAddDocumentsBatch:
         assert results[0]["note_id"] == "id1"
 
     def test_returns_false_on_error(self, bm25):
-        """异常时返回 False 并恢复索引状态"""
+        """异常时返回 False 并恢复索引状态（包括 bm25 对象）"""
         bm25.add_documents_batch([("id1", "first doc")])  # add something first
         count_before = len(bm25.doc_ids)
+        original_tokenize = bm25._tokenize
         bm25._tokenize = MagicMock(side_effect=RuntimeError("boom"))
         result = bm25.add_documents_batch([("id2", "test")])
         assert result is False
+        # 恢复原始 _tokenize 以便搜索正常工作
+        bm25._tokenize = original_tokenize
         # 状态应恢复到错误前
         assert len(bm25.doc_ids) == count_before
+        # bm25 对象也应恢复，搜索仍能正常工作
+        results = bm25.search("first doc", top_k=1)
+        assert len(results) == 1
+        assert results[0]["note_id"] == "id1"
+
+    def test_save_failure_rolls_back(self, bm25):
+        """_save 失败时，应回滚所有状态（包括 bm25 对象）"""
+        bm25.add_documents_batch([("id1", "alpha beta")])
+
+        # 让 _save 失败
+        bm25._save = MagicMock(return_value=False)
+        result = bm25.add_documents_batch([("id2", "gamma delta")])
+        assert result is False
+
+        # 索引应回滚到只有 id1 的状态
+        assert len(bm25.doc_ids) == 1
+        assert bm25.doc_ids == ["id1"]
+        # bm25 对象也应恢复，搜索仍能找到 id1
+        results = bm25.search("alpha", top_k=1)
+        assert len(results) == 1
+        assert results[0]["note_id"] == "id1"
 
     def test_appends_to_existing_index(self, bm25):
         """批量添加应追加到已有索引，不覆盖"""
@@ -155,7 +179,7 @@ class TestBulkImportBM25Integration:
     @patch("jfox.embedding_backend.get_backend")
     @patch("jfox.note.create_note")
     def test_bulk_import_bm25_failure_does_not_fail_import(
-        self, mock_create_note, mock_get_bm25, mock_get_backend, mock_get_vs, tmp_path
+        self, mock_create_note, mock_get_backend, mock_get_vs, mock_get_bm25, tmp_path
     ):
         """BM25 更新失败不应导致整个导入失败"""
         import numpy as np

--- a/tests/unit/test_bm25_batch.py
+++ b/tests/unit/test_bm25_batch.py
@@ -1,0 +1,99 @@
+"""
+BM25Index.add_documents_batch() 单元测试
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+from jfox.bm25_index import BM25Index
+
+
+@pytest.fixture
+def bm25(tmp_path):
+    """提供干净的 BM25Index 实例，索引目录指向临时目录"""
+    with patch.object(BM25Index, '_load', return_value=False):
+        idx = BM25Index(index_dir=tmp_path)
+    # 阻止自动保存，减少 IO
+    idx._save = MagicMock(return_value=True)
+    return idx
+
+
+class TestAddDocumentsBatch:
+    """测试 add_documents_batch 方法"""
+
+    def test_adds_multiple_documents(self, bm25):
+        """批量添加多个文档后，doc_ids 和 doc_mapping 应包含所有文档"""
+        docs = [
+            ("id1", "hello world"),
+            ("id2", "foo bar baz"),
+            ("id3", "测试中文内容"),
+        ]
+        result = bm25.add_documents_batch(docs)
+
+        assert result is True
+        assert len(bm25.doc_ids) == 3
+        assert "id1" in bm25.doc_mapping
+        assert "id2" in bm25.doc_mapping
+        assert "id3" in bm25.doc_mapping
+
+    def test_builds_valid_bm25_index(self, bm25):
+        """批量添加后 BM25 索引应可用，搜索能返回结果"""
+        docs = [
+            ("id1", "machine learning algorithm"),
+            ("id2", "deep learning neural network"),
+            ("id3", "natural language processing"),
+        ]
+        bm25.add_documents_batch(docs)
+
+        results = bm25.search("machine learning", top_k=3)
+        assert len(results) > 0
+        assert results[0]["note_id"] == "id1"
+
+    def test_single_rebuild_per_batch(self, bm25):
+        """批量添加应只触发一次 _rebuild_index 和一次 _save"""
+        bm25._rebuild_index = MagicMock()
+        bm25._save = MagicMock(return_value=True)
+
+        docs = [("id1", "a"), ("id2", "b"), ("id3", "c")]
+        bm25.add_documents_batch(docs)
+
+        bm25._rebuild_index.assert_called_once()
+        bm25._save.assert_called_once()
+
+    def test_empty_batch_returns_true(self, bm25):
+        """空批次不触发 rebuild，直接返回 True"""
+        bm25._rebuild_index = MagicMock()
+        result = bm25.add_documents_batch([])
+
+        assert result is True
+        bm25._rebuild_index.assert_not_called()
+
+    def test_handles_duplicate_ids(self, bm25):
+        """重复 ID 应覆盖旧文档（先移除再添加）"""
+        bm25.add_documents_batch([("id1", "old content")])
+        bm25.add_documents_batch([("id1", "new content")])
+
+        assert len(bm25.doc_ids) == 1
+        results = bm25.search("new content", top_k=1)
+        assert results[0]["note_id"] == "id1"
+
+    def test_returns_false_on_error(self, bm25):
+        """异常时返回 False 并恢复索引状态"""
+        bm25.add_documents_batch([("id1", "first doc")])  # add something first
+        count_before = len(bm25.doc_ids)
+        bm25._tokenize = MagicMock(side_effect=RuntimeError("boom"))
+        result = bm25.add_documents_batch([("id2", "test")])
+        assert result is False
+        # 状态应恢复到错误前
+        assert len(bm25.doc_ids) == count_before
+
+    def test_appends_to_existing_index(self, bm25):
+        """批量添加应追加到已有索引，不覆盖"""
+        bm25.add_documents_batch([("id1", "alpha beta")])
+        bm25.add_documents_batch([("id2", "gamma delta")])
+
+        assert len(bm25.doc_ids) == 2
+        results_alpha = bm25.search("alpha", top_k=2)
+        results_gamma = bm25.search("gamma", top_k=2)
+        assert any(r["note_id"] == "id1" for r in results_alpha)
+        assert any(r["note_id"] == "id2" for r in results_gamma)


### PR DESCRIPTION
## Summary

- `bulk_import_notes()` now updates the BM25 keyword index alongside the ChromaDB vector index, fixing keyword search returning 0 results after bulk import
- Added `BM25Index.add_documents_batch()` for efficient single-rebuild-per-batch (instead of per-document rebuild+save)
- Full snapshot/rollback semantics: restores all state including the BM25 model object on failure

## Changes

| File | Change |
|------|--------|
| `jfox/bm25_index.py` | New `add_documents_batch()` method with snapshot/rollback |
| `jfox/performance.py` | Wired BM25 batch call into `bulk_import_notes()` |
| `tests/unit/test_bm25_batch.py` | 11 tests: 8 unit + 3 integration |

## Test plan

- [x] 11/11 unit tests pass (`tests/unit/test_bm25_batch.py`)
- [ ] Full integration test: `jfox bulk-import notes.json --kb test-kb` then `jfox search "keyword" --kb test-kb`
- [ ] Verify `jfox index bm25-status` shows updated count after bulk import

Fixes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)