### PR TITLE
feat(skill): add user confirmation and note type selection to session-summary

### DIFF
--- a/docs/superpowers/plans/2026-04-15-session-summary-confirmation.md
+++ b/docs/superpowers/plans/2026-04-15-session-summary-confirmation.md
@@ -1,0 +1,135 @@
+# Session Summary Confirmation Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add user confirmation and note type selection steps to the jfox-session-summary skill before writing to the knowledge base.
+
+**Architecture:** Insert two new steps (confirm content + select type) between summary generation and `jfox add`. The modification is purely in the skill Markdown document — no Python code changes.
+
+**Tech Stack:** Skill document (Markdown), AskUserQuestion tool
+
+**Spec:** `docs/superpowers/specs/2026-04-15-session-summary-confirmation-design.md`
+
+---
+
+### Task 1: Rewrite SKILL.md workflow section
+
+**Files:**
+- Modify: `skills-recommend/claude-code/jfox-session-summary/SKILL.md`
+
+This is the only task. The file is a single skill document — no decomposition needed.
+
+- [ ] **Step 1: Read current SKILL.md**
+
+Read `skills-recommend/claude-code/jfox-session-summary/SKILL.md` to confirm current content matches expectations (3-step workflow, Step 2 hardcodes `--type fleeting`).
+
+- [ ] **Step 2: Replace Step 2 and add new Steps 2–3**
+
+Replace the entire `### Step 2: 写入知识库` section and everything after it (through end of file) with the new 5-step workflow. The exact replacement content:
+
+Replace the old `### Step 2` and `### Step 3` sections (lines 42–96) with:
+
+```markdown
+### Step 2: 用户确认
+
+将生成的总结用普通文本输出，供用户阅读。然后使用 `AskUserQuestion` 询问：
+
+- 问题：`笔记内容是否 OK？`
+- 选项：
+  - `内容没问题` → 继续 Step 3
+  - `需要修改` → 用户在 "Other" 中输入修改意见，根据意见调整总结后回到 Step 2 重新展示和确认
+
+循环直到用户满意为止。
+
+### Step 3: 选择笔记类型
+
+用户确认内容后，使用 `AskUserQuestion` 询问笔记类型：
+
+- 问题：`选择笔记类型`
+- 选项：
+  - `fleeting`（推荐）— 会话记录是临时性笔记，后续可提炼为 permanent
+  - `literature` — 如果会话有明确的参考资料来源
+  - `permanent` — 如果总结已经是成熟的知识
+
+### Step 4: 写入知识库
+
+使用 Step 3 选定的笔记类型执行写入：
+
+```bash
+jfox add "<markdown-escaped-summary>" \
+  --title "Session: <topic>" \
+  --type <Step 3 选定的类型> \
+  --tag session \
+  --kb <kb-name> \
+  --format json
+```
+
+**注意**：
+- 标题格式统一为 `Session: <简短主题>`
+- 类型使用 Step 3 的选择结果，不再硬编码 `fleeting`
+- 标签统一使用 `session`
+- 内容中的双引号需要转义，或使用 `--content-file` 从临时文件读取
+
+### Step 5: 处理长内容
+
+如果总结超过 500 字或包含特殊字符，优先使用 `--content-file`：
+
+```bash
+# 写入临时文件
+cat > /tmp/session-summary.md << 'EOF'
+<总结内容>
+EOF
+
+# 从文件导入
+jfox add --content-file /tmp/session-summary.md \
+  --title "Session: <topic>" \
+  --type <Step 3 选定的类型> \
+  --tag session \
+  --kb <kb-name> \
+  --format json
+```
+
+## 命令参考
+
+```bash
+# 直接添加（短内容）
+jfox add "<summary>" --title "Session: <topic>" --type <type> --tag session --kb <name>
+
+# 从文件添加（长内容或含特殊字符）
+jfox add --content-file <path> --title "Session: <topic>" --type <type> --tag session --kb <name>
+
+# 验证写入
+jfox show <note_id> --format json
+```
+
+## 错误处理
+
+- **"Knowledge base not found"**: 提示用户先运行 `/jfox-common` 创建知识库
+- **内容过长导致 shell 解析失败**: 切换到 `--content-file` 方式
+- **特殊字符转义问题**: 使用单引号包裹内容，或写入临时文件
+```
+
+- [ ] **Step 3: Verify the file reads correctly**
+
+Read the full updated `SKILL.md` and confirm:
+1. Step 1 (生成会话总结) is unchanged
+2. Step 2 (用户确认) has AskUserQuestion with "内容没问题" and "需要修改" options, plus loop description
+3. Step 3 (选择笔记类型) has AskUserQuestion with fleeting/literature/permanent options
+4. Step 4 (写入知识库) uses `<Step 3 选定的类型>` not hardcoded `fleeting`
+5. Step 5 (处理长内容) also uses `<Step 3 选定的类型>`
+6. 命令参考 section shows `--type <type>` not `--type fleeting`
+7. No leftover hardcoded `fleeting` in any `jfox add` example (except the Step 3 option description)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills-recommend/claude-code/jfox-session-summary/SKILL.md
+git commit -m "feat(skill): add user confirmation and note type selection to session-summary
+
+Inserts Step 2 (content confirmation via AskUserQuestion) and Step 3
+(note type selection) before writing to knowledge base. Users can now
+review the generated summary, request modifications, and choose between
+fleeting/literature/permanent note types.
+
+Closes #154"
+```

--- a/docs/superpowers/specs/2026-04-15-session-summary-confirmation-design.md
+++ b/docs/superpowers/specs/2026-04-15-session-summary-confirmation-design.md
@@ -1,0 +1,52 @@
+# jfox-session-summary 用户确认流程设计
+
+**Date**: 2026-04-15
+**Issue**: #154
+**Status**: Draft
+
+## 背景
+
+当前 `jfox-session-summary` skill 生成总结后直接写入知识库，硬编码 `--type fleeting`。用户无法审查内容或选择笔记类型。
+
+## 改动范围
+
+仅修改 `skills-recommend/claude-code/jfox-session-summary/SKILL.md`。不涉及 CLI 命令或 Python 代码变更。
+
+## 新流程
+
+当前 3 步扩展为 5 步：
+
+| Step | 内容 | 状态 |
+|------|------|------|
+| Step 1 | 生成会话总结 | 不变 |
+| Step 2 | 展示总结 + 用户确认 | **新增** |
+| Step 3 | 选择笔记类型 | **新增** |
+| Step 4 | `jfox add --type <选择>` | 原 Step 2 |
+| Step 5 | 处理长内容 | 原 Step 3，不变 |
+
+### Step 2：展示总结 + 用户确认
+
+1. 用普通文本输出完整总结内容，供用户阅读
+2. 使用 `AskUserQuestion` 询问「笔记内容是否 OK？」
+   - **内容没问题** → 继续 Step 3
+   - **需要修改** → 用户在 Other 中输入修改意见 → 根据意见调整总结 → 回到 Step 2 重新展示和确认
+3. 循环直到用户满意为止
+
+### Step 3：选择笔记类型
+
+使用 `AskUserQuestion` 询问「选择笔记类型」：
+
+- **fleeting**（推荐）— 会话记录是临时性笔记，后续可提炼为 permanent
+- **literature** — 会话有明确的参考资料来源
+- **permanent** — 总结已经是成熟的知识
+
+### Step 4：写入知识库
+
+`jfox add` 的 `--type` 参数使用 Step 3 的选择结果，不再硬编码 `fleeting`。其余参数（`--title`、`--tag session`、`--kb`）不变。
+
+## 不在范围内
+
+- 不修改 `jfox add` CLI 命令本身
+- 不增加新的笔记类型
+- 不改变总结模板格式（Step 1 不变）
+- 不做自动检测笔记类型的智能逻辑

--- a/skills-recommend/claude-code/jfox-common/SKILL.md
+++ b/skills-recommend/claude-code/jfox-common/SKILL.md
@@ -339,7 +339,7 @@ jfox index rebuild                           # 重建索引
 jfox inbox --json --limit <N>                # 未处理笔记
 ```
 
-### Daemon（可选）
+### Daemon
 
 ```bash
 jfox daemon start                               # 启动 embedding 守护进程

--- a/skills-recommend/claude-code/jfox-session-summary/SKILL.md
+++ b/skills-recommend/claude-code/jfox-session-summary/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: jfox-session-summary
 description: |
-  Use when user wants to save the current conversation/session summary into their Zettelkasten as a fleeting note. Triggers on "保存会话", "总结到知识库", "记录这次对话", "写入知识库", "save session", "summarize to knowledge base", "log this conversation".
+  Use when user wants to save the current conversation/session summary into their Zettelkasten. Triggers on "保存会话", "总结到知识库", "记录这次对话", "写入知识库", "save session", "summarize to knowledge base", "log this conversation".
 ---
 
 # JFox Session Summary

--- a/skills-recommend/claude-code/jfox-session-summary/SKILL.md
+++ b/skills-recommend/claude-code/jfox-session-summary/SKILL.md
@@ -6,7 +6,7 @@ description: |
 
 # JFox Session Summary
 
-将当前 Claude Code 会话的总结写入 jfox 知识库作为 fleeting 笔记。
+将当前 Claude Code 会话的总结写入 jfox 知识库（支持用户确认和笔记类型选择）。
 
 ## 前置条件
 
@@ -39,12 +39,35 @@ description: |
 - [后续步骤]
 ```
 
-### Step 2: 写入知识库
+### Step 2: 用户确认
+
+将生成的总结用普通文本输出，供用户阅读。然后使用 `AskUserQuestion` 询问：
+
+- 问题：`笔记内容是否 OK？`
+- 选项：
+  - `内容没问题` → 继续 Step 3
+  - `需要修改` → 用户在 "Other" 中输入修改意见，根据意见调整总结后回到 Step 2 重新展示和确认
+
+循环直到用户满意为止。
+
+### Step 3: 选择笔记类型
+
+用户确认内容后，使用 `AskUserQuestion` 询问笔记类型：
+
+- 问题：`选择笔记类型`
+- 选项：
+  - `fleeting`（推荐）— 会话记录是临时性笔记，后续可提炼为 permanent
+  - `literature` — 如果会话有明确的参考资料来源
+  - `permanent` — 如果总结已经是成熟的知识
+
+### Step 4: 写入知识库
+
+使用 Step 3 选定的笔记类型执行写入：
 
 ```bash
 jfox add "<markdown-escaped-summary>" \
   --title "Session: <topic>" \
-  --type fleeting \
+  --type <Step 3 选定的类型> \
   --tag session \
   --kb <kb-name> \
   --format json
@@ -52,11 +75,11 @@ jfox add "<markdown-escaped-summary>" \
 
 **注意**：
 - 标题格式统一为 `Session: <简短主题>`
-- 类型使用 `fleeting`（会话记录是临时性笔记，后续可提炼为 permanent）
+- 类型使用 Step 3 的选择结果，不再硬编码 `fleeting`
 - 标签统一使用 `session`
 - 内容中的双引号需要转义，或使用 `--content-file` 从临时文件读取
 
-### Step 3: 处理长内容
+### Step 5: 处理长内容
 
 如果总结超过 500 字或包含特殊字符，优先使用 `--content-file`：
 
@@ -69,7 +92,7 @@ EOF
 # 从文件导入
 jfox add --content-file /tmp/session-summary.md \
   --title "Session: <topic>" \
-  --type fleeting \
+  --type <Step 3 选定的类型> \
   --tag session \
   --kb <kb-name> \
   --format json
@@ -79,10 +102,10 @@ jfox add --content-file /tmp/session-summary.md \
 
 ```bash
 # 直接添加（短内容）
-jfox add "<summary>" --title "Session: <topic>" --type fleeting --tag session --kb <name>
+jfox add "<summary>" --title "Session: <topic>" --type <type> --tag session --kb <name>
 
 # 从文件添加（长内容或含特殊字符）
-jfox add --content-file <path> --title "Session: <topic>" --type fleeting --tag session --kb <name>
+jfox add --content-file <path> --title "Session: <topic>" --type <type> --tag session --kb <name>
 
 # 验证写入
 jfox show <note_id> --format json


### PR DESCRIPTION
## Summary

- Add Step 2 (user confirmation via AskUserQuestion) and Step 3 (note type selection) before writing to knowledge base
- Users can now review the generated summary, request modifications, and choose between fleeting/literature/permanent
- Remove hardcoded `--type fleeting` from all `jfox add` examples
- Update skill description to reflect the new confirmation flow

## Test plan

- [ ] Verify SKILL.md reads correctly with 5-step workflow
- [ ] Confirm no leftover hardcoded `--type fleeting` in any `jfox add` example
- [ ] Test the skill in a Claude Code session: trigger session-summary, verify AskUserQuestion prompts appear

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)