### PR TITLE
fix: add --kb parameter to jfox index command (#104)

### DIFF
--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -1590,6 +1590,7 @@ def index(
     action: str = typer.Argument(
         "status", help="操作: status, rebuild, verify, rebuild-bm25, bm25-status"
     ),
+    kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
     output_format: str = typer.Option("table", "--format", "-f", help="输出格式: json, table"),
     json_output: bool = typer.Option(
         False, "--json", help="JSON 输出（快捷方式，等同于 --format json）"
@@ -1597,137 +1598,145 @@ def index(
 ):
     """索引管理：查看状态、重建索引、验证完整性"""
     try:
-        # 处理 --json 快捷方式
-        if json_output:
-            output_format = "json"
+        from .config import use_kb
 
-        if action == "rebuild-bm25":
-            # 重建 BM25 索引
-            from . import note as note_module
-            from .bm25_index import get_bm25_index
+        with use_kb(kb):
+            # 处理 --json 快捷方式
+            if json_output:
+                output_format = "json"
 
-            console.print("[yellow]Rebuilding BM25 index...[/yellow]")
-            bm25_index = get_bm25_index()
-            notes = note_module.list_notes(limit=10000)
-            success = bm25_index.rebuild_from_notes(notes)
+            if action == "rebuild-bm25":
+                # 重建 BM25 索引
+                from . import note as note_module
+                from .bm25_index import get_bm25_index
 
-            result = {
-                "success": success,
-                "indexed": len(notes),
-            }
-
-            if output_format == "json":
-                print(output_json(result))
-            else:
-                if success:
-                    console.print(f"[green]✓[/green] BM25 index rebuilt: {len(notes)} notes")
-                else:
-                    console.print("[red]✗[/red] Failed to rebuild BM25 index")
-
-        elif action == "bm25-status":
-            # 查看 BM25 索引状态
-            from .bm25_index import get_bm25_index
-
-            bm25_index = get_bm25_index()
-            stats = bm25_index.get_stats()
-
-            result = {
-                "bm25_index": stats,
-            }
-
-            if output_format == "json":
-                print(output_json(result))
-            else:
-                table = Table(title="BM25 Index Status")
-                table.add_column("Property", style="cyan")
-                table.add_column("Value", style="green")
-                table.add_row("Indexed Documents", str(stats["indexed"]))
-                table.add_row("Index Version", str(stats["version"]))
-                table.add_row("Index File", str(stats["index_path"]))
-                table.add_row("Index Exists", "Yes" if stats["index_exists"] else "No")
-                console.print(table)
-
-        else:
-            vector_store = get_vector_store()
-            indexer = Indexer(config, vector_store)
-
-            if action == "status":
-                stats = indexer.get_stats()
-                vs_stats = vector_store.get_stats()
+                console.print("[yellow]Rebuilding BM25 index...[/yellow]")
+                bm25_index = get_bm25_index()
+                notes = note_module.list_notes(limit=10000)
+                success = bm25_index.rebuild_from_notes(notes)
 
                 result = {
-                    "total_indexed": stats.total_indexed,
-                    "last_indexed": stats.last_indexed.isoformat() if stats.last_indexed else None,
-                    "pending_changes": stats.pending_changes,
-                    "vector_store": vs_stats,
+                    "success": success,
+                    "indexed": len(notes),
                 }
 
                 if output_format == "json":
                     print(output_json(result))
                 else:
-                    table = Table(title="Index Status")
+                    if success:
+                        console.print(f"[green]✓[/green] BM25 index rebuilt: {len(notes)} notes")
+                    else:
+                        console.print("[red]✗[/red] Failed to rebuild BM25 index")
+
+            elif action == "bm25-status":
+                # 查看 BM25 索引状态
+                from .bm25_index import get_bm25_index
+
+                bm25_index = get_bm25_index()
+                stats = bm25_index.get_stats()
+
+                result = {
+                    "bm25_index": stats,
+                }
+
+                if output_format == "json":
+                    print(output_json(result))
+                else:
+                    table = Table(title="BM25 Index Status")
                     table.add_column("Property", style="cyan")
                     table.add_column("Value", style="green")
-                    table.add_row("Total Indexed", str(stats.total_indexed))
-                    table.add_row("Last Indexed", str(stats.last_indexed or "Never"))
-                    table.add_row("Pending Changes", str(stats.pending_changes))
-                    table.add_row("Vector Store Notes", str(vs_stats.get("total_notes", 0)))
+                    table.add_row("Indexed Documents", str(stats["indexed"]))
+                    table.add_row("Index Version", str(stats["version"]))
+                    table.add_row("Index File", str(stats["index_path"]))
+                    table.add_row("Index Exists", "Yes" if stats["index_exists"] else "No")
                     console.print(table)
 
-                    if stats.errors:
-                        console.print("\n[yellow]Recent Errors:[/yellow]")
-                        for err in stats.errors[-5:]:
-                            console.print(f"  - {err}")
+            else:
+                vector_store = get_vector_store()
+                indexer = Indexer(config, vector_store)
 
-            elif action == "rebuild":
-                console.print("[yellow]Rebuilding index...[/yellow]")
-                count = indexer.index_all()
+                if action == "status":
+                    stats = indexer.get_stats()
+                    vs_stats = vector_store.get_stats()
 
-                result = {
-                    "success": True,
-                    "indexed": count,
-                }
+                    result = {
+                        "total_indexed": stats.total_indexed,
+                        "last_indexed": (
+                            stats.last_indexed.isoformat() if stats.last_indexed else None
+                        ),
+                        "pending_changes": stats.pending_changes,
+                        "vector_store": vs_stats,
+                    }
 
-                if output_format == "json":
-                    print(output_json(result))
-                else:
-                    console.print(f"[green]✓[/green] Indexed {count} notes")
-
-            elif action == "verify":
-                verification = indexer.verify_index()
-
-                result = verification
-
-                if output_format == "json":
-                    print(output_json(result))
-                else:
-                    if verification["healthy"]:
-                        console.print("[green]✓[/green] Index is healthy")
+                    if output_format == "json":
+                        print(output_json(result))
                     else:
-                        console.print("[yellow]⚠[/yellow] Index has issues")
+                        table = Table(title="Index Status")
+                        table.add_column("Property", style="cyan")
+                        table.add_column("Value", style="green")
+                        table.add_row("Total Indexed", str(stats.total_indexed))
+                        table.add_row("Last Indexed", str(stats.last_indexed or "Never"))
+                        table.add_row("Pending Changes", str(stats.pending_changes))
+                        table.add_row("Vector Store Notes", str(vs_stats.get("total_notes", 0)))
+                        console.print(table)
 
-                    console.print(f"  Files: {verification['total_files']}")
-                    console.print(f"  Indexed: {verification['total_indexed']}")
+                        if stats.errors:
+                            console.print("\n[yellow]Recent Errors:[/yellow]")
+                            for err in stats.errors[-5:]:
+                                console.print(f"  - {err}")
 
-                    if verification["missing_from_index"]:
-                        console.print(
-                            f"\n[yellow]Missing from index ({len(verification['missing_from_index'])}):[/yellow]"
-                        )
-                    for nid in verification["missing_from_index"][:5]:
-                        console.print(f"  - {nid}")
+                elif action == "rebuild":
+                    console.print("[yellow]Rebuilding index...[/yellow]")
+                    count = indexer.index_all()
 
-                    if verification["orphaned_in_index"]:
-                        console.print(
-                            f"\n[yellow]Orphaned in index ({len(verification['orphaned_in_index'])}):[/yellow]"
-                        )
-                        for nid in verification["orphaned_in_index"][:5]:
+                    result = {
+                        "success": True,
+                        "indexed": count,
+                    }
+
+                    if output_format == "json":
+                        print(output_json(result))
+                    else:
+                        console.print(f"[green]✓[/green] Indexed {count} notes")
+
+                elif action == "verify":
+                    verification = indexer.verify_index()
+
+                    result = verification
+
+                    if output_format == "json":
+                        print(output_json(result))
+                    else:
+                        if verification["healthy"]:
+                            console.print("[green]✓[/green] Index is healthy")
+                        else:
+                            console.print("[yellow]⚠[/yellow] Index has issues")
+
+                        console.print(f"  Files: {verification['total_files']}")
+                        console.print(f"  Indexed: {verification['total_indexed']}")
+
+                        if verification["missing_from_index"]:
+                            console.print(
+                                f"\n[yellow]Missing from index "
+                                f"({len(verification['missing_from_index'])}):[/yellow]"
+                            )
+                        for nid in verification["missing_from_index"][:5]:
                             console.print(f"  - {nid}")
 
-            else:
-                console.print(
-                    f"[red]Unknown action: {action}. Use: status, rebuild, verify, rebuild-bm25, bm25-status[/red]"
-                )
-                raise typer.Exit(1)
+                        if verification["orphaned_in_index"]:
+                            console.print(
+                                f"\n[yellow]Orphaned in index "
+                                f"({len(verification['orphaned_in_index'])}):[/yellow]"
+                            )
+                            for nid in verification["orphaned_in_index"][:5]:
+                                console.print(f"  - {nid}")
+
+                else:
+                    console.print(
+                        f"[red]Unknown action: {action}. "
+                        "Use: status, rebuild, verify, rebuild-bm25, bm25-status[/red]"
+                    )
+                    raise typer.Exit(1)
 
     except Exception as e:
         result = {"success": False, "error": str(e)}

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -1585,6 +1585,140 @@ def inbox(
         raise typer.Exit(1)
 
 
+def _index_impl(action: str, output_format: str):
+    """索引管理实现：查看状态、重建索引、验证完整性"""
+    if action == "rebuild-bm25":
+        # 重建 BM25 索引
+        from . import note as note_module
+        from .bm25_index import get_bm25_index
+
+        console.print("[yellow]Rebuilding BM25 index...[/yellow]")
+        bm25_index = get_bm25_index()
+        notes = note_module.list_notes(limit=10000)
+        success = bm25_index.rebuild_from_notes(notes)
+
+        result = {
+            "success": success,
+            "indexed": len(notes),
+        }
+
+        if output_format == "json":
+            print(output_json(result))
+        else:
+            if success:
+                console.print(f"[green]✓[/green] BM25 index rebuilt: {len(notes)} notes")
+            else:
+                console.print("[red]✗[/red] Failed to rebuild BM25 index")
+
+    elif action == "bm25-status":
+        # 查看 BM25 索引状态
+        from .bm25_index import get_bm25_index
+
+        bm25_index = get_bm25_index()
+        stats = bm25_index.get_stats()
+
+        result = {
+            "bm25_index": stats,
+        }
+
+        if output_format == "json":
+            print(output_json(result))
+        else:
+            table = Table(title="BM25 Index Status")
+            table.add_column("Property", style="cyan")
+            table.add_column("Value", style="green")
+            table.add_row("Indexed Documents", str(stats["indexed"]))
+            table.add_row("Index Version", str(stats["version"]))
+            table.add_row("Index File", str(stats["index_path"]))
+            table.add_row("Index Exists", "Yes" if stats["index_exists"] else "No")
+            console.print(table)
+
+    else:
+        vector_store = get_vector_store()
+        indexer = Indexer(config, vector_store)
+
+        if action == "status":
+            stats = indexer.get_stats()
+            vs_stats = vector_store.get_stats()
+
+            result = {
+                "total_indexed": stats.total_indexed,
+                "last_indexed": (stats.last_indexed.isoformat() if stats.last_indexed else None),
+                "pending_changes": stats.pending_changes,
+                "vector_store": vs_stats,
+            }
+
+            if output_format == "json":
+                print(output_json(result))
+            else:
+                table = Table(title="Index Status")
+                table.add_column("Property", style="cyan")
+                table.add_column("Value", style="green")
+                table.add_row("Total Indexed", str(stats.total_indexed))
+                table.add_row("Last Indexed", str(stats.last_indexed or "Never"))
+                table.add_row("Pending Changes", str(stats.pending_changes))
+                table.add_row("Vector Store Notes", str(vs_stats.get("total_notes", 0)))
+                console.print(table)
+
+                if stats.errors:
+                    console.print("\n[yellow]Recent Errors:[/yellow]")
+                    for err in stats.errors[-5:]:
+                        console.print(f"  - {err}")
+
+        elif action == "rebuild":
+            console.print("[yellow]Rebuilding index...[/yellow]")
+            count = indexer.index_all()
+
+            result = {
+                "success": True,
+                "indexed": count,
+            }
+
+            if output_format == "json":
+                print(output_json(result))
+            else:
+                console.print(f"[green]✓[/green] Indexed {count} notes")
+
+        elif action == "verify":
+            verification = indexer.verify_index()
+
+            result = verification
+
+            if output_format == "json":
+                print(output_json(result))
+            else:
+                if verification["healthy"]:
+                    console.print("[green]✓[/green] Index is healthy")
+                else:
+                    console.print("[yellow]⚠[/yellow] Index has issues")
+
+                console.print(f"  Files: {verification['total_files']}")
+                console.print(f"  Indexed: {verification['total_indexed']}")
+
+                if verification["missing_from_index"]:
+                    console.print(
+                        f"\n[yellow]Missing from index "
+                        f"({len(verification['missing_from_index'])}):[/yellow]"
+                    )
+                for nid in verification["missing_from_index"][:5]:
+                    console.print(f"  - {nid}")
+
+                if verification["orphaned_in_index"]:
+                    console.print(
+                        f"\n[yellow]Orphaned in index "
+                        f"({len(verification['orphaned_in_index'])}):[/yellow]"
+                    )
+                    for nid in verification["orphaned_in_index"][:5]:
+                        console.print(f"  - {nid}")
+
+        else:
+            console.print(
+                f"[red]Unknown action: {action}. "
+                "Use: status, rebuild, verify, rebuild-bm25, bm25-status[/red]"
+            )
+            raise typer.Exit(1)
+
+
 @app.command()
 def index(
     action: str = typer.Argument(
@@ -1598,146 +1732,21 @@ def index(
 ):
     """索引管理：查看状态、重建索引、验证完整性"""
     try:
-        from .config import use_kb
+        # 处理 --json 快捷方式
+        if json_output:
+            output_format = "json"
 
-        with use_kb(kb):
-            # 处理 --json 快捷方式
-            if json_output:
-                output_format = "json"
+        # 如果指定了知识库，临时切换
+        if kb:
+            from .config import use_kb
 
-            if action == "rebuild-bm25":
-                # 重建 BM25 索引
-                from . import note as note_module
-                from .bm25_index import get_bm25_index
+            with use_kb(kb):
+                _index_impl(action, output_format)
+        else:
+            _index_impl(action, output_format)
 
-                console.print("[yellow]Rebuilding BM25 index...[/yellow]")
-                bm25_index = get_bm25_index()
-                notes = note_module.list_notes(limit=10000)
-                success = bm25_index.rebuild_from_notes(notes)
-
-                result = {
-                    "success": success,
-                    "indexed": len(notes),
-                }
-
-                if output_format == "json":
-                    print(output_json(result))
-                else:
-                    if success:
-                        console.print(f"[green]✓[/green] BM25 index rebuilt: {len(notes)} notes")
-                    else:
-                        console.print("[red]✗[/red] Failed to rebuild BM25 index")
-
-            elif action == "bm25-status":
-                # 查看 BM25 索引状态
-                from .bm25_index import get_bm25_index
-
-                bm25_index = get_bm25_index()
-                stats = bm25_index.get_stats()
-
-                result = {
-                    "bm25_index": stats,
-                }
-
-                if output_format == "json":
-                    print(output_json(result))
-                else:
-                    table = Table(title="BM25 Index Status")
-                    table.add_column("Property", style="cyan")
-                    table.add_column("Value", style="green")
-                    table.add_row("Indexed Documents", str(stats["indexed"]))
-                    table.add_row("Index Version", str(stats["version"]))
-                    table.add_row("Index File", str(stats["index_path"]))
-                    table.add_row("Index Exists", "Yes" if stats["index_exists"] else "No")
-                    console.print(table)
-
-            else:
-                vector_store = get_vector_store()
-                indexer = Indexer(config, vector_store)
-
-                if action == "status":
-                    stats = indexer.get_stats()
-                    vs_stats = vector_store.get_stats()
-
-                    result = {
-                        "total_indexed": stats.total_indexed,
-                        "last_indexed": (
-                            stats.last_indexed.isoformat() if stats.last_indexed else None
-                        ),
-                        "pending_changes": stats.pending_changes,
-                        "vector_store": vs_stats,
-                    }
-
-                    if output_format == "json":
-                        print(output_json(result))
-                    else:
-                        table = Table(title="Index Status")
-                        table.add_column("Property", style="cyan")
-                        table.add_column("Value", style="green")
-                        table.add_row("Total Indexed", str(stats.total_indexed))
-                        table.add_row("Last Indexed", str(stats.last_indexed or "Never"))
-                        table.add_row("Pending Changes", str(stats.pending_changes))
-                        table.add_row("Vector Store Notes", str(vs_stats.get("total_notes", 0)))
-                        console.print(table)
-
-                        if stats.errors:
-                            console.print("\n[yellow]Recent Errors:[/yellow]")
-                            for err in stats.errors[-5:]:
-                                console.print(f"  - {err}")
-
-                elif action == "rebuild":
-                    console.print("[yellow]Rebuilding index...[/yellow]")
-                    count = indexer.index_all()
-
-                    result = {
-                        "success": True,
-                        "indexed": count,
-                    }
-
-                    if output_format == "json":
-                        print(output_json(result))
-                    else:
-                        console.print(f"[green]✓[/green] Indexed {count} notes")
-
-                elif action == "verify":
-                    verification = indexer.verify_index()
-
-                    result = verification
-
-                    if output_format == "json":
-                        print(output_json(result))
-                    else:
-                        if verification["healthy"]:
-                            console.print("[green]✓[/green] Index is healthy")
-                        else:
-                            console.print("[yellow]⚠[/yellow] Index has issues")
-
-                        console.print(f"  Files: {verification['total_files']}")
-                        console.print(f"  Indexed: {verification['total_indexed']}")
-
-                        if verification["missing_from_index"]:
-                            console.print(
-                                f"\n[yellow]Missing from index "
-                                f"({len(verification['missing_from_index'])}):[/yellow]"
-                            )
-                        for nid in verification["missing_from_index"][:5]:
-                            console.print(f"  - {nid}")
-
-                        if verification["orphaned_in_index"]:
-                            console.print(
-                                f"\n[yellow]Orphaned in index "
-                                f"({len(verification['orphaned_in_index'])}):[/yellow]"
-                            )
-                            for nid in verification["orphaned_in_index"][:5]:
-                                console.print(f"  - {nid}")
-
-                else:
-                    console.print(
-                        f"[red]Unknown action: {action}. "
-                        "Use: status, rebuild, verify, rebuild-bm25, bm25-status[/red]"
-                    )
-                    raise typer.Exit(1)
-
+    except typer.Exit:
+        raise
     except Exception as e:
         result = {"success": False, "error": str(e)}
         if json_output:

--- a/tests/unit/test_index_kb_param.py
+++ b/tests/unit/test_index_kb_param.py
@@ -1,0 +1,92 @@
+"""Tests for jfox index --kb parameter support (issue #104)"""
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from jfox.cli import app
+
+runner = CliRunner()
+
+
+class TestIndexKbParamErrors:
+    """验证 --kb 参数错误处理"""
+
+    def test_status_with_nonexistent_kb_returns_error(self):
+        """--kb 指向不存在的知识库时应报错"""
+        result = runner.invoke(app, ["index", "status", "--kb", "nonexistent_kb_104"])
+        assert result.exit_code != 0
+        output_lower = result.output.lower()
+        assert "nonexistent_kb_104" in output_lower or "not found" in output_lower
+
+    def test_verify_with_nonexistent_kb_returns_error(self):
+        """index verify --kb <不存在的知识库> 应报错"""
+        result = runner.invoke(app, ["index", "verify", "--kb", "nonexistent_kb_104"])
+        assert result.exit_code != 0
+        output_lower = result.output.lower()
+        assert "nonexistent_kb_104" in output_lower or "not found" in output_lower
+
+    def test_rebuild_with_nonexistent_kb_returns_error(self):
+        """index rebuild --kb <不存在的知识库> 应报错"""
+        result = runner.invoke(app, ["index", "rebuild", "--kb", "nonexistent_kb_104"])
+        assert result.exit_code != 0
+        output_lower = result.output.lower()
+        assert "nonexistent_kb_104" in output_lower or "not found" in output_lower
+
+    def test_rebuild_bm25_with_nonexistent_kb_returns_error(self):
+        """index rebuild-bm25 --kb <不存在的知识库> 应报错"""
+        result = runner.invoke(app, ["index", "rebuild-bm25", "--kb", "nonexistent_kb_104"])
+        assert result.exit_code != 0
+        output_lower = result.output.lower()
+        assert "nonexistent_kb_104" in output_lower or "not found" in output_lower
+
+    def test_bm25_status_with_nonexistent_kb_returns_error(self):
+        """index bm25-status --kb <不存在的知识库> 应报错"""
+        result = runner.invoke(app, ["index", "bm25-status", "--kb", "nonexistent_kb_104"])
+        assert result.exit_code != 0
+        output_lower = result.output.lower()
+        assert "nonexistent_kb_104" in output_lower or "not found" in output_lower
+
+
+@pytest.mark.embedding
+class TestIndexKbParamSuccess:
+    """验证 --kb 参数正常功能"""
+
+    @staticmethod
+    def _reset_global_config_cache():
+        """清除全局配置缓存，使 subprocess 注册的 KB 可被 runner.invoke 看到。
+
+        cli fixture 通过 subprocess 调用 jfox init 注册 KB，但 runner.invoke
+        在同一进程内运行，GlobalConfigManager 的缓存可能不包含新注册的 KB。
+        需要同时清除 kb_manager 和 global_config_manager 的缓存实例。
+        """
+        from jfox import global_config as gc
+        from jfox import kb_manager as km
+
+        km._kb_manager = None
+        if gc._global_config_manager is not None:
+            gc._global_config_manager._config = None
+        gc._global_config_manager = None
+
+    def test_status_with_valid_kb(self, cli):
+        """index status --kb <存在的知识库> 应正常执行"""
+        self._reset_global_config_cache()
+        result = runner.invoke(app, ["index", "status", "--kb", cli.kb_name, "--json"])
+        assert result.exit_code == 0, f"Expected success but got: {result.output}"
+        data = json.loads(result.output.strip())
+        assert "total_indexed" in data
+
+    def test_verify_with_valid_kb(self, cli):
+        """index verify --kb <存在的知识库> 应正常执行"""
+        self._reset_global_config_cache()
+        result = runner.invoke(app, ["index", "verify", "--kb", cli.kb_name, "--json"])
+        assert result.exit_code == 0, f"Expected success but got: {result.output}"
+        data = json.loads(result.output.strip())
+        assert "healthy" in data
+
+    def test_default_kb_not_affected(self, cli):
+        """不传 --kb 时行为与修改前一致"""
+        self._reset_global_config_cache()
+        result = runner.invoke(app, ["index", "status", "--json"])
+        assert result.exit_code == 0

--- a/tests/unit/test_index_kb_param.py
+++ b/tests/unit/test_index_kb_param.py
@@ -1,4 +1,4 @@
-"""Tests for jfox index --kb parameter support (issue #104)"""
+"""jfox index --kb 参数支持测试（issue #104）"""
 
 import json
 


### PR DESCRIPTION
## Summary
- Add `--kb` parameter to `jfox index` command for all sub-actions (status, rebuild, verify, rebuild-bm25, bm25-status)
- Uses `use_kb(kb)` context manager — same pattern as ~10 other commands (add, list, search, edit, delete, etc.)
- `use_kb(None)` is a no-op, so backward compatibility is preserved

## Test plan
- [x] 5 error-path tests: nonexistent KB → "not found" error for all sub-actions
- [x] 2 success-path tests: valid KB works for `status` and `verify`
- [x] 1 backward-compat test: no `--kb` still works
- [x] 190 existing unit tests pass, no regressions
- [ ] Manual: `jfox index status --kb <name>` / `jfox index rebuild --kb <name>` / `jfox index verify --kb <name>`

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)