### PR TITLE
chore: bump version to 0.1.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,10 @@ Four jobs in `.github/workflows/integration-test.yml`:
 - Set `PYTHONUTF8=1` and `chcp 65001` for encoding
 - HuggingFace mirror for China: `export HF_ENDPOINT=https://hf-mirror.com`
 
+## Branch Rules
+
+- **main 是保护分支**，不能直接 commit 或 push。所有改动必须通过新分支 + PR 合入。
+
 ## Gotchas
 
 - `pytest.ini` `addopts` includes `-v`, so `pytest tests/` already runs verbose — adding `-v` manually is redundant

--- a/jfox/__init__.py
+++ b/jfox/__init__.py
@@ -1,5 +1,5 @@
 """JFox - Zettelkasten 知识管理工具"""
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 __author__ = "User"
 __email__ = "user@example.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jfox-cli"
-version = "0.1.4"
+version = "0.1.5"
 description = "JFox - Zettelkasten 知识管理 CLI 工具"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- Bump version from 0.1.4 to 0.1.5 in `pyproject.toml` and `jfox/__init__.py`
- Document that main is a protected branch in CLAUDE.md

Includes fixes since v0.1.4:
- `--kb` parameter for index command (#113)
- index verify false positive fix (#111)
- index rebuild clears ChromaDB before re-indexing (#110)

## Test plan
- [ ] Verify `jfox --version` returns 0.1.5 after install
- [ ] Verify `jfox index rebuild --kb <name>` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)