### PR TITLE
feat: jfox add 支持 --content-file 从文件读取笔记内容

### DIFF
--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -365,7 +365,7 @@ def _add_note_impl(
 
 @app.command()
 def add(
-    content: str = typer.Argument(..., help="笔记内容（支持 [[笔记标题]] 格式链接）"),
+    content: Optional[str] = typer.Argument(None, help="笔记内容（支持 [[笔记标题]] 格式链接）"),
     title: Optional[str] = typer.Option(None, "--title", "-t", help="笔记标题"),
     note_type: str = typer.Option(
         "fleeting", "--type", help="笔记类型 (fleeting/literature/permanent)"
@@ -374,6 +374,9 @@ def add(
     source: Optional[str] = typer.Option(None, "--source", "-s", help="来源（文献笔记）"),
     template: Optional[str] = typer.Option(
         None, "--template", "-T", help="使用模板创建笔记 (quick/meeting/literature)"
+    ),
+    content_file: Optional[str] = typer.Option(
+        None, "--content-file", help="从文件读取内容（用 - 表示 stdin）"
     ),
     kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
     output_format: str = typer.Option("table", "--format", "-f", help="输出格式: json, table"),
@@ -386,6 +389,18 @@ def add(
         # 向后兼容：--json 快捷方式
         if json_output:
             output_format = "json"
+
+        # content 和 --content-file 互斥
+        if content is not None and content_file is not None:
+            raise ValueError("不能同时指定内容参数和 --content-file，请选择其一")
+
+        # 从文件读取内容
+        if content_file is not None:
+            content = _read_content_file(content_file)
+
+        # 至少提供一种内容来源
+        if not content:
+            raise ValueError("请提供笔记内容（位置参数或 --content-file）")
 
         # 如果指定了知识库，临时切换
         if kb:

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -956,6 +956,26 @@ def delete(
         raise typer.Exit(1)
 
 
+def _read_content_file(content_file: str) -> str:
+    """从文件或 stdin 读取内容（--content-file 共用逻辑）"""
+    if content_file == "-":
+        import sys
+
+        return sys.stdin.read()
+
+    p = Path(content_file)
+    if not p.exists():
+        raise ValueError(f"文件不存在: {content_file}")
+    if not p.is_file():
+        raise ValueError(f"路径不是文件: {content_file}")
+    try:
+        return p.read_text(encoding="utf-8")
+    except PermissionError:
+        raise ValueError(f"无权限读取文件: {content_file}")
+    except UnicodeDecodeError:
+        raise ValueError(f"文件编码错误（需要 UTF-8）: {content_file}")
+
+
 def _edit_impl(
     note_id: str,
     content: Optional[str],
@@ -973,17 +993,7 @@ def _edit_impl(
 
     # 从文件读取内容
     if content_file is not None:
-        p = Path(content_file)
-        if not p.exists():
-            raise ValueError(f"文件不存在: {content_file}")
-        if not p.is_file():
-            raise ValueError(f"路径不是文件: {content_file}")
-        try:
-            content = p.read_text(encoding="utf-8")
-        except PermissionError:
-            raise ValueError(f"无权限读取文件: {content_file}")
-        except UnicodeDecodeError:
-            raise ValueError(f"文件编码错误（需要 UTF-8）: {content_file}")
+        content = _read_content_file(content_file)
 
     # 验证：至少指定一个编辑字段
     if all(v is None for v in [content, title, tags, note_type, source]):

--- a/tests/test_cli_format.py
+++ b/tests/test_cli_format.py
@@ -324,6 +324,55 @@ class TestCLIFormat:
     # ==========================================================================
     # Add 命令测试
     # ==========================================================================
+    def test_add_content_file(self, cli, tmp_path):
+        """测试 add 命令 --content-file 从文件读取内容"""
+        content_file = tmp_path / "note.md"
+        content_file.write_text("从文件读取的笔记内容", encoding="utf-8")
+
+        result = cli.run("add", "--content-file", str(content_file), "--title", "FileContent")
+
+        assert result.success
+        data = result.data
+        assert data["success"] is True
+        assert data["note"]["title"] == "FileContent"
+
+    def test_add_content_file_mutual_exclusive(self, cli, tmp_path):
+        """测试 add 命令 content 参数和 --content-file 不能同时指定"""
+        content_file = tmp_path / "note.md"
+        content_file.write_text("file content", encoding="utf-8")
+
+        result = cli.run("add", "直接内容", "--content-file", str(content_file))
+
+        assert not result.success
+        assert "不能同时指定" in result.stderr or "不能同时指定" in result.stdout
+
+    def test_add_content_file_not_found(self, cli):
+        """测试 add 命令 --content-file 文件不存在时报错"""
+        result = cli.run("add", "--content-file", "/nonexistent/file.md")
+
+        assert not result.success
+        assert "文件不存在" in result.stderr or "文件不存在" in result.stdout
+
+    def test_add_content_file_empty(self, cli):
+        """测试 add 命令不提供内容时报错"""
+        result = cli.run("add")
+
+        assert not result.success
+
+    def test_add_content_file_with_wiki_links(self, cli, tmp_path):
+        """测试 add 命令 --content-file 内容中的 [[wiki链接]] 正常解析"""
+        # 先创建一个目标笔记
+        cli.add("目标笔记内容", title="目标笔记")
+
+        content_file = tmp_path / "linked.md"
+        content_file.write_text("引用 [[目标笔记]] 的内容", encoding="utf-8")
+
+        result = cli.run("add", "--content-file", str(content_file), "--title", "带链接的笔记")
+
+        assert result.success
+        data = result.data
+        assert data["note"]["links"]
+
     def test_add_format_json(self, cli):
         """测试 add 命令 --format json"""
         result = cli.run("add", "test content", "--title", "FormatTest", "--format", "json")


### PR DESCRIPTION
## Summary

Closes #133

- `jfox add` 新增 `--content-file` 选项，支持从文件或 stdin 读取笔记内容
- 提取 `_read_content_file()` 公共函数，`edit` 命令复用同一逻辑
- 位置参数和 `--content-file` 互斥，至少提供一种内容来源

## 用法

```bash
jfox add --content-file notes.md --title "标题" --type permanent
cat notes.md | jfox add --content-file - --title "标题"
jfox add "简短内容" --title "标题"  # 原有方式不变
```

## 改动

| 文件 | 改动 |
|------|------|
| `jfox/cli.py` | `add()` 签名改为 Optional content + 新增 `--content-file`；提取 `_read_content_file()`；`_edit_impl` 复用 |
| `tests/test_cli_format.py` | 5 个测试：文件读取、互斥报错、文件不存在、空内容、wiki 链接 |

## Test plan

- [ ] `uv run pytest tests/test_cli_format.py -v` — 45 tests pass
- [ ] `jfox add --content-file test.md --title "smoke" --json` — 正常创建
- [ ] `echo "test" | jfox add --content-file - --title "stdin" --json` — stdin 正常
- [ ] `jfox add "x" --content-file test.md` — 报互斥错误
- [ ] `jfox add` — 报缺少内容错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)