### PR TITLE
feat: add show command to view note content (#145)

### DIFF
--- a/docs/superpowers/specs/2026-04-14-show-command-design.md
+++ b/docs/superpowers/specs/2026-04-14-show-command-design.md
@@ -1,0 +1,44 @@
+# `jfox show` 命令设计
+
+## 问题
+
+jfox 缺少只读查看单条笔记完整内容的命令。现有命令要么只显示摘要（search），要么只列标题（list），要么会触发修改流程（edit）。
+
+## 方案
+
+新增 `jfox show <note_id_or_title> [--kb <name>]` 命令，直接输出原始 Markdown 文件内容。
+
+### 输入
+
+- 必选参数：笔记 ID 或标题
+- 复用 `find_note_id_by_title_or_id` 定位逻辑，优先级：精确 ID → 精确标题 → 标题包含
+- 可选 `--kb` 切换知识库
+
+### 输出
+
+- 直接 `print` 原始 Markdown 文件内容（frontmatter + body）
+- 不做任何格式化、高亮或截断
+- 找不到笔记时报错并 `exit(1)`
+
+### 不支持
+
+- 不支持 `--format`，纯 Markdown 输出
+- 不支持 `--json`
+
+## 实现
+
+仅修改 `cli.py`：
+
+1. 新增 `show` command 函数，参数：`note_ref: str`（必选）、`--kb`
+2. 新增 `_show_impl(note_ref)` helper：
+   - 调用 `find_note_id_by_title_or_id` 定位笔记
+   - 调用 `note.load_note_by_id` 加载笔记
+   - `note.filepath.read_text(encoding='utf-8')` → `print`
+3. 遵循现有命令模式（`@app.command()` → `_xxx_impl` helper + `--kb` 支持）
+
+不涉及 `note.py`、`models.py`、`formatters.py` 的修改。
+
+## 测试
+
+- 快速单元测试：mock `load_note_by_id`，验证正确输出 Markdown 内容
+- 边界情况：笔记不存在时的错误处理

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -746,6 +746,48 @@ def list(
         raise typer.Exit(1)
 
 
+def _show_impl(note_ref: str):
+    """查看笔记完整内容的内部实现"""
+    # 通过 ID 或标题定位笔记
+    note_id = find_note_id_by_title_or_id(note_ref)
+    if not note_id:
+        raise ValueError(f"笔记不存在: {note_ref}")
+
+    # 加载笔记
+    n = note.load_note_by_id(note_id)
+    if not n:
+        raise ValueError(f"笔记不存在: {note_id}")
+
+    # 输出原始 Markdown 内容
+    content = n.filepath.read_text(encoding="utf-8")
+    print(content)
+
+
+@app.command()
+def show(
+    note_ref: str = typer.Argument(..., help="笔记 ID 或标题"),
+    kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
+):
+    """
+    查看笔记完整内容
+
+    输出原始 Markdown（含 YAML frontmatter），只读不修改。
+    支持通过笔记 ID 或标题定位。
+    """
+    try:
+        if kb:
+            from .config import use_kb
+
+            with use_kb(kb):
+                _show_impl(note_ref)
+        else:
+            _show_impl(note_ref)
+
+    except Exception as e:
+        console.print(f"[red]✗[/red] Error: {e}")
+        raise typer.Exit(1)
+
+
 def _refs_impl(
     note_id: Optional[str],
     search: Optional[str],

--- a/tests/unit/test_show.py
+++ b/tests/unit/test_show.py
@@ -49,10 +49,10 @@ class TestShowCommand:
         mock_note.filepath.read_text.return_value = "---\nid: test\n---\n笔记内容"
         mock_load.return_value = mock_note
 
-        from jfox.cli import _show_impl
-
         import io
         import sys
+
+        from jfox.cli import _show_impl
 
         captured = io.StringIO()
         sys.stdout = captured

--- a/tests/unit/test_show.py
+++ b/tests/unit/test_show.py
@@ -1,0 +1,73 @@
+"""Unit tests for show command"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from jfox.cli import app
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+runner = CliRunner()
+
+
+class TestShowCommand:
+    """测试 show 命令"""
+
+    @patch("jfox.cli._show_impl")
+    def test_show_calls_impl(self, mock_impl):
+        """测试 show 命令调用 _show_impl"""
+        result = runner.invoke(app, ["show", "202604141200001234"])
+        assert result.exit_code == 0
+        mock_impl.assert_called_once_with("202604141200001234")
+
+    @patch("jfox.cli._show_impl", side_effect=ValueError("笔记不存在: xxx"))
+    def test_show_not_found(self, mock_impl):
+        """测试笔记不存在时的错误处理"""
+        result = runner.invoke(app, ["show", "xxx"])
+        assert result.exit_code != 0
+
+    @patch("jfox.cli._show_impl")
+    def test_show_with_kb(self, mock_impl):
+        """测试 --kb 参数传递"""
+        # use_kb 在 show 函数内部通过 `from .config import use_kb` 导入，
+        # 因此需要在 jfox.config 模块上打补丁
+        with patch("jfox.config.use_kb") as mock_use_kb:
+            mock_use_kb.return_value.__enter__ = MagicMock()
+            mock_use_kb.return_value.__exit__ = MagicMock(return_value=False)
+            result = runner.invoke(app, ["show", "test-note", "--kb", "mykb"])
+            assert result.exit_code == 0
+            mock_use_kb.assert_called_once_with("mykb")
+
+    @patch("jfox.cli.note.load_note_by_id")
+    @patch("jfox.cli.find_note_id_by_title_or_id")
+    def test_show_impl_reads_file(self, mock_find, mock_load):
+        """测试 _show_impl 读取并输出文件内容"""
+        mock_find.return_value = "202604141200001234"
+        mock_note = MagicMock()
+        mock_note.filepath.read_text.return_value = "---\nid: test\n---\n笔记内容"
+        mock_load.return_value = mock_note
+
+        from jfox.cli import _show_impl
+
+        import io
+        import sys
+
+        captured = io.StringIO()
+        sys.stdout = captured
+        try:
+            _show_impl("测试笔记")
+        finally:
+            sys.stdout = sys.__stdout__
+
+        assert "笔记内容" in captured.getvalue()
+        mock_note.filepath.read_text.assert_called_once_with(encoding="utf-8")
+
+    @patch("jfox.cli.find_note_id_by_title_or_id", return_value=None)
+    def test_show_impl_not_found(self, mock_find):
+        """测试 _show_impl 笔记不存在时抛出异常"""
+        from jfox.cli import _show_impl
+
+        with pytest.raises(ValueError, match="nonexistent"):
+            _show_impl("nonexistent")

--- a/tests/unit/test_show.py
+++ b/tests/unit/test_show.py
@@ -1,4 +1,4 @@
-"""Unit tests for show command"""
+"""测试类型: 单元测试 / 目标模块: jfox.cli (show 命令)"""
 
 from unittest.mock import MagicMock, patch
 


### PR DESCRIPTION
## Summary
- 新增 `jfox show <note_id_or_title>` 命令，只读查看单条笔记完整 Markdown 内容
- 支持通过 ID 或标题定位笔记（复用 `find_note_id_by_title_or_id`）
- 支持 `--kb` 切换知识库
- 5 个单元测试全部通过

## Test plan
- [x] `uv run jfox show --help` 显示帮助信息
- [x] `uv run jfox --help` 列表中包含 show
- [x] `uv run pytest tests/unit/test_show.py -v` — 5 passed

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)