### PR TITLE
fix: add 'use' as alias for 'kb switch' subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ jfox init --name personal --path ~/my-notes --desc "个人笔记"
 jfox kb list
 
 # 切换默认知识库
-jfox kb switch work
+jfox kb use work
 
 # 查看知识库详情
 jfox kb info work
@@ -170,7 +170,7 @@ jfox query "卢曼的方法论"
 | `jfox init` | 初始化知识库 | `jfox init --name work --desc "工作笔记"` |
 | `jfox kb list` | 列出所有知识库 | `jfox kb list` |
 | `jfox kb create <name>` | 创建知识库 | `jfox kb create work --desc "工作笔记"` |
-| `jfox kb switch <name>` | 切换默认知识库 | `jfox kb switch work` |
+| `jfox kb use <name>` | 切换默认知识库 | `jfox kb use work` |
 | `jfox kb info [name]` | 查看知识库详情 | `jfox kb info work` |
 | `jfox kb rename <old> <new>` | 重命名知识库 | `jfox kb rename work job` |
 | `jfox kb remove <name>` | 删除知识库 | `jfox kb remove temp --force` |
@@ -284,7 +284,7 @@ $ jfox kb list
 
 ```bash
 # 切换到 work 知识库
-jfox kb switch work
+jfox kb use work
 
 # 之后的所有操作都在 work 知识库上进行
 jfox add "新项目想法" --title "项目A"

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -1764,7 +1764,7 @@ def index(
 @app.command()
 def kb(
     action: str = typer.Argument(
-        "list", help="操作: list, create, switch, remove, info, current, rename"
+        "list", help="操作: list, create, switch/use, remove, info, current, rename"
     ),
     name: Optional[str] = typer.Argument(None, help="知识库名称"),
     new_name: Optional[str] = typer.Argument(None, help="新名称（仅 rename 使用）"),
@@ -1786,7 +1786,7 @@ def kb(
         jfox kb list                    # 列出所有知识库
         jfox kb create work             # 创建名为 work 的知识库（~/.zettelkasten/work/）
         jfox kb create work --desc "工作笔记"
-        jfox kb switch work             # 切换到 work 知识库
+        jfox kb use work                # 切换到 work 知识库（或 jfox kb switch work）
         jfox kb current                 # 显示当前知识库
         jfox kb info work               # 查看 work 知识库详情
         jfox kb remove temp --force     # 强制删除 temp 知识库
@@ -1927,9 +1927,9 @@ def kb(
                     console.print(f"[red]✗[/red] {message}")
                     raise typer.Exit(1)
 
-        elif action == "switch":
+        elif action in ("switch", "use"):
             if not name:
-                console.print("[red]Error: name is required for switch[/red]")
+                console.print("[red]Error: name is required for switch/use[/red]")
                 raise typer.Exit(1)
 
             success, message = manager.switch(name)
@@ -2103,7 +2103,9 @@ def kb(
 
         else:
             console.print(f"[red]Unknown action: {action}[/red]")
-            console.print("Available actions: list, create, switch, remove, info, current, rename")
+            console.print(
+                "Available actions: list, create, switch/use, remove, info, current, rename"
+            )
             raise typer.Exit(1)
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- Add `use` as a backward-compatible alias for `switch` in `jfox kb` subcommand
- Update help text, error messages, and docstring to show `switch/use`
- Update README.md examples to prefer `jfox kb use work` over `jfox kb switch work`

## Test plan
- [ ] Verify `jfox kb use work` works correctly
- [ ] Verify `jfox kb switch work` still works (backward compat)
- [ ] Verify `jfox kb --help` shows `switch/use` in actions list
- [ ] Verify `jfox kb use` without name shows proper error

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)