### PR TITLE
fix: suppress console window on Windows daemon start

### DIFF
--- a/jfox/daemon/process.py
+++ b/jfox/daemon/process.py
@@ -115,7 +115,8 @@ def start_daemon(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> bool:
         # Windows: 后台分离进程，不弹窗
         CREATE_NEW_PROCESS_GROUP = 0x00000200
         DETACHED_PROCESS = 0x00000008
-        kwargs["creationflags"] = CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS
+        CREATE_NO_WINDOW = 0x08000000
+        kwargs["creationflags"] = CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS | CREATE_NO_WINDOW
     else:
         kwargs["start_new_session"] = True
 


### PR DESCRIPTION
## Summary
- Add `CREATE_NO_WINDOW` flag (`0x08000000`) to subprocess `creationflags` in `start_daemon()` to prevent a console window from appearing when running `jfox daemon start` on Windows

## Test plan
- [ ] On Windows, run `jfox daemon start` and verify no console window appears
- [ ] Verify daemon starts and responds to health check normally
- [ ] Verify `jfox daemon stop` still works correctly

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)