### PR TITLE
fix: bulk-import VectorStore 未初始化 + index rebuild 含 BM25

### DIFF
--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -1702,15 +1702,31 @@ def _index_impl(action: str, output_format: str):
             console.print("[yellow]Rebuilding index...[/yellow]")
             count = indexer.index_all()
 
+            # 同时重建 BM25 索引
+            from . import note as note_module
+            from .bm25_index import get_bm25_index
+
+            bm25_index = get_bm25_index()
+            notes = note_module.list_notes(limit=10000)
+            bm25_success = bm25_index.rebuild_from_notes(notes)
+
             result = {
                 "success": True,
                 "indexed": count,
+                "bm25_rebuilt": bm25_success,
+                "bm25_indexed": len(notes),
             }
 
             if output_format == "json":
                 print(output_json(result))
             else:
                 console.print(f"[green]✓[/green] Indexed {count} notes")
+                if bm25_success:
+                    console.print(f"[green]✓[/green] BM25 index rebuilt: {len(notes)} notes")
+                else:
+                    console.print(
+                        "[yellow]⚠[/yellow] ChromaDB rebuilt, but BM25 rebuild failed"
+                    )
 
         elif action == "verify":
             verification = indexer.verify_index()

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -1724,9 +1724,7 @@ def _index_impl(action: str, output_format: str):
                 if bm25_success:
                     console.print(f"[green]✓[/green] BM25 index rebuilt: {len(notes)} notes")
                 else:
-                    console.print(
-                        "[yellow]⚠[/yellow] ChromaDB rebuilt, but BM25 rebuild failed"
-                    )
+                    console.print("[yellow]⚠[/yellow] ChromaDB rebuilt, but BM25 rebuild failed")
 
         elif action == "verify":
             verification = indexer.verify_index()

