### PR TITLE
feat: 添加 embedding daemon 后台常驻服务

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,8 @@ Notes are Markdown files with YAML frontmatter stored under `~/.zettelkasten/<kb
 | `models.py` | `Note` data model with frontmatter serialization |
 | `search_engine.py` | `HybridSearchEngine` with `SearchMode` enum, RRF fusion |
 | `bm25_index.py` | BM25 keyword search index |
-| `embedding_backend.py` | Sentence-transformers embedding backend |
+| `embedding_backend.py` | Sentence-transformers embedding backend（支持 daemon 代理） |
+| `daemon/` | Embedding 模型 HTTP 守护进程（可选依赖 `[daemon]`），`jfox daemon start/stop/status` |
 | `vector_store.py` | ChromaDB vector store for semantic search |
 | `graph.py` | NetworkX knowledge graph from links/backlinks |
 | `template.py` / `template_cli.py` | Jinja2 template system for structured note creation |

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -2457,10 +2457,10 @@ def daemon(
         jfox daemon stop        # 停止 daemon
     """
     from .daemon.process import (
-        start_daemon,
-        stop_daemon,
         get_daemon_status,
         is_daemon_running,
+        start_daemon,
+        stop_daemon,
     )
 
     try:

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -2439,6 +2439,88 @@ def perf(
         raise typer.Exit(1)
 
 
+@app.command()
+def daemon(
+    action: str = typer.Argument("status", help="操作: start, stop, status"),
+    port: int = typer.Option(18700, "--port", "-p", help="Daemon 监听端口"),
+):
+    """
+    管理嵌入模型守护进程
+
+    启动后台 daemon 可避免每次 CLI 调用重复加载模型（节省 ~5-15 秒）。
+    daemon 仅持有 embedding 模型，不持有知识库数据。
+
+    示例:
+
+        jfox daemon start       # 启动 daemon
+        jfox daemon status      # 查看状态
+        jfox daemon stop        # 停止 daemon
+    """
+    from .daemon.process import (
+        start_daemon,
+        stop_daemon,
+        get_daemon_status,
+        is_daemon_running,
+    )
+
+    try:
+        if action == "start":
+            console.print("[yellow]正在启动 embedding daemon...[/yellow]")
+            ok = start_daemon(port=port)
+            if ok:
+                info = get_daemon_status()
+                if info:
+                    table = Table(title="Embedding Daemon")
+                    table.add_column("属性", style="cyan")
+                    table.add_column("值", style="green")
+                    table.add_row("状态", "[green]运行中[/green]")
+                    table.add_row("PID", str(info["pid"]))
+                    table.add_row("端口", str(info["port"]))
+                    table.add_row("模型", info["model"])
+                    table.add_row("维度", str(info["dimension"]))
+                    console.print(table)
+                else:
+                    console.print("[green]✓ Daemon 已启动[/green]")
+            else:
+                console.print("[red]✗ Daemon 启动失败[/red]")
+                raise typer.Exit(1)
+
+        elif action == "stop":
+            if not is_daemon_running():
+                console.print("[dim]Daemon 未运行[/dim]")
+                return
+            console.print("[yellow]正在停止 daemon...[/yellow]")
+            stop_daemon()
+            console.print("[green]✓ Daemon 已停止[/green]")
+
+        elif action == "status":
+            info = get_daemon_status()
+            if info:
+                table = Table(title="Embedding Daemon")
+                table.add_column("属性", style="cyan")
+                table.add_column("值", style="green")
+                table.add_row("状态", "[green]运行中[/green]")
+                table.add_row("PID", str(info["pid"]))
+                table.add_row("端口", str(info["port"]))
+                table.add_row("模型", info.get("model", "unknown"))
+                table.add_row("维度", str(info.get("dimension", "unknown")))
+                console.print(table)
+            else:
+                console.print("[dim]Daemon 未运行[/dim]")
+                console.print("提示: 运行 [cyan]jfox daemon start[/cyan] 启动")
+
+        else:
+            console.print(f"[red]未知操作: {action}[/red]")
+            console.print("可用操作: start, stop, status")
+            raise typer.Exit(1)
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]✗[/red] 错误: {e}")
+        raise typer.Exit(1)
+
+
 # 入口点
 def main():
     """CLI 入口点"""

--- a/jfox/daemon/__init__.py
+++ b/jfox/daemon/__init__.py
@@ -1,0 +1,15 @@
+"""嵌入模型守护进程"""
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 18700
+
+from .process import get_daemon_status, is_daemon_running, start_daemon, stop_daemon
+
+__all__ = [
+    "DEFAULT_HOST",
+    "DEFAULT_PORT",
+    "start_daemon",
+    "stop_daemon",
+    "is_daemon_running",
+    "get_daemon_status",
+]

--- a/jfox/daemon/__main__.py
+++ b/jfox/daemon/__main__.py
@@ -1,0 +1,5 @@
+"""支持 python -m jfox.daemon.server 启动"""
+
+from .server import main
+
+main()

--- a/jfox/daemon/client.py
+++ b/jfox/daemon/client.py
@@ -1,0 +1,99 @@
+"""
+嵌入模型 HTTP 客户端
+
+通过 HTTP 调用 daemon 获取 embedding，接口与 EmbeddingBackend 一致。
+"""
+
+import json
+import time
+from typing import List, Optional
+
+import numpy as np
+
+# 健康检查结果缓存时间（秒）
+_HEALTH_CACHE_TTL = 30.0
+
+# HTTP 请求超时（秒）
+_REQUEST_TIMEOUT = 120.0
+_HEALTH_TIMEOUT = 2.0
+
+
+class DaemonClient:
+    """HTTP 客户端，代理 embedding 请求到 daemon"""
+
+    def __init__(self, base_url: str):
+        self.base_url = base_url.rstrip("/")
+        self._health_cache_time: float = 0.0
+        self._health_cache_result: Optional[bool] = None
+        self._dimension: int = 384
+
+    @property
+    def available(self) -> bool:
+        """检查 daemon 是否可用（带缓存）"""
+        now = time.time()
+        cached = self._health_cache_result
+        if cached is not None and (now - self._health_cache_time) < _HEALTH_CACHE_TTL:
+            return cached
+
+        try:
+            import urllib.request
+
+            resp = urllib.request.urlopen(f"{self.base_url}/health", timeout=_HEALTH_TIMEOUT)
+            data = json.loads(resp.read().decode("utf-8"))
+            self._dimension = data.get("dimension", 384)
+            self._health_cache_result = True
+        except Exception:
+            self._health_cache_result = False
+
+        self._health_cache_time = now
+        return self._health_cache_result
+
+    def encode(self, texts: List[str], batch_size: int = 32) -> np.ndarray:
+        """批量文本编码"""
+        import urllib.request
+
+        payload = json.dumps({"texts": texts, "batch_size": batch_size}).encode("utf-8")
+        req = urllib.request.Request(
+            f"{self.base_url}/encode",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+
+        resp = urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT)
+        result = json.loads(resp.read().decode("utf-8"))
+
+        return np.array(result["embeddings"], dtype=np.float32)
+
+    def encode_single(self, text: str) -> np.ndarray:
+        """单文本编码"""
+        import urllib.request
+
+        payload = json.dumps({"text": text}).encode("utf-8")
+        req = urllib.request.Request(
+            f"{self.base_url}/encode_single",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+
+        resp = urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT)
+        result = json.loads(resp.read().decode("utf-8"))
+
+        return np.array(result["embedding"], dtype=np.float32)
+
+    @property
+    def model_name(self) -> str:
+        """获取模型名称"""
+        try:
+            import urllib.request
+
+            resp = urllib.request.urlopen(f"{self.base_url}/health", timeout=_HEALTH_TIMEOUT)
+            data = json.loads(resp.read().decode("utf-8"))
+            return data.get("model", "unknown")
+        except Exception:
+            return "daemon"
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension

--- a/jfox/daemon/process.py
+++ b/jfox/daemon/process.py
@@ -1,0 +1,222 @@
+"""
+Daemon 进程管理
+
+负责启动、停止、查询 daemon 后台进程。
+PID 文件存储在 ~/.jfox_daemon.pid。
+"""
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+from . import DEFAULT_HOST, DEFAULT_PORT
+
+logger = logging.getLogger(__name__)
+
+STARTUP_TIMEOUT = 60  # 模型加载可能较慢
+PID_FILE = Path.home() / ".jfox_daemon.pid"
+
+
+def _read_pid_file() -> Optional[dict]:
+    """读取 PID 文件"""
+    if not PID_FILE.exists():
+        return None
+    try:
+        return json.loads(PID_FILE.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _write_pid_file(data: dict):
+    """写入 PID 文件"""
+    PID_FILE.parent.mkdir(parents=True, exist_ok=True)
+    PID_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    logger.debug(f"PID 文件已写入: {PID_FILE}")
+
+
+def _remove_pid_file():
+    """删除 PID 文件"""
+    try:
+        PID_FILE.unlink()
+    except OSError:
+        pass
+
+
+def _get_daemon_url(data: Optional[dict] = None) -> str:
+    """获取 daemon URL"""
+    if data is None:
+        data = _read_pid_file()
+    if data is None:
+        return f"http://{DEFAULT_HOST}:{DEFAULT_PORT}"
+    host = data.get("host", DEFAULT_HOST)
+    port = data.get("port", DEFAULT_PORT)
+    return f"http://{host}:{port}"
+
+
+def _http_health_check(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> Optional[dict]:
+    """HTTP 健康检查，返回健康信息或 None"""
+    try:
+        import urllib.request
+
+        resp = urllib.request.urlopen(f"http://{host}:{port}/health", timeout=2)
+        return json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        return None
+
+
+def is_daemon_running() -> bool:
+    """检查 daemon 是否在运行（以 HTTP 健康检查为准）"""
+    # 先尝试 PID 文件记录的地址
+    data = _read_pid_file()
+    if data is not None:
+        host = data.get("host", DEFAULT_HOST)
+        port = data.get("port", DEFAULT_PORT)
+        if _http_health_check(host, port) is not None:
+            return True
+
+    # 再尝试默认地址
+    if _http_health_check() is not None:
+        return True
+
+    return False
+
+
+def start_daemon(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> bool:
+    """
+    启动 daemon 后台进程
+
+    Returns:
+        True 表示启动成功
+    """
+    # 检查是否已在运行
+    health = _http_health_check(host, port)
+    if health is not None:
+        logger.info("Daemon 已在运行")
+        _write_pid_file(
+            {
+                "pid": health.get("pid", 0),
+                "host": host,
+                "port": port,
+                "started_at": time.time(),
+            }
+        )
+        return True
+
+    # 构建启动命令
+    cmd = [sys.executable, "-m", "jfox.daemon.server", "--host", host, "--port", str(port)]
+
+    kwargs = {}
+    if sys.platform == "win32":
+        # Windows: 后台分离进程，不弹窗
+        CREATE_NEW_PROCESS_GROUP = 0x00000200
+        DETACHED_PROCESS = 0x00000008
+        kwargs["creationflags"] = CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS
+    else:
+        kwargs["start_new_session"] = True
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            **kwargs,
+        )
+        logger.info(f"Daemon 进程已启动 (PID: {proc.pid})")
+    except Exception as e:
+        logger.error(f"启动 daemon 失败: {e}")
+        return False
+
+    # 等待 daemon 就绪（用 HTTP 健康检查判断，不用 PID）
+    for i in range(STARTUP_TIMEOUT):
+        time.sleep(1)
+        health = _http_health_check(host, port)
+        if health is not None:
+            # 从 daemon 自身获取真实 PID
+            real_pid = health.get("pid", proc.pid)
+            _write_pid_file(
+                {
+                    "pid": real_pid,
+                    "host": host,
+                    "port": port,
+                    "started_at": time.time(),
+                }
+            )
+            logger.info(f"Daemon 已就绪 (PID: {real_pid}, port: {port})")
+            return True
+
+    logger.warning("Daemon 启动超时")
+    return False
+
+
+def stop_daemon() -> bool:
+    """
+    停止 daemon 进程
+
+    Returns:
+        True 表示停止成功
+    """
+    data = _read_pid_file()
+    host = DEFAULT_HOST
+    port = DEFAULT_PORT
+    pid = 0
+
+    if data is not None:
+        pid = data.get("pid", 0)
+        host = data.get("host", DEFAULT_HOST)
+        port = data.get("port", DEFAULT_PORT)
+
+    # 先检查是否真的在跑
+    if _http_health_check(host, port) is None:
+        _remove_pid_file()
+        return True
+
+    # 尝试停止
+    if pid > 0:
+        try:
+            if sys.platform == "win32":
+                subprocess.run(
+                    ["taskkill", "/PID", str(pid), "/T", "/F"],
+                    capture_output=True,
+                    timeout=10,
+                )
+            else:
+                os.kill(pid, 15)  # SIGTERM
+        except Exception as e:
+            logger.warning(f"停止 daemon 失败: {e}")
+
+    # 等待进程退出
+    for _ in range(10):
+        if _http_health_check(host, port) is None:
+            break
+        time.sleep(0.5)
+
+    _remove_pid_file()
+    logger.info(f"Daemon 已停止 (PID: {pid})")
+    return True
+
+
+def get_daemon_status() -> Optional[dict]:
+    """获取 daemon 状态信息（含健康检查）"""
+    data = _read_pid_file()
+    host = data.get("host", DEFAULT_HOST) if data else DEFAULT_HOST
+    port = data.get("port", DEFAULT_PORT) if data else DEFAULT_PORT
+
+    health = _http_health_check(host, port)
+    if health is None:
+        _remove_pid_file()
+        return None
+
+    return {
+        "pid": health.get("pid", 0),
+        "host": host,
+        "port": port,
+        "model": health.get("model", "unknown"),
+        "dimension": health.get("dimension", 384),
+        "started_at": data.get("started_at") if data else None,
+    }

--- a/jfox/daemon/process.py
+++ b/jfox/daemon/process.py
@@ -193,12 +193,15 @@ def stop_daemon() -> bool:
     # 等待进程退出
     for _ in range(10):
         if _http_health_check(host, port) is None:
-            break
+            _remove_pid_file()
+            logger.info(f"Daemon 已停止 (PID: {pid})")
+            return True
         time.sleep(0.5)
 
+    # 超时未退出
+    logger.warning(f"Daemon 停止超时 (PID: {pid})")
     _remove_pid_file()
-    logger.info(f"Daemon 已停止 (PID: {pid})")
-    return True
+    return False
 
 
 def get_daemon_status() -> Optional[dict]:

--- a/jfox/daemon/server.py
+++ b/jfox/daemon/server.py
@@ -1,0 +1,122 @@
+"""
+嵌入模型 HTTP 守护进程 - 服务端
+
+常驻后台，加载 sentence-transformers 模型，通过 HTTP API 提供 embedding 编码服务。
+入口：python -m jfox.daemon.server --port 18700
+"""
+
+import argparse
+import logging
+import os
+from typing import List
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="JFox Embedding Daemon")
+
+# 全局 embedding 后端（模型加载后常驻内存）
+_backend = None
+
+
+@app.on_event("startup")
+def _load_model():
+    """启动时加载模型（标记为 daemon 进程，防止自引用）"""
+    global _backend
+    os.environ["JFOX_DAEMON_PROCESS"] = "1"
+    from ..embedding_backend import EmbeddingBackend
+
+    _backend = EmbeddingBackend()
+    _backend.load()
+    logger.info(f"Daemon: 模型已加载 ({_backend.model_name})")
+
+
+# =============================================================================
+# 请求/响应模型
+# =============================================================================
+
+
+class HealthResponse(BaseModel):
+    status: str
+    model: str
+    dimension: int
+    pid: int
+
+
+class EncodeRequest(BaseModel):
+    texts: List[str]
+    batch_size: int = 32
+
+
+class EncodeResponse(BaseModel):
+    embeddings: List[List[float]]
+    dimension: int
+
+
+class EncodeSingleRequest(BaseModel):
+    text: str
+
+
+class EncodeSingleResponse(BaseModel):
+    embedding: List[float]
+    dimension: int
+
+
+# =============================================================================
+# API 端点
+# =============================================================================
+
+
+@app.get("/health", response_model=HealthResponse)
+def health():
+    """健康检查"""
+    return HealthResponse(
+        status="ok",
+        model=_backend.model_name,
+        dimension=_backend.dimension,
+        pid=os.getpid(),
+    )
+
+
+@app.post("/encode", response_model=EncodeResponse)
+def encode(req: EncodeRequest):
+    """批量文本编码"""
+    embeddings = _backend.encode(req.texts, batch_size=req.batch_size)
+    return EncodeResponse(
+        embeddings=embeddings.tolist(),
+        dimension=_backend.dimension,
+    )
+
+
+@app.post("/encode_single", response_model=EncodeSingleResponse)
+def encode_single(req: EncodeSingleRequest):
+    """单文本编码"""
+    embedding = _backend.encode_single(req.text)
+    return EncodeSingleResponse(
+        embedding=embedding.tolist(),
+        dimension=_backend.dimension,
+    )
+
+
+# =============================================================================
+# 入口
+# =============================================================================
+
+
+def main():
+    from . import DEFAULT_HOST, DEFAULT_PORT
+
+    parser = argparse.ArgumentParser(description="JFox Embedding Daemon")
+    parser.add_argument("--host", default=DEFAULT_HOST, help="监听地址")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="监听端口")
+    args = parser.parse_args()
+
+    import uvicorn
+
+    uvicorn.run(app, host=args.host, port=args.port, log_level="warning")
+
+
+if __name__ == "__main__":
+    main()

--- a/jfox/daemon/server.py
+++ b/jfox/daemon/server.py
@@ -29,8 +29,12 @@ def _load_model():
     from ..embedding_backend import EmbeddingBackend
 
     _backend = EmbeddingBackend()
-    _backend.load()
-    logger.info(f"Daemon: 模型已加载 ({_backend.model_name})")
+    try:
+        _backend.load()
+        logger.info(f"Daemon: 模型已加载 ({_backend.model_name})")
+    except Exception as e:
+        logger.error(f"Daemon: 模型加载失败，进程退出: {e}")
+        os._exit(1)
 
 
 # =============================================================================

--- a/jfox/embedding_backend.py
+++ b/jfox/embedding_backend.py
@@ -1,6 +1,7 @@
-"""Embedding Backend - CPU Only (Simplified)"""
+"""Embedding Backend - 支持 daemon 加速"""
 
 import logging
+import os
 from typing import List, Optional
 
 import numpy as np
@@ -9,28 +10,69 @@ logger = logging.getLogger(__name__)
 
 
 class EmbeddingBackend:
-    """Simple CPU-based embedding backend"""
+    """嵌入模型后端（支持 daemon 代理）"""
 
     def __init__(self, model_name: str = "sentence-transformers/all-MiniLM-L6-v2"):
         self.model_name = model_name
         self.model = None
+        self._daemon_client = None  # 延迟初始化
+        self._use_daemon: Optional[bool] = None  # None=未检测
+
+    def _check_daemon(self) -> bool:
+        """检测是否使用 daemon（仅检测一次，缓存结果）"""
+        if self._use_daemon is not None:
+            return self._use_daemon
+
+        # daemon 进程内不应连接自己
+        if os.environ.get("JFOX_DAEMON_PROCESS"):
+            self._use_daemon = False
+            return False
+
+        try:
+            from .daemon.process import _get_daemon_url, is_daemon_running
+
+            if is_daemon_running():
+                from .daemon.client import DaemonClient
+
+                url = _get_daemon_url()
+                client = DaemonClient(url)
+                if client.available:
+                    self._daemon_client = client
+                    self._use_daemon = True
+                    logger.info("使用远程 embedding daemon")
+                    return True
+        except Exception:
+            pass
+
+        self._use_daemon = False
+        return False
 
     def load(self):
-        """Load the model"""
+        """加载模型"""
         if self.model is not None:
             return
+        if self._check_daemon():
+            return  # daemon 已持有模型，无需本地加载
 
         try:
             from sentence_transformers import SentenceTransformer
 
             self.model = SentenceTransformer(self.model_name)
-            logger.info(f"Model loaded: {self.model_name}")
+            logger.info(f"模型已加载: {self.model_name}")
         except Exception as e:
-            logger.error(f"Failed to load model: {e}")
+            logger.error(f"加载模型失败: {e}")
             raise
 
     def encode(self, texts: List[str], batch_size: int = 32) -> np.ndarray:
-        """Encode texts to embeddings"""
+        """文本编码（优先使用 daemon）"""
+        # 优先使用 daemon
+        if self._check_daemon() and self._daemon_client is not None:
+            try:
+                return self._daemon_client.encode(texts, batch_size=batch_size)
+            except Exception as e:
+                logger.warning(f"Daemon 编码失败，回退到本地: {e}")
+                self._use_daemon = False
+
         if self.model is None:
             self.load()
 
@@ -39,16 +81,16 @@ class EmbeddingBackend:
                 texts, batch_size=batch_size, show_progress_bar=False, convert_to_numpy=True
             )
         except Exception as e:
-            logger.error(f"Encoding failed: {e}")
+            logger.error(f"编码失败: {e}")
             raise
 
     def encode_single(self, text: str) -> np.ndarray:
-        """Encode a single text"""
+        """单文本编码"""
         return self.encode([text])[0]
 
     @property
     def dimension(self) -> int:
-        """Return embedding dimension"""
+        """返回嵌入维度"""
         return 384
 
 
@@ -57,8 +99,14 @@ _backend: Optional[EmbeddingBackend] = None
 
 
 def get_backend() -> EmbeddingBackend:
-    """Get global embedding backend instance"""
+    """获取全局 embedding 后端实例"""
     global _backend
     if _backend is None:
         _backend = EmbeddingBackend()
     return _backend
+
+
+def reset_backend():
+    """重置全局 embedding 后端（用于测试或特殊场景）"""
+    global _backend
+    _backend = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,14 @@ dev = [
     "pytest-cov>=4.0",
     "pytest-xdist>=3.0",       # 并行测试加速
     "pytest-timeout>=2.0",     # 超时控制
-    
+
     # 代码质量
     "black>=23.0",
     "ruff>=0.1.0",
+]
+daemon = [
+    "fastapi>=0.110.0",
+    "uvicorn[standard]>=0.27.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -580,6 +580,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.135.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98", size = 117734, upload-time = "2026-04-01T16:23:59.328Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -868,6 +884,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+daemon = [
+    { name = "fastapi" },
+    { name = "uvicorn", extra = ["standard"] },
+]
 dev = [
     { name = "black" },
     { name = "pytest" },
@@ -881,6 +901,7 @@ dev = [
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0" },
     { name = "chromadb", specifier = ">=0.5.0" },
+    { name = "fastapi", marker = "extra == 'daemon'", specifier = ">=0.110.0" },
     { name = "jinja2", specifier = ">=3.0" },
     { name = "networkx", specifier = ">=3.0" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -894,9 +915,10 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "sentence-transformers", specifier = ">=3.0" },
     { name = "typer", specifier = ">=0.12.0" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'daemon'", specifier = ">=0.27.0" },
     { name = "watchdog", specifier = ">=3.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "daemon"]
 
 [[package]]
 name = "jinja2"
@@ -3021,6 +3043,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Closes #140

- 新增 `jfox daemon start/stop/status` 命令，后台常驻 sentence-transformers 模型
- CLI 命令通过 HTTP 复用已加载模型，embedding 操作从 10s+ 降到 ~0.2s
- daemon 未运行时自动 fallback 到本地加载，向后兼容

## 改动

**新增文件：**
- `jfox/daemon/server.py` — FastAPI 服务端（/health, /encode, /encode_single）
- `jfox/daemon/client.py` — HTTP 客户端，接口与 EmbeddingBackend 一致
- `jfox/daemon/process.py` — 进程管理（start/stop/status + PID 文件）
- `jfox/daemon/__init__.py` / `__main__.py` — 包入口

**修改文件：**
- `jfox/embedding_backend.py` — `get_backend()` 支持 daemon 优先 + 本地 fallback
- `jfox/cli.py` — 新增 `daemon` 命令
- `pyproject.toml` — 新增 `[daemon]` 可选依赖（fastapi + uvicorn）

## 验证结果

- [x] `jfox daemon start` — 启动成功，模型加载完毕（~8s）
- [x] `jfox daemon status` — 正确显示 PID、端口、模型、维度
- [x] 通过 daemon 编码 — 0.174s（vs 本地 18.8s）
- [x] `jfox daemon stop` — 正确停止
- [x] daemon 关闭后 fallback — 正常，行为不变
- [x] lint (ruff) + format (black) 通过

## Test plan
- [ ] 手动：`jfox daemon start` → `jfox search` → `jfox daemon stop` → `jfox search`（验证 fallback）
- [ ] 手动：Windows 开机自启（Task Scheduler）配置验证
- [ ] 后续：添加 daemon 单元测试（mock HTTP client）

🤖 Generated with [Claude Code](https://claude.com/claude-code)