### PR TITLE
docs: update skills with edit command support

### DIFF
--- a/skills-recommend/claude-code/jfox-insert/SKILL.md
+++ b/skills-recommend/claude-code/jfox-insert/SKILL.md
@@ -100,6 +100,28 @@ jfox bulk-import <path-to-file.json> --type permanent --batch-size 32
 jfox bulk-import <path-to-file.json> --kb work --type permanent
 ```
 
+## Editing Existing Notes
+
+Modify existing notes while preserving ID and creation timestamp:
+
+```bash
+# Edit content
+jfox edit <note_id> --content "新内容"
+
+# Edit title
+jfox edit <note_id> --title "新标题"
+
+# Edit multiple fields at once
+jfox edit <note_id> --content "新内容" --title "新标题" --tag tag1 --tag tag2
+
+# Edit in a specific knowledge base
+jfox edit <note_id> --kb <kb-name> --content "新内容"
+```
+
+**Workflow**: Find note ID via `jfox list --format json` or `jfox inbox --json`, then edit.
+
+> **Note**: `jfox edit` uses `--json`/`--no-json` (default: on), NOT `--format json`.
+
 ## Command Reference
 
 ```bash
@@ -114,6 +136,9 @@ jfox add "<content>" --template <quick|meeting|literature>
 
 # Bulk
 jfox bulk-import <file.json> --type <type> --batch-size <N>
+
+# Edit existing note
+jfox edit <note_id> --content "新内容" --title "新标题" --tag <tag>
 
 # Link suggestions before insert
 jfox suggest-links "<content>" --top 5 --threshold 0.6 --format json

--- a/skills-recommend/claude-code/jfox-organize/SKILL.md
+++ b/skills-recommend/claude-code/jfox-organize/SKILL.md
@@ -52,7 +52,11 @@ For each orphan:
    ```bash
    jfox suggest-links "<content>" --format json
    ```
-3. If good matches found (score >= 0.6), suggest adding `[[links]]` to connect the note
+3. If good matches found (score >= 0.6), suggest adding `[[links]]` to connect the note:
+   ```bash
+   # Edit the orphan note to add links
+   jfox edit <orphan_id> --content "原内容... [[相关笔记标题]]"
+   ```
 
 ### Step 3: Analyze Graph Connectivity
 
@@ -112,6 +116,7 @@ jfox suggest-links "<content>" --format json # 推荐链接
 jfox refs --search "<title>" --format json  # 查看引用关系
 jfox list --format json --limit <N>         # 列出笔记
 jfox add "<content>" --type permanent       # 添加精炼笔记
+jfox edit <id> --content "新内容"            # 编辑已有笔记（保留 ID 和时间戳）
 jfox delete <id> --force                    # 删除原始笔记
 jfox daily --json                           # 查看今天的笔记
 ```
@@ -120,5 +125,5 @@ jfox daily --json                           # 查看今天的笔记
 
 - **Process inbox weekly**: Don't let fleeting notes accumulate past 30.
 - **Link liberally**: The value of Zettelkasten is in connections, not volume.
-- **Convert, don't edit**: Instead of editing fleeting notes in-place, create a new permanent note and delete the fleeting original. This preserves the audit trail.
+- **Editing notes**: Use `jfox edit` to modify existing notes while preserving ID and creation time. Use `jfox add` + `jfox delete` only when converting note types (e.g. fleeting → permanent).
 - **Use tags for topics, links for ideas**: Tags group by topic; `[[links]]` connect by thought.


### PR DESCRIPTION
## Summary
- Add `jfox edit` command documentation to jfox-insert skill (new "Editing Existing Notes" section + Command Reference entry)
- Update jfox-organize skill: add `jfox edit` for orphan linking, fix "Convert, don't edit" tip, add edit to Command Reference

Closes #99

## Test plan
- [x] Verify `jfox-insert/SKILL.md` includes edit usage and workflow
- [x] Verify `jfox-organize/SKILL.md` updated orphan handling and tips
- [ ] Manual review of skill content

🤖 Generated with [Claude Code](https://claude.com/claude-code)