### PR TITLE
perf: optimize CI coverage job to avoid rerunning tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -88,6 +88,7 @@ jobs:
       run: uv sync --extra dev
 
     - name: Run fast tests (no embedding)
+      shell: bash
       run: |
         # 运行非 embedding 测试（单进程避免知识库冲突）
         ARGS="-m 'not embedding and not slow' --timeout=180 -v --tb=short"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -90,7 +90,12 @@ jobs:
     - name: Run fast tests (no embedding)
       run: |
         # 运行非 embedding 测试（单进程避免知识库冲突）
-        uv run pytest tests/ -m "not embedding and not slow" --timeout=180 -v --tb=short
+        ARGS="-m 'not embedding and not slow' --timeout=180 -v --tb=short"
+        if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+          eval uv run pytest tests/ $ARGS --cov=jfox --cov-report=xml
+        else
+          eval uv run pytest tests/ $ARGS
+        fi
       timeout-minutes: ${{ matrix.os == 'windows-latest' && 50 || 20 }}
       env:
         PYTHONIOENCODING: utf-8
@@ -104,6 +109,14 @@ jobs:
         path: |
           .pytest_cache/
           htmlcov/
+
+    - name: Upload coverage data
+      if: matrix.os == 'ubuntu-latest'
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-data
+        path: coverage.xml
+        retention-days: 1
 
   # ============ 核心测试（带 embedding，但只跑核心）============
   test-core:
@@ -239,33 +252,22 @@ jobs:
           exit 1
         fi
 
-  # ============ 覆盖率报告（仅 fast 测试通过后）============
+  # ============ 覆盖率报告（解析 test-fast 的 coverage artifact）============
   coverage:
     runs-on: ubuntu-latest
     needs: [test-fast]
     if: always() && needs.test-fast.result == 'success'
+    permissions:
+      pull-requests: write
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - name: Download coverage data
+      uses: actions/download-artifact@v4
       with:
-        python-version: '3.11'
-
-    - uses: astral-sh/setup-uv@v4
-      with:
-        version: "latest"
-        enable-cache: true
-
-    - name: Install dependencies
-      run: uv sync --extra dev
-
-    - name: Run coverage
-      run: |
-        uv run pytest tests/ -m "not embedding and not slow" --cov=jfox --cov-report=xml --cov-report=html --cov-report=term -v --timeout=300
-      timeout-minutes: 25
+        name: coverage-data
 
     - name: Post coverage comment on PR
       if: github.event_name == 'pull_request'
@@ -304,6 +306,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: coverage-report
-        path: |
-          htmlcov/
-          coverage.xml
+        path: coverage.xml


### PR DESCRIPTION
## Summary
- test-fast (ubuntu) 现在直接生成 `coverage.xml` 并上传为 artifact
- coverage job 简化为下载 artifact + 解析评论，不再重跑 pytest
- 添加 `permissions: pull-requests: write` 修复 PR coverage 评论权限问题

## 预期效果
- CI 总时间：~35min → ~19min（瓶颈为 windows test-fast）
- coverage job：~15min → <30s

Fixes #112

## Test plan
- [ ] test-fast (ubuntu) 日志确认 `--cov` 生效且 coverage.xml 生成
- [ ] "Upload coverage data" step 成功上传 coverage-data artifact
- [ ] coverage job 只有 Checkout + Download + Post comment 步骤，无 pytest 运行
- [ ] coverage job 耗时 < 30s
- [ ] PR 成功发布 coverage 评论（无 `Resource not accessible` 错误）
- [ ] 覆盖率百分比与改动前一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)