### PR TITLE
feat: add ingest-log command for git history import

### DIFF
--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -2156,6 +2156,99 @@ def kb(
 
 
 @app.command()
+def ingest_log(
+    repo_path: str = typer.Argument(..., help="本地 Git 仓库路径"),
+    limit: int = typer.Option(50, "--limit", "-n", help="提取 commit 数量"),
+    note_type: str = typer.Option("fleeting", "--type", "-t", help="笔记类型"),
+    batch_size: int = typer.Option(32, "--batch-size", "-b", help="批处理大小"),
+    kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
+    json_output: bool = typer.Option(True, "--json/--no-json", help="JSON 输出"),
+):
+    """
+    从 Git 仓库提取 commit 历史并导入为笔记
+
+    使用 block 分隔符格式提取 git log，自动处理 UTF-8 编码和路径规范化。
+
+    示例:
+        jfox ingest-log ./my-project --limit 50
+        jfox ingest-log ./my-project --kb work --type permanent
+    """
+    try:
+        from .git_extractor import commits_to_notes, extract_commits
+
+        # 提取 commits
+        commits = extract_commits(repo_path, limit=limit)
+
+        if not commits:
+            result = {
+                "success": True,
+                "imported": 0,
+                "total": 0,
+                "message": "没有找到 commit 记录",
+            }
+            if json_output:
+                print(output_json(result))
+            else:
+                console.print("[yellow]![/yellow] 没有找到 commit 记录")
+            return
+
+        # 转换为笔记格式
+        notes_data = commits_to_notes(commits, repo_path=repo_path)
+
+        console.print(f"[yellow]提取了 {len(notes_data)} 条 commit，正在导入...[/yellow]")
+
+        # 批量导入
+        from .performance import bulk_import_notes
+
+        if kb:
+            from .config import use_kb
+
+            with use_kb(kb):
+                import_result = bulk_import_notes(
+                    notes_data=notes_data,
+                    note_type=note_type,
+                    batch_size=batch_size,
+                    show_progress=not json_output,
+                )
+        else:
+            import_result = bulk_import_notes(
+                notes_data=notes_data,
+                note_type=note_type,
+                batch_size=batch_size,
+                show_progress=not json_output,
+            )
+
+        result = {
+            "success": True,
+            "repo_path": str(Path(repo_path).resolve()),
+            "commits_extracted": len(commits),
+            **import_result,
+        }
+
+        if json_output:
+            print(output_json(result))
+        else:
+            console.print(f"[green]✓[/green] 导入: {import_result['imported']}")
+            console.print(f"[red]✗[/red] 失败: {import_result['failed']}")
+            console.print(f"总计: {import_result['total']}")
+
+    except ValueError as e:
+        result = {"success": False, "error": str(e)}
+        if json_output:
+            print(output_json(result))
+        else:
+            console.print(f"[red]✗[/red] {e}")
+        raise typer.Exit(1)
+    except Exception as e:
+        result = {"success": False, "error": str(e)}
+        if json_output:
+            print(output_json(result))
+        else:
+            console.print(f"[red]✗[/red] Error: {e}")
+        raise typer.Exit(1)
+
+
+@app.command()
 def bulk_import(
     file_path: str = typer.Argument(..., help="JSON 文件路径，包含笔记数据"),
     note_type: str = typer.Option("permanent", "--type", "-t", help="笔记类型"),

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -2195,7 +2195,8 @@ def ingest_log(
         # 转换为笔记格式
         notes_data = commits_to_notes(commits, repo_path=repo_path)
 
-        console.print(f"[yellow]提取了 {len(notes_data)} 条 commit，正在导入...[/yellow]")
+        if not json_output:
+            console.print(f"[yellow]提取了 {len(notes_data)} 条 commit，正在导入...[/yellow]")
 
         # 批量导入
         from .performance import bulk_import_notes

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -2155,6 +2155,62 @@ def kb(
 # =============================================================================
 
 
+def _ingest_log_impl(
+    repo_path: str,
+    limit: int,
+    note_type: str,
+    batch_size: int,
+    output_format: str,
+    json_output: bool,
+):
+    """从 Git 仓库提取 commit 历史并导入为笔记"""
+    from .git_extractor import commits_to_notes, extract_commits
+    from .performance import bulk_import_notes
+
+    # 提取 commits
+    commits = extract_commits(repo_path, limit=limit)
+
+    if not commits:
+        result = {
+            "success": True,
+            "imported": 0,
+            "total": 0,
+            "message": "没有找到 commit 记录",
+        }
+        if output_format == "json":
+            print(output_json(result))
+        else:
+            console.print("[yellow]![/yellow] 没有找到 commit 记录")
+        return
+
+    # 转换为笔记格式
+    notes_data = commits_to_notes(commits, repo_path=repo_path)
+
+    if output_format != "json":
+        console.print(f"[yellow]提取了 {len(notes_data)} 条 commit，正在导入...[/yellow]")
+
+    import_result = bulk_import_notes(
+        notes_data=notes_data,
+        note_type=note_type,
+        batch_size=batch_size,
+        show_progress=output_format != "json",
+    )
+
+    result = {
+        "success": True,
+        "repo_path": str(Path(repo_path).resolve()),
+        "commits_extracted": len(commits),
+        **import_result,
+    }
+
+    if output_format == "json":
+        print(output_json(result))
+    else:
+        console.print(f"[green]✓[/green] 导入: {import_result['imported']}")
+        console.print(f"[red]✗[/red] 失败: {import_result['failed']}")
+        console.print(f"总计: {import_result['total']}")
+
+
 @app.command()
 def ingest_log(
     repo_path: str = typer.Argument(..., help="本地 Git 仓库路径"),
@@ -2162,7 +2218,10 @@ def ingest_log(
     note_type: str = typer.Option("fleeting", "--type", "-t", help="笔记类型"),
     batch_size: int = typer.Option(32, "--batch-size", "-b", help="批处理大小"),
     kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
-    json_output: bool = typer.Option(True, "--json/--no-json", help="JSON 输出"),
+    output_format: str = typer.Option("table", "--format", "-f", help="输出格式: json, table"),
+    json_output: bool = typer.Option(
+        False, "--json", help="JSON 输出（快捷方式，等同于 --format json）"
+    ),
 ):
     """
     从 Git 仓库提取 commit 历史并导入为笔记
@@ -2174,75 +2233,31 @@ def ingest_log(
         jfox ingest-log ./my-project --kb work --type permanent
     """
     try:
-        from .git_extractor import commits_to_notes, extract_commits
+        # 处理 --json 快捷方式
+        if json_output:
+            output_format = "json"
 
-        # 提取 commits
-        commits = extract_commits(repo_path, limit=limit)
-
-        if not commits:
-            result = {
-                "success": True,
-                "imported": 0,
-                "total": 0,
-                "message": "没有找到 commit 记录",
-            }
-            if json_output:
-                print(output_json(result))
-            else:
-                console.print("[yellow]![/yellow] 没有找到 commit 记录")
-            return
-
-        # 转换为笔记格式
-        notes_data = commits_to_notes(commits, repo_path=repo_path)
-
-        if not json_output:
-            console.print(f"[yellow]提取了 {len(notes_data)} 条 commit，正在导入...[/yellow]")
-
-        # 批量导入
-        from .performance import bulk_import_notes
-
+        # 如果指定了知识库，临时切换
         if kb:
             from .config import use_kb
 
             with use_kb(kb):
-                import_result = bulk_import_notes(
-                    notes_data=notes_data,
-                    note_type=note_type,
-                    batch_size=batch_size,
-                    show_progress=not json_output,
+                _ingest_log_impl(
+                    repo_path, limit, note_type, batch_size, output_format, json_output
                 )
         else:
-            import_result = bulk_import_notes(
-                notes_data=notes_data,
-                note_type=note_type,
-                batch_size=batch_size,
-                show_progress=not json_output,
-            )
-
-        result = {
-            "success": True,
-            "repo_path": str(Path(repo_path).resolve()),
-            "commits_extracted": len(commits),
-            **import_result,
-        }
-
-        if json_output:
-            print(output_json(result))
-        else:
-            console.print(f"[green]✓[/green] 导入: {import_result['imported']}")
-            console.print(f"[red]✗[/red] 失败: {import_result['failed']}")
-            console.print(f"总计: {import_result['total']}")
+            _ingest_log_impl(repo_path, limit, note_type, batch_size, output_format, json_output)
 
     except ValueError as e:
         result = {"success": False, "error": str(e)}
-        if json_output:
+        if output_format == "json":
             print(output_json(result))
         else:
             console.print(f"[red]✗[/red] {e}")
         raise typer.Exit(1)
     except Exception as e:
         result = {"success": False, "error": str(e)}
-        if json_output:
+        if output_format == "json":
             print(output_json(result))
         else:
             console.print(f"[red]✗[/red] Error: {e}")

--- a/jfox/git_extractor.py
+++ b/jfox/git_extractor.py
@@ -1,0 +1,80 @@
+"""Git 仓库数据提取模块
+
+从本地 Git 仓库提取 commit 历史，转换为结构化数据。
+"""
+
+import logging
+import re
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+# git log block 分隔符
+_COMMIT_DELIMITER = "---COMMIT_START---"
+# git log format 模板
+_GIT_LOG_FORMAT = (
+    f"{_COMMIT_DELIMITER}%n"
+    f"Hash: %H%n"
+    f"Subject: %s%n"
+    f"Author: %an%n"
+    f"Date: %ad%n"
+    f"%n%b"
+)
+
+
+def parse_git_log_output(raw: str) -> List[Dict[str, str]]:
+    """
+    解析 git log block 分隔符格式的输出
+
+    Args:
+        raw: git log 原始输出
+
+    Returns:
+        commit 列表，每项包含 hash, subject, author, date, body
+    """
+    if not raw.strip():
+        return []
+
+    commits = []
+    blocks = raw.split(_COMMIT_DELIMITER)
+
+    for block in blocks:
+        block = block.strip()
+        if not block:
+            continue
+
+        commit: Dict[str, str] = {
+            "hash": "",
+            "subject": "",
+            "author": "",
+            "date": "",
+            "body": "",
+        }
+
+        lines = block.split("\n")
+        i = 0
+        body_lines = []
+
+        # Parse header fields
+        for i, line in enumerate(lines):
+            line = line.rstrip()
+            if line.startswith("Hash:"):
+                commit["hash"] = line[5:].strip()
+            elif line.startswith("Subject:"):
+                commit["subject"] = line[8:].strip()
+            elif line.startswith("Author:"):
+                commit["author"] = line[7:].strip()
+            elif line.startswith("Date:"):
+                commit["date"] = line[5:].strip()
+            elif line == "":
+                # Empty line marks end of headers, start collecting body
+                body_lines = lines[i+1:]
+                break
+
+        # Join body lines with newlines
+        commit["body"] = "\n".join(body_lines).strip()
+
+        if commit["hash"]:
+            commits.append(commit)
+
+    return commits

--- a/jfox/git_extractor.py
+++ b/jfox/git_extractor.py
@@ -5,7 +5,9 @@
 
 import logging
 import re
-from typing import Dict, List
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -13,12 +15,7 @@ logger = logging.getLogger(__name__)
 _COMMIT_DELIMITER = "---COMMIT_START---"
 # git log format 模板
 _GIT_LOG_FORMAT = (
-    f"{_COMMIT_DELIMITER}%n"
-    f"Hash: %H%n"
-    f"Subject: %s%n"
-    f"Author: %an%n"
-    f"Date: %ad%n"
-    f"%n%b"
+    f"{_COMMIT_DELIMITER}%n" f"Hash: %H%n" f"Subject: %s%n" f"Author: %an%n" f"Date: %ad%n" f"%n%b"
 )
 
 
@@ -68,7 +65,7 @@ def parse_git_log_output(raw: str) -> List[Dict[str, str]]:
                 commit["date"] = line[5:].strip()
             elif line == "":
                 # Empty line marks end of headers, start collecting body
-                body_lines = lines[i+1:]
+                body_lines = lines[i + 1 :]
                 break
 
         # Join body lines with newlines
@@ -78,3 +75,105 @@ def parse_git_log_output(raw: str) -> List[Dict[str, str]]:
             commits.append(commit)
 
     return commits
+
+
+def extract_commits(repo_path: str, limit: int = 50) -> List[Dict[str, str]]:
+    """
+    从 Git 仓库提取 commit 历史
+
+    Args:
+        repo_path: 仓库路径（支持 Windows / Git Bash 路径）
+        limit: 最大提取条数
+
+    Returns:
+        commit 列表，每项包含 hash, subject, author, date, body
+
+    Raises:
+        ValueError: 路径不是 Git 仓库 或 git 未安装
+    """
+    repo = Path(repo_path).resolve()
+
+    cmd = [
+        "git",
+        "-C",
+        str(repo),
+        "log",
+        f"--format={_GIT_LOG_FORMAT}",
+        "--date=short",
+        f"-{limit}",
+    ]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except FileNotFoundError:
+        raise ValueError("git 命令未找到，请确认 git 已安装")
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        raise ValueError(f"git log 执行失败: {stderr}")
+
+    return parse_git_log_output(result.stdout)
+
+
+def commits_to_notes(
+    commits: List[Dict[str, str]],
+    repo_name: Optional[str] = None,
+    repo_path: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """
+    将 commit 列表转换为 bulk-import 兼容的笔记格式
+
+    Args:
+        commits: parse_git_log_output 的返回值
+        repo_name: 仓库名称（用于标签），None 时从 repo_path 提取
+        repo_path: 仓库路径（repo_name 为 None 时使用）
+
+    Returns:
+        笔记数据列表，兼容 bulk_import_notes() 输入格式
+    """
+    if not commits:
+        return []
+
+    if not repo_name:
+        if repo_path:
+            repo_name = Path(repo_path).resolve().name
+        else:
+            repo_name = "unknown"
+
+    notes = []
+    for c in commits:
+        short_hash = c["hash"][:7]
+
+        # 清理 body：去掉 Co-authored-by 行和末尾空行
+        body = c.get("body", "")
+        body_lines = [
+            line
+            for line in body.split("\n")
+            if line.strip() and not line.strip().lower().startswith("co-authored-by:")
+        ]
+        clean_body = "\n".join(body_lines).strip()
+
+        content_parts = [
+            f"Commit: {short_hash}",
+            f"Author: {c['author']}",
+            f"Date: {c['date']}",
+        ]
+        if clean_body:
+            content_parts.append("")
+            content_parts.append(clean_body)
+
+        notes.append(
+            {
+                "title": c["subject"],
+                "content": "\n".join(content_parts),
+                "tags": [f"source:{repo_name}", "source:git-log"],
+            }
+        )
+
+    return notes

--- a/jfox/git_extractor.py
+++ b/jfox/git_extractor.py
@@ -4,7 +4,6 @@
 """
 
 import logging
-import re
 import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Optional

--- a/tests/unit/test_git_extractor.py
+++ b/tests/unit/test_git_extractor.py
@@ -105,6 +105,20 @@ class TestParseGitLogOutput:
         result = parse_git_log_output(raw)
         assert result[0]["body"] == "line 1\nline 2\nline 3"
 
+    def test_delimiter_in_body_ignored(self):
+        """commit body 包含分隔符文本不应产生幻影 commit"""
+        raw = textwrap.dedent("""\
+            ---COMMIT_START---
+            Hash: abc123
+            Subject: feat: something
+            Author: Alice
+            Date: 2026-04-10
+
+            ---COMMIT_START--- this is just body text
+        """)
+        result = parse_git_log_output(raw)
+        assert len(result) == 1
+
 
 class TestExtractCommits:
     """测试 git 仓库 commit 提取"""
@@ -254,9 +268,10 @@ class TestIngestLogCommand:
         assert notes_data[0]["title"] == "feat: test feature"
         assert "abc123d" in notes_data[0]["content"]
 
+    @patch("jfox.performance.bulk_import_notes")
     @patch("jfox.git_extractor.extract_commits")
-    def test_ingest_log_empty_repo(self, mock_extract, tmp_path):
-        """空仓库不导入"""
+    def test_ingest_log_empty_repo(self, mock_extract, mock_import, tmp_path):
+        """空仓库不导入，bulk_import_notes 不应被调用"""
         mock_extract.return_value = []
 
         from typer.testing import CliRunner
@@ -267,3 +282,4 @@ class TestIngestLogCommand:
         result = runner.invoke(app, ["ingest-log", str(tmp_path)], catch_exceptions=False)
 
         assert result.exit_code == 0
+        mock_import.assert_not_called()

--- a/tests/unit/test_git_extractor.py
+++ b/tests/unit/test_git_extractor.py
@@ -1,0 +1,104 @@
+"""git_extractor 单元测试"""
+
+import textwrap
+from pathlib import Path
+
+from jfox.git_extractor import parse_git_log_output
+
+
+class TestParseGitLogOutput:
+    """测试 git log 输出解析"""
+
+    def test_single_commit(self):
+        """解析单条 commit"""
+        raw = textwrap.dedent("""\
+            ---COMMIT_START---
+            Hash: abc123def456
+            Subject: feat: add login
+            Author: 张三
+            Date: 2026-04-10
+
+            实现了登录功能
+        """)
+        result = parse_git_log_output(raw)
+        assert len(result) == 1
+        assert result[0]["hash"] == "abc123def456"
+        assert result[0]["subject"] == "feat: add login"
+        assert result[0]["author"] == "张三"
+        assert result[0]["date"] == "2026-04-10"
+        assert result[0]["body"] == "实现了登录功能"
+
+    def test_multiple_commits(self):
+        """解析多条 commit"""
+        raw = textwrap.dedent("""\
+            ---COMMIT_START---
+            Hash: aaa111
+            Subject: first commit
+            Author: Alice
+            Date: 2026-04-01
+
+            body of first
+            ---COMMIT_START---
+            Hash: bbb222
+            Subject: second commit
+            Author: Bob
+            Date: 2026-04-02
+
+            body of second
+        """)
+        result = parse_git_log_output(raw)
+        assert len(result) == 2
+        assert result[0]["hash"] == "aaa111"
+        assert result[1]["hash"] == "bbb222"
+
+    def test_empty_body(self):
+        """空 body 的 commit"""
+        raw = textwrap.dedent("""\
+            ---COMMIT_START---
+            Hash: abc123
+            Subject: chore: version bump
+            Author: Bot
+            Date: 2026-04-10
+        """)
+        result = parse_git_log_output(raw)
+        assert len(result) == 1
+        assert result[0]["body"] == ""
+
+    def test_body_with_special_chars(self):
+        """body 包含特殊字符（|、中文、换行）"""
+        raw = textwrap.dedent("""\
+            ---COMMIT_START---
+            Hash: abc123
+            Subject: fix: parser | handling
+            Author: 张三
+            Date: 2026-04-10
+
+            修复 | 分隔符问题
+            和中文内容
+            Co-Authored-By: Claude <noreply@anthropic.com>
+        """)
+        result = parse_git_log_output(raw)
+        assert len(result) == 1
+        assert "|" in result[0]["body"]
+        assert "中文" in result[0]["body"]
+
+    def test_empty_input(self):
+        """空输入返回空列表"""
+        result = parse_git_log_output("")
+        assert result == []
+
+    def test_multiline_body_preserved(self):
+        """多行 body 完整保留"""
+        raw = textwrap.dedent("""\
+            ---COMMIT_START---
+            Hash: abc123
+            Subject: feat: big change
+            Author: Alice
+            Date: 2026-04-10
+
+            line 1
+            line 2
+            line 3
+        """)
+        result = parse_git_log_output(raw)
+        assert result[0]["body"] == "line 1\nline 2\nline 3"

--- a/tests/unit/test_git_extractor.py
+++ b/tests/unit/test_git_extractor.py
@@ -218,3 +218,53 @@ class TestCommitsToNotes:
         ]
         result = commits_to_notes(commits, repo_path="/home/user/my-project")
         assert "source:my-project" in result[0]["tags"]
+
+
+class TestIngestLogCommand:
+    """测试 ingest-log CLI 命令"""
+
+    @patch("jfox.performance.bulk_import_notes")
+    @patch("jfox.git_extractor.extract_commits")
+    def test_ingest_log_basic(self, mock_extract, mock_import, tmp_path):
+        """基本 ingest-log 流程"""
+        mock_extract.return_value = [
+            {
+                "hash": "abc123def456",
+                "subject": "feat: test feature",
+                "author": "Alice",
+                "date": "2026-04-10",
+                "body": "test body",
+            }
+        ]
+        mock_import.return_value = {"imported": 1, "failed": 0, "total": 1}
+
+        from typer.testing import CliRunner
+
+        from jfox.cli import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["ingest-log", str(tmp_path)], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        mock_extract.assert_called_once()
+        mock_import.assert_called_once()
+
+        # 验证传入 bulk_import 的 notes 格式
+        notes_data = mock_import.call_args[1]["notes_data"]
+        assert len(notes_data) == 1
+        assert notes_data[0]["title"] == "feat: test feature"
+        assert "abc123d" in notes_data[0]["content"]
+
+    @patch("jfox.git_extractor.extract_commits")
+    def test_ingest_log_empty_repo(self, mock_extract, tmp_path):
+        """空仓库不导入"""
+        mock_extract.return_value = []
+
+        from typer.testing import CliRunner
+
+        from jfox.cli import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["ingest-log", str(tmp_path)], catch_exceptions=False)
+
+        assert result.exit_code == 0

--- a/tests/unit/test_git_extractor.py
+++ b/tests/unit/test_git_extractor.py
@@ -2,8 +2,11 @@
 
 import textwrap
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
-from jfox.git_extractor import parse_git_log_output
+import pytest
+
+from jfox.git_extractor import commits_to_notes, extract_commits, parse_git_log_output
 
 
 class TestParseGitLogOutput:
@@ -102,3 +105,116 @@ class TestParseGitLogOutput:
         """)
         result = parse_git_log_output(raw)
         assert result[0]["body"] == "line 1\nline 2\nline 3"
+
+
+class TestExtractCommits:
+    """测试 git 仓库 commit 提取"""
+
+    @patch("jfox.git_extractor.subprocess.run")
+    def test_basic_extraction(self, mock_run):
+        """基本提取流程"""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="---COMMIT_START---\nHash: abc123\nSubject: feat: test\nAuthor: Alice\nDate: 2026-04-10\n\nbody\n",
+        )
+        result = extract_commits("/fake/repo", limit=10)
+        assert len(result) == 1
+        assert result[0]["hash"] == "abc123"
+        assert result[0]["subject"] == "feat: test"
+
+        call_args = mock_run.call_args
+        assert call_args[1]["encoding"] == "utf-8"
+        assert call_args[1]["errors"] == "replace"
+
+    @patch("jfox.git_extractor.subprocess.run")
+    def test_path_normalization(self, mock_run):
+        """路径规范化（resolve 处理）"""
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        extract_commits("/c/Users/test/repo")
+        called_cmd = mock_run.call_args[0][0]
+        assert "-C" in called_cmd
+
+    @patch("jfox.git_extractor.subprocess.run")
+    def test_git_not_repo_error(self, mock_run):
+        """非 git 仓库应抛出 ValueError"""
+        mock_run.return_value = MagicMock(
+            returncode=128,
+            stderr="fatal: not a git repository",
+        )
+        with pytest.raises(ValueError, match="not a git repository"):
+            extract_commits("/not/a/repo")
+
+    @patch("jfox.git_extractor.subprocess.run")
+    def test_default_limit_50(self, mock_run):
+        """默认 limit 为 50"""
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        extract_commits("/fake/repo")
+        called_cmd = mock_run.call_args[0][0]
+        assert "-50" in called_cmd
+
+
+class TestCommitsToNotes:
+    """测试 commit → note 转换"""
+
+    def test_basic_conversion(self):
+        """基本转换"""
+        commits = [
+            {
+                "hash": "abc123def456",
+                "subject": "feat: add login",
+                "author": "张三",
+                "date": "2026-04-10",
+                "body": "实现了 JWT 认证",
+            }
+        ]
+        result = commits_to_notes(commits, repo_name="my-app")
+        assert len(result) == 1
+        assert result[0]["title"] == "feat: add login"
+        assert "abc123d" in result[0]["content"]
+        assert "张三" in result[0]["content"]
+        assert "2026-04-10" in result[0]["content"]
+        assert "JWT" in result[0]["content"]
+        assert "source:my-app" in result[0]["tags"]
+        assert "source:git-log" in result[0]["tags"]
+
+    def test_empty_commits(self):
+        """空列表返回空列表"""
+        result = commits_to_notes([], repo_name="test")
+        assert result == []
+
+    def test_long_hash_truncated(self):
+        """hash 截断为短 hash"""
+        commits = [
+            {
+                "hash": "a" * 40,
+                "subject": "test",
+                "author": "A",
+                "date": "2026-01-01",
+                "body": "",
+            }
+        ]
+        result = commits_to_notes(commits, repo_name="test")
+        assert "a" * 7 in result[0]["content"]
+
+    def test_body_with_co_authored_by_stripped(self):
+        """body 末尾的 Co-authored-by 行被清理"""
+        commits = [
+            {
+                "hash": "abc1234",
+                "subject": "feat: something",
+                "author": "Alice",
+                "date": "2026-04-10",
+                "body": "real content\n\nCo-authored-by: Bob <bob@example.com>\nCo-authored-by: Claude <noreply@anthropic.com>",
+            }
+        ]
+        result = commits_to_notes(commits, repo_name="test")
+        assert "real content" in result[0]["content"]
+        assert "Co-authored-by" not in result[0]["content"]
+
+    def test_repo_name_from_path(self):
+        """repo_name=None 时从路径提取目录名"""
+        commits = [
+            {"hash": "abc1234", "subject": "test", "author": "A", "date": "2026-01-01", "body": ""}
+        ]
+        result = commits_to_notes(commits, repo_path="/home/user/my-project")
+        assert "source:my-project" in result[0]["tags"]

--- a/tests/unit/test_git_extractor.py
+++ b/tests/unit/test_git_extractor.py
@@ -1,7 +1,6 @@
 """git_extractor 单元测试"""
 
 import textwrap
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest


### PR DESCRIPTION
## Summary

- 新增 `jfox ingest-log <repo-path>` 子命令，从本地 Git 仓库提取 commit 历史并导入为 fleeting 笔记
- 新增 `jfox/git_extractor.py` 模块：使用 block 分隔符解析 git log，解决 `|` 分隔符被 commit body 污染的问题
- 自动处理 Windows 编码（UTF-8）、路径规范化（`Path.resolve()`）、Co-authored-by 清理

## 设计决策

- **Block 分隔符** `---COMMIT_START---` 替代 `|` 分隔符，避免 `%b` body 中的管道符导致解析错误
- **直接调用** `bulk_import_notes()` 而非生成中间 JSON 文件，避免 Windows 管道兼容问题
- **零依赖**：`git_extractor.py` 不依赖 jfox 其他模块，独立可测试

Closes #125

## Test plan

- [x] 18 个单元测试全部通过（解析器、subprocess、转换器、CLI 集成）
- [x] `uv run ruff check` + `uv run black --check` 通过
- [x] `uv run pytest tests/unit/` 229 passed（2 个预先存在的 Windows ChromaDB 锁定问题，与此 PR 无关）
- [ ] 手动端到端：`jfox ingest-log --help`、`jfox ingest-log . --limit 5`、`jfox ingest-log . --kb homework`

🤖 Generated with [Claude Code](https://claude.com/claude-code)