### PR TITLE
fix(cli): list 命令 table 输出显示完整 18 位笔记 ID

### DIFF
--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -787,7 +787,7 @@ def _list_impl(
 
         for n in notes:
             created_str = n.created.strftime("%Y-%m-%d") if n.created else ""
-            table.add_row(n.id[:14], n.title[:40], n.type.value, created_str)
+            table.add_row(n.id, n.title[:40], n.type.value, created_str)
 
         console.print(table)
     elif output_format == "tree":


### PR DESCRIPTION
## Summary
- `note.generate_id()` 生成 18 位 ID（`YYYYMMDDHHMMSS` + 4 位随机后缀），但 `_list_impl` 中 `n.id[:14]` 截断导致 table 输出缺少后 4 位随机数
- 去掉 `[:14]` 截断，直接显示完整 `n.id`

## Test plan
- [x] 确认 `generate_id()` 返回 18 位字符串（`note.py:14-25`）
- [ ] `jfox list` 验证 ID 显示为完整 18 位

🤖 Generated with [Claude Code](https://claude.com/claude-code)