### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to jfox-cli will be documented in this file.
+
+## [0.2.0] - 2026-04-13
+
+### Features
+- **edit**: add `--content-file` parameter for reading note content from a file (#106)
+
+### Fixes
+- **skill**: add `--kb` parameter support to jfox-health skill
+- **cli**: add `use` as alias for `kb switch` subcommand (#105)
+
+### Changes
+- **skills**: redesign from 5 skills to 4
+- **test**: fix flaky `test_update_content_preserves_id_and_created` (timing race on fast machines)
+
+### Performance
+- **startup**: lazy import optimization to eliminate startup overhead for lightweight commands (#122)
+- **ci**: optimize CI coverage job to avoid rerunning tests (#119)
+
+## [0.1.5] - 2026-04-12
+
+### Fixes
+- **index**: add `--kb` parameter to `jfox index` command (#104) (#113)
+- **index**: fix `index verify` false positives (filename vs index ID format mismatch) (#111)
+- **index**: fix `index rebuild` clearing ChromaDB before re-indexing (#110)
+- **test**: prevent test KB residue in global config (#101)
+- **ci**: resolve Windows path comparison bug and add quality gate
+
+### Changes
+- **style**: auto-fix all ruff/black lint errors (1869 fixed)
+
+[0.2.0]: https://github.com/zhuxixi/jfox/compare/v0.1.5...v0.2.0
+[0.1.5]: https://github.com/zhuxixi/jfox/compare/v0.1.4...v0.1.5

--- a/jfox/__init__.py
+++ b/jfox/__init__.py
@@ -1,5 +1,5 @@
 """JFox - Zettelkasten 知识管理工具"""
 
-__version__ = "0.1.5"
+__version__ = "0.2.0"
 __author__ = "User"
 __email__ = "user@example.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jfox-cli"
-version = "0.1.5"
+version = "0.2.0"
 description = "JFox - Zettelkasten 知识管理 CLI 工具"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/unit/test_edit.py
+++ b/tests/unit/test_edit.py
@@ -5,6 +5,8 @@
 依赖要求: 无外部依赖
 """
 
+import time
+
 import pytest
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
@@ -41,7 +43,8 @@ class TestUpdateNote:
         original_id = n.id
         original_created = n.created
 
-        # 更新内容
+        # 确保更新时间与创建时间不同（避免微秒级竞争）
+        time.sleep(0.001)
         n.content = "updated content"
         updated = update_note(n, add_to_index=False)
 

--- a/uv.lock
+++ b/uv.lock
@@ -851,7 +851,7 @@ wheels = [
 
 [[package]]
 name = "jfox-cli"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },

--- a/uv.lock
+++ b/uv.lock
@@ -851,7 +851,7 @@ wheels = [
 
 [[package]]
 name = "jfox-cli"
-version = "0.1.5"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary
- Version bump from 0.1.5 to 0.2.0 (both `pyproject.toml` and `__init__.py`)
- Add `CHANGELOG.md` documenting all changes since v0.1.5
- Fix flaky test timing race in `test_edit.py`

## Changes included since v0.1.5
- **feat**: `edit --content-file` parameter, `kb switch` alias `use`
- **fix**: health skill `--kb` parameter
- **refactor**: skills redesign 5→4
- **perf**: lazy import startup optimization, CI coverage optimization
- **fix**: flaky `test_update_content_preserves_id_and_created`

## Test plan
- [x] `pytest tests/unit/` passes (17/17 in test_edit.py)
- [ ] Full test suite (run locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)