### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/jfox/__init__.py
+++ b/jfox/__init__.py
@@ -1,5 +1,5 @@
 """JFox - Zettelkasten 知识管理工具"""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __author__ = "User"
 __email__ = "user@example.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jfox-cli"
-version = "0.4.0"
+version = "0.4.1"
 description = "JFox - Zettelkasten 知识管理 CLI 工具"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -867,7 +867,7 @@ wheels = [
 
 [[package]]
 name = "jfox-cli"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary
- Bump version from 0.4.0 to 0.4.1 for release
- Includes daemon startup timeout/log visibility fix (#162) and previous GPU embedding + Windows fixes

## Test plan
- [x] `uv lock` updated
- [x] `pyproject.toml` and `__init__.py` versions match

🤖 Generated with [Claude Code](https://claude.com/claude-code)