### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/jfox/__init__.py
+++ b/jfox/__init__.py
@@ -1,5 +1,5 @@
 """JFox - Zettelkasten 知识管理工具"""
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"
 __author__ = "User"
 __email__ = "user@example.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jfox-cli"
-version = "0.2.2"
+version = "0.3.0"
 description = "JFox - Zettelkasten 知识管理 CLI 工具"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -867,7 +867,7 @@ wheels = [
 
 [[package]]
 name = "jfox-cli"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary
- Bump version from 0.2.2 to 0.3.0 (two new features: `jfox daemon` and `jfox show`)
- Updated `pyproject.toml`, `jfox/__init__.py`, and `uv.lock`

## Test plan
- [ ] `uv run jfox --version` returns 0.3.0
- [ ] `uv sync` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)