### PR TITLE
feat(edit): add --content-file parameter for long text input (#106)

### DIFF
--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -962,6 +962,7 @@ def delete(
 def _edit_impl(
     note_id: str,
     content: Optional[str],
+    content_file: Optional[str],
     title: Optional[str],
     tags: Optional[List[str]],
     note_type: Optional[str],
@@ -969,9 +970,30 @@ def _edit_impl(
     output_format: str,
 ):
     """编辑笔记的内部实现"""
+    # 验证：--content 和 --content-file 互斥
+    if content is not None and content_file is not None:
+        raise ValueError("--content 和 --content-file 不能同时指定")
+
+    # 从文件读取内容
+    if content_file is not None:
+        p = Path(content_file)
+        if not p.exists():
+            raise ValueError(f"文件不存在: {content_file}")
+        if not p.is_file():
+            raise ValueError(f"路径不是文件: {content_file}")
+        try:
+            content = p.read_text(encoding="utf-8")
+        except PermissionError:
+            raise ValueError(f"无权限读取文件: {content_file}")
+        except UnicodeDecodeError:
+            raise ValueError(f"文件编码错误（需要 UTF-8）: {content_file}")
+
     # 验证：至少指定一个编辑字段
     if all(v is None for v in [content, title, tags, note_type, source]):
-        raise ValueError("至少指定一个要编辑的字段 (--content, --title, --tags, --type, --source)")
+        raise ValueError(
+            "至少指定一个要编辑的字段 "
+            "(--content, --content-file, --title, --tags, --type, --source)"
+        )
 
     # 加载笔记
     n = note.load_note_by_id(note_id)
@@ -1089,6 +1111,9 @@ def _edit_impl(
 def edit(
     note_id: str = typer.Argument(..., help="笔记 ID"),
     content: Optional[str] = typer.Option(None, "--content", "-c", help="新内容"),
+    content_file: Optional[str] = typer.Option(
+        None, "--content-file", help="从文件读取内容（支持长文本和特殊字符）"
+    ),
     title: Optional[str] = typer.Option(None, "--title", "-t", help="新标题"),
     tags: Optional[List[str]] = typer.Option(None, "--tag", help="新标签（替换全部）"),
     note_type: Optional[str] = typer.Option(
@@ -1111,9 +1136,13 @@ def edit(
             from .config import use_kb
 
             with use_kb(kb):
-                _edit_impl(note_id, content, title, tags, note_type, source, output_format)
+                _edit_impl(
+                    note_id, content, content_file, title, tags, note_type, source, output_format
+                )
         else:
-            _edit_impl(note_id, content, title, tags, note_type, source, output_format)
+            _edit_impl(
+                note_id, content, content_file, title, tags, note_type, source, output_format
+            )
     except typer.Exit:
         raise
     except Exception as e:

--- a/tests/unit/test_edit.py
+++ b/tests/unit/test_edit.py
@@ -143,6 +143,7 @@ class TestEditImpl:
         _edit_impl(
             note_id=n.id,
             content="updated content",
+            content_file=None,
             title=None,
             tags=None,
             note_type=None,
@@ -172,6 +173,7 @@ class TestEditImpl:
         _edit_impl(
             note_id=n.id,
             content=None,
+            content_file=None,
             title="NewTitle",
             tags=None,
             note_type=None,
@@ -199,6 +201,7 @@ class TestEditImpl:
         _edit_impl(
             note_id=n.id,
             content="new content",
+            content_file=None,
             title="New Title",
             tags=["x", "y"],
             note_type="permanent",
@@ -228,6 +231,7 @@ class TestEditImpl:
             _edit_impl(
                 note_id="9999999999999999",
                 content="x",
+                content_file=None,
                 title=None,
                 tags=None,
                 note_type=None,
@@ -252,6 +256,7 @@ class TestEditImpl:
             _edit_impl(
                 note_id=n.id,
                 content=None,
+                content_file=None,
                 title=None,
                 tags=None,
                 note_type=None,
@@ -281,6 +286,7 @@ class TestEditImpl:
         _edit_impl(
             note_id=source.id,
             content="see [[TargetNote]] for details",
+            content_file=None,
             title=None,
             tags=None,
             note_type=None,
@@ -330,6 +336,7 @@ class TestEditImpl:
         _edit_impl(
             note_id=source.id,
             content="no more links here",
+            content_file=None,
             title=None,
             tags=None,
             note_type=None,
@@ -368,6 +375,7 @@ class TestEditImpl:
         _edit_impl(
             note_id=n.id,
             content=None,
+            content_file=None,
             title=None,
             tags=None,
             note_type="permanent",
@@ -384,3 +392,160 @@ class TestEditImpl:
         assert loaded.type == NoteType.PERMANENT
         assert "permanent" in str(loaded.filepath)
         assert loaded.filepath.exists()
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_edit_content_file_reads_content(self, mock_global_config, mock_note_config, tmp_path):
+        """通过 --content-file 编辑笔记内容"""
+        from jfox.cli import _edit_impl
+
+        cfg = self._make_config(tmp_path)
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        # 创建笔记
+        n = create_note("original", title="FileEdit", note_type=NoteType.PERMANENT)
+        save_note(n, add_to_index=False)
+
+        # 写入临时文件
+        content_file = tmp_path / "content.txt"
+        content_file.write_text("content from file", encoding="utf-8")
+
+        _edit_impl(
+            note_id=n.id,
+            content=None,
+            content_file=str(content_file),
+            title=None,
+            tags=None,
+            note_type=None,
+            source=None,
+            output_format="json",
+        )
+
+        loaded = load_note_by_id(n.id, cfg=cfg)
+        assert loaded is not None
+        assert loaded.content == "content from file"
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_edit_content_file_not_exists_raises(
+        self, mock_global_config, mock_note_config, tmp_path
+    ):
+        """--content-file 指向不存在的文件时报错"""
+        from jfox.cli import _edit_impl
+
+        cfg = self._make_config(tmp_path)
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        n = create_note("content", title="NoFile", note_type=NoteType.PERMANENT)
+        save_note(n, add_to_index=False)
+
+        with pytest.raises(ValueError, match="文件不存在"):
+            _edit_impl(
+                note_id=n.id,
+                content=None,
+                content_file=str(tmp_path / "nonexistent.txt"),
+                title=None,
+                tags=None,
+                note_type=None,
+                source=None,
+                output_format="json",
+            )
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_edit_content_and_content_file_exclusive(
+        self, mock_global_config, mock_note_config, tmp_path
+    ):
+        """--content 和 --content-file 不能同时指定"""
+        from jfox.cli import _edit_impl
+
+        cfg = self._make_config(tmp_path)
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        n = create_note("content", title="Exclusive", note_type=NoteType.PERMANENT)
+        save_note(n, add_to_index=False)
+
+        content_file = tmp_path / "content.txt"
+        content_file.write_text("from file", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="不能同时指定"):
+            _edit_impl(
+                note_id=n.id,
+                content="from arg",
+                content_file=str(content_file),
+                title=None,
+                tags=None,
+                note_type=None,
+                source=None,
+                output_format="json",
+            )
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_edit_content_file_with_special_chars(
+        self, mock_global_config, mock_note_config, tmp_path
+    ):
+        """--content-file 正确处理反引号、换行、特殊字符"""
+        from jfox.cli import _edit_impl
+
+        cfg = self._make_config(tmp_path)
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        n = create_note("original", title="SpecialChars", note_type=NoteType.PERMANENT)
+        save_note(n, add_to_index=False)
+
+        special_content = (
+            "包含 `jfox rebuild` 命令\n" '还有 $variable 和 "引号"\n' "以及 [[WikiLink]]"
+        )
+        content_file = tmp_path / "special.txt"
+        content_file.write_text(special_content, encoding="utf-8")
+
+        _edit_impl(
+            note_id=n.id,
+            content=None,
+            content_file=str(content_file),
+            title=None,
+            tags=None,
+            note_type=None,
+            source=None,
+            output_format="json",
+        )
+
+        loaded = load_note_by_id(n.id, cfg=cfg)
+        assert loaded is not None
+        assert loaded.content == special_content
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_edit_content_file_empty(self, mock_global_config, mock_note_config, tmp_path):
+        """--content-file 空文件将内容清空"""
+        from jfox.cli import _edit_impl
+
+        cfg = self._make_config(tmp_path)
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        n = create_note("has content", title="EmptyFile", note_type=NoteType.PERMANENT)
+        save_note(n, add_to_index=False)
+
+        content_file = tmp_path / "empty.txt"
+        content_file.write_text("", encoding="utf-8")
+
+        _edit_impl(
+            note_id=n.id,
+            content=None,
+            content_file=str(content_file),
+            title=None,
+            tags=None,
+            note_type=None,
+            source=None,
+            output_format="json",
+        )
+
+        loaded = load_note_by_id(n.id, cfg=cfg)
+        assert loaded is not None
+        assert loaded.content == ""

--- a/tests/unit/test_format_unify.py
+++ b/tests/unit/test_format_unify.py
@@ -227,6 +227,7 @@ class TestEditFormat:
         _edit_impl(
             note_id=n.id,
             content="updated",
+            content_file=None,
             title=None,
             tags=None,
             note_type=None,
@@ -259,6 +260,7 @@ class TestEditFormat:
         _edit_impl(
             note_id=n.id,
             content="new content",
+            content_file=None,
             title="NewTitle",
             tags=None,
             note_type=None,

--- a/tests/utils/jfox_cli.py
+++ b/tests/utils/jfox_cli.py
@@ -237,6 +237,7 @@ class ZKCLI:
         self,
         note_id: str,
         content: Optional[str] = None,
+        content_file: Optional[str] = None,
         title: Optional[str] = None,
         tags: Optional[List[str]] = None,
         note_type: Optional[str] = None,
@@ -248,6 +249,7 @@ class ZKCLI:
         Args:
             note_id: 笔记 ID
             content: 新内容
+            content_file: 从文件读取内容
             title: 新标题
             tags: 新标签列表（替换全部）
             note_type: 新类型 (fleeting/literature/permanent)
@@ -256,6 +258,8 @@ class ZKCLI:
         args = [note_id]
         if content:
             args.extend(["--content", content])
+        if content_file:
+            args.extend(["--content-file", content_file])
         if title:
             args.extend(["--title", title])
         if tags:


### PR DESCRIPTION
## Summary
- Add `--content-file` option to `jfox edit` command, allowing users to pass note content via file instead of `--content`
- Mutual exclusion between `--content` and `--content-file` with clear error message
- Friendly Chinese error messages for file-not-found, permission errors, encoding issues, and directory paths

## Test plan
- [x] 5 new unit tests covering: file read, missing file, mutual exclusion, special characters, empty file
- [x] All 29 existing edit-related tests still pass
- [x] ruff lint + black format clean

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)