--- a/jfox/performance.py
+++ b/jfox/performance.py
@@ -251,6 +251,10 @@ def bulk_import_notes(
                 documents = [f"{n.title}\n{n.content}" for n in notes]
                 embeddings = backend.encode(documents).tolist()
 
+                # 确保 VectorStore 已初始化
+                if vector_store.collection is None:
+                    vector_store.init()
+
                 # 批量添加到 ChromaDB
                 ids = [n.id for n in notes]
                 metadatas = [

--- a/tests/unit/test_bm25_batch.py
+++ b/tests/unit/test_bm25_batch.py
@@ -300,8 +300,7 @@ class TestBulkImportBM25Integration:
         mock_bm25.add_documents_batch.return_value = True
         mock_get_bm25.return_value = mock_bm25
 
-        # 不 mock get_vector_store，让真实的 VectorStore 被创建
-        # 但 patch 掉 VectorStore.init 来验证它被调用了
+        # 使用 context manager 代替 decorator mock，精细控制 collection 的初始状态
         with patch("jfox.vector_store.get_vector_store") as mock_get_vs:
             mock_vs = MagicMock()
             # 关键：collection 初始为 None，模拟真实场景

--- a/tests/unit/test_bm25_batch.py
+++ b/tests/unit/test_bm25_batch.py
@@ -265,3 +265,59 @@ class TestBulkImportBM25Integration:
         # batch_size=3, 5 notes = 2 batches
         assert result["imported"] == 5
         assert mock_bm25.add_documents_batch.call_count == 2
+
+    @patch("jfox.bm25_index.get_bm25_index")
+    @patch("jfox.embedding_backend.get_backend")
+    @patch("jfox.note.create_note")
+    def test_bulk_import_with_uninitialized_vectorstore(
+        self, mock_create_note, mock_get_backend, mock_get_bm25, tmp_path
+    ):
+        """bulk_import_notes 应在 collection.add() 前自动初始化 VectorStore"""
+        import numpy as np
+
+        from jfox.models import Note, NoteType
+        from jfox.performance import bulk_import_notes
+
+        # 准备 mock note
+        mock_note = MagicMock(spec=Note)
+        mock_note.id = "20260413120000"
+        mock_note.title = "测试初始化"
+        mock_note.content = "内容"
+        mock_note.type = NoteType.PERMANENT
+        mock_note.tags = []
+        mock_note.filepath = tmp_path / "notes" / "permanent" / "test.md"
+        mock_note.to_markdown.return_value = "# 测试初始化\n内容"
+        mock_create_note.return_value = mock_note
+
+        # mock embedding backend
+        mock_backend = MagicMock()
+        mock_backend.model = MagicMock()
+        mock_backend.encode.return_value = np.array([[0.1] * 384])
+        mock_get_backend.return_value = mock_backend
+
+        # mock BM25
+        mock_bm25 = MagicMock()
+        mock_bm25.add_documents_batch.return_value = True
+        mock_get_bm25.return_value = mock_bm25
+
+        # 不 mock get_vector_store，让真实的 VectorStore 被创建
+        # 但 patch 掉 VectorStore.init 来验证它被调用了
+        with patch("jfox.vector_store.get_vector_store") as mock_get_vs:
+            mock_vs = MagicMock()
+            # 关键：collection 初始为 None，模拟真实场景
+            mock_vs.collection = None
+
+            # init() 会设置 collection
+            def fake_init():
+                mock_vs.collection = MagicMock()
+
+            mock_vs.init.side_effect = fake_init
+            mock_get_vs.return_value = mock_vs
+
+            notes_data = [{"title": "测试初始化", "content": "内容"}]
+            result = bulk_import_notes(notes_data, show_progress=False)
+
+            # 验证 init 被调用了
+            mock_vs.init.assert_called()
+            # 导入成功
+            assert result["imported"] == 1

--- a/tests/unit/test_index_kb_param.py
+++ b/tests/unit/test_index_kb_param.py
@@ -1,6 +1,7 @@
 """jfox index --kb 参数支持测试（issue #104）"""
 
 import json
+from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
@@ -90,3 +91,43 @@ class TestIndexKbParamSuccess:
         self._reset_global_config_cache()
         result = runner.invoke(app, ["index", "status", "--json"])
         assert result.exit_code == 0
+
+
+class TestIndexRebuildIncludesBM25:
+    """验证 index rebuild 同时重建 BM25 索引"""
+
+    @patch("jfox.note.list_notes")
+    @patch("jfox.bm25_index.get_bm25_index")
+    @patch("jfox.indexer.Indexer")
+    @patch("jfox.vector_store.get_vector_store")
+    def test_rebuild_calls_bm25_rebuild(
+        self, mock_get_vs, mock_indexer_cls, mock_get_bm25, mock_list_notes, tmp_path
+    ):
+        """index rebuild 应在 ChromaDB 重建后调用 BM25 rebuild_from_notes"""
+        from jfox.cli import _index_impl
+
+        # mock vector store
+        mock_vs = MagicMock()
+        mock_get_vs.return_value = mock_vs
+
+        # mock indexer
+        mock_indexer = MagicMock()
+        mock_indexer.index_all.return_value = 10
+        mock_indexer_cls.return_value = mock_indexer
+
+        # mock note.list_notes
+        mock_notes = [MagicMock() for _ in range(3)]
+        mock_list_notes.return_value = mock_notes
+
+        # mock BM25
+        mock_bm25 = MagicMock()
+        mock_bm25.rebuild_from_notes.return_value = True
+        mock_get_bm25.return_value = mock_bm25
+
+        _index_impl("rebuild", "text")
+
+        # 验证 ChromaDB 重建被调用
+        mock_indexer.index_all.assert_called_once()
+        # 验证 BM25 重建也被调用
+        mock_get_bm25.assert_called_once()
+        mock_bm25.rebuild_from_notes.assert_called_once_with(mock_notes)


### PR DESCRIPTION
## Summary
- **修复 1**：`bulk_import_notes()` 中 `VectorStore.collection` 未初始化导致 `'NoneType' object has no attribute 'add'` 错误。在 `collection.add()` 前添加 init 守卫。
- **修复 2**：`index rebuild` 命令现在同时重建 ChromaDB 和 BM25 索引（之前只重建 ChromaDB）。

## Test plan
- [x] 新增 `test_bulk_import_with_uninitialized_vectorstore` 验证 init 守卫
- [x] 新增 `test_rebuild_calls_bm25_rebuild` 验证 rebuild 触发 BM25 重建
- [x] `tests/unit/test_bm25_batch.py` 全部 12 个测试通过
- [x] `tests/unit/test_index_kb_param.py` 全部 9 个测试通过
- [ ] 用户手动验证：全新会话直接执行 `jfox bulk-import` 不再报错
- [ ] 用户手动验证：`jfox index rebuild` 后 BM25 索引也更新

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)