### PR TITLE
fix(daemon): use pythonw.exe to prevent console window on Windows

### DIFF
--- a/jfox/daemon/process.py
+++ b/jfox/daemon/process.py
@@ -124,8 +124,8 @@ def start_daemon(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> bool:
         )
         return True
 
-    # 构建启动命令
-    cmd = [sys.executable, "-m", "jfox.daemon.server", "--host", host, "--port", str(port)]
+    # 构建启动命令（Windows 使用 pythonw.exe 避免控制台窗口）
+    cmd = [_get_pythonw_executable(), "-m", "jfox.daemon.server", "--host", host, "--port", str(port)]
 
     kwargs = {}
     if sys.platform == "win32":

--- a/jfox/daemon/process.py
+++ b/jfox/daemon/process.py
@@ -125,7 +125,12 @@ def start_daemon(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> bool:
         return True
 
     # 构建启动命令（Windows 使用 pythonw.exe 避免控制台窗口）
-    cmd = [_get_pythonw_executable(), "-m", "jfox.daemon.server", "--host", host, "--port", str(port)]
+    cmd = [
+        _get_pythonw_executable(),
+        "-m", "jfox.daemon.server",
+        "--host", host,
+        "--port", str(port),
+    ]
 
     kwargs = {}
     if sys.platform == "win32":

--- a/jfox/daemon/process.py
+++ b/jfox/daemon/process.py
@@ -127,9 +127,12 @@ def start_daemon(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> bool:
     # 构建启动命令（Windows 使用 pythonw.exe 避免控制台窗口）
     cmd = [
         _get_pythonw_executable(),
-        "-m", "jfox.daemon.server",
-        "--host", host,
-        "--port", str(port),
+        "-m",
+        "jfox.daemon.server",
+        "--host",
+        host,
+        "--port",
+        str(port),
     ]
 
     kwargs = {}

--- a/jfox/daemon/process.py
+++ b/jfox/daemon/process.py
@@ -16,6 +16,23 @@ from typing import Optional
 
 from . import DEFAULT_HOST, DEFAULT_PORT
 
+
+def _get_pythonw_executable() -> str:
+    """获取 pythonw.exe 路径（Windows 无控制台入口）
+
+    Windows 上优先使用 pythonw.exe 避免 daemon 子进程弹出控制台窗口。
+    如果 pythonw.exe 不存在则回退到 sys.executable。
+    非 Windows 平台直接返回 sys.executable。
+    """
+    if sys.platform != "win32":
+        return sys.executable
+
+    pythonw = sys.executable.replace("python.exe", "pythonw.exe")
+    if pythonw != sys.executable and Path(pythonw).exists():
+        return pythonw
+    return sys.executable
+
+
 logger = logging.getLogger(__name__)
 
 STARTUP_TIMEOUT = 60  # 模型加载可能较慢

--- a/tests/unit/test_daemon_process.py
+++ b/tests/unit/test_daemon_process.py
@@ -41,3 +41,45 @@ class TestGetPythonwExecutable:
             mock_sys.executable = "/usr/bin/python3"
             result = _get_pythonw_executable()
             assert result == "/usr/bin/python3"
+
+
+class TestStartDaemonWindowsExecutable:
+    """测试 start_daemon 在 Windows 上使用 pythonw.exe"""
+
+    @patch("jfox.daemon.process.subprocess.Popen")
+    @patch("jfox.daemon.process._http_health_check")
+    def test_uses_pythonw_on_windows(self, mock_health, mock_popen):
+        """Windows 上 start_daemon 使用 pythonw.exe 启动子进程"""
+        if sys.platform != "win32":
+            pytest.skip("Windows only")
+
+        from jfox.daemon.process import start_daemon
+
+        # daemon 未运行 → 启动新进程
+        mock_health.side_effect = [None, {"pid": 9999}]
+        mock_popen.return_value.pid = 1234
+
+        start_daemon()
+
+        call_args = mock_popen.call_args
+        cmd = call_args[0][0]
+        assert cmd[0].endswith("pythonw.exe"), f"Expected pythonw.exe, got {cmd[0]}"
+
+    @patch("jfox.daemon.process.subprocess.Popen")
+    @patch("jfox.daemon.process._http_health_check")
+    def test_creationflags_present(self, mock_health, mock_popen):
+        """Windows 上 creationflags 包含 CREATE_NO_WINDOW"""
+        if sys.platform != "win32":
+            pytest.skip("Windows only")
+
+        from jfox.daemon.process import start_daemon
+
+        mock_health.side_effect = [None, {"pid": 9999}]
+        mock_popen.return_value.pid = 1234
+
+        start_daemon()
+
+        kwargs = mock_popen.call_args[1]
+        flags = kwargs.get("creationflags", 0)
+        CREATE_NO_WINDOW = 0x08000000
+        assert flags & CREATE_NO_WINDOW, "CREATE_NO_WINDOW flag not set"

--- a/tests/unit/test_daemon_process.py
+++ b/tests/unit/test_daemon_process.py
@@ -1,4 +1,5 @@
 """Daemon 进程管理单元测试"""
+
 import sys
 from unittest.mock import patch
 

--- a/tests/unit/test_daemon_process.py
+++ b/tests/unit/test_daemon_process.py
@@ -16,7 +16,7 @@ class TestGetPythonwExecutable:
         from jfox.daemon.process import _get_pythonw_executable
 
         result = _get_pythonw_executable()
-        assert result.endswith("pythonw.exe") or result.endswith("python.exe")
+        assert result.endswith("pythonw.exe"), f"Expected pythonw.exe, got {result}"
 
     def test_fallback_when_pythonw_missing(self):
         """pythonw.exe 不存在时回退到 python.exe"""

--- a/tests/unit/test_daemon_process.py
+++ b/tests/unit/test_daemon_process.py
@@ -1,0 +1,43 @@
+"""Daemon 进程管理单元测试"""
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+class TestGetPythonwExecutable:
+    """测试 _get_pythonw_executable 辅助函数"""
+
+    def test_returns_pythonw_on_windows(self):
+        """Windows 上返回 pythonw.exe"""
+        if sys.platform != "win32":
+            pytest.skip("Windows only")
+
+        from jfox.daemon.process import _get_pythonw_executable
+
+        result = _get_pythonw_executable()
+        assert result.endswith("pythonw.exe") or result.endswith("python.exe")
+
+    def test_fallback_when_pythonw_missing(self):
+        """pythonw.exe 不存在时回退到 python.exe"""
+        if sys.platform != "win32":
+            pytest.skip("Windows only")
+
+        from jfox.daemon.process import _get_pythonw_executable
+
+        with patch("jfox.daemon.process.Path") as mock_path_cls:
+            # 模拟 pythonw.exe 不存在
+            mock_path_instance = mock_path_cls.return_value
+            mock_path_instance.exists.return_value = False
+            result = _get_pythonw_executable()
+            assert result == sys.executable
+
+    def test_non_windows_returns_sys_executable(self):
+        """非 Windows 平台返回 sys.executable"""
+        from jfox.daemon.process import _get_pythonw_executable
+
+        with patch("jfox.daemon.process.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            mock_sys.executable = "/usr/bin/python3"
+            result = _get_pythonw_executable()
+            assert result == "/usr/bin/python3"


### PR DESCRIPTION
## Summary

- Windows 上 `jfox daemon start` 使用 `pythonw.exe` 替代 `python.exe` 启动 daemon 子进程，避免控制台窗口常驻
- 保留 `CREATE_NO_WINDOW` 标志作为双重保障
- `pythonw.exe` 不存在时自动回退到 `python.exe`

Closes #159

## Test plan

- [x] 5 个新单元测试全部通过（helper 逻辑 + start_daemon 集成）
- [ ] Windows 上手动验证：`jfox daemon start` 无控制台窗口
- [ ] `jfox daemon stop` 正常停止
- [ ] 非 Windows 平台行为不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)