### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Notes are Markdown files with YAML frontmatter stored under `~/.zettelkasten/<kb
 
 ## Conventions
 
-- **Version bump**: 发版时必须同时修改 `pyproject.toml` 和 `jfox/__init__.py` 两处版本号（曾有 #88 遗漏 `__init__.py` 的教训）
+- **Version bump**: 发版时必须同时修改 `pyproject.toml`、`jfox/__init__.py` 和 `uv.lock` 三处版本号。先改前两个文件，再跑 `uv lock` 更新 lock 文件（曾有 #88 遗漏 `__init__.py` 的教训）
 - **Line length**: 100 chars (black + ruff configured in `pyproject.toml`)
 - **Comments/docs**: Chinese (中文)
 - **Adding a CLI command**: Add `@app.command()` in `cli.py`, implement `_xxx_impl()` helper, add `--kb` and `--format json` support

--- a/jfox/__init__.py
+++ b/jfox/__init__.py
@@ -1,5 +1,5 @@
 """JFox - Zettelkasten 知识管理工具"""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __author__ = "User"
 __email__ = "user@example.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jfox-cli"
-version = "0.2.1"
+version = "0.2.2"
 description = "JFox - Zettelkasten 知识管理 CLI 工具"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -851,7 +851,7 @@ wheels = [
 
 [[package]]
 name = "jfox-cli"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

- 版本号 0.2.1 → 0.2.2（`pyproject.toml` + `jfox/__init__.py`）

### v0.2.2 变更清单

| 类型 | 内容 | PR |
|------|------|-----|
| feat | `jfox add --content-file` 从文件读取笔记内容 | #135 |
| refactor | jfox-ingest skill 使用 ingest-log | #132 |
| fix | 抑制第三方库 INFO 日志 | #136 |
| docs | 3 个 skill 同步 CLI v0.2.1 | #138 |

## Test plan

- [ ] `uv run jfox --version` 输出 `0.2.2`
- [ ] 两处版本号一致：`jfox/__init__.py` 和 `pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)