### PR TITLE
feat: add Kimi CLI skill collection (#166)

### DIFF
--- a/skills-recommend/README.md
+++ b/skills-recommend/README.md
@@ -6,12 +6,18 @@
 
 ```
 skills-recommend/
-└── claude-code/          # Claude Code 专用 SKILL.md 格式
-    ├── jfox-ingest/      # 数据导入（git log / GitHub PR / Issues）
-    ├── jfox-organize/    # 知识库整理与提炼（fleeting → permanent）
-    ├── jfox-search/      # 知识库搜索与图谱查询
-    ├── jfox-session-summary/  # 会话总结写入知识库
-    └── jfox-common/      # 知识库管理 + 健康检查
+├── claude-code/          # Claude Code 专用 SKILL.md 格式
+│   ├── jfox-ingest/      # 数据导入（git log / GitHub PR / Issues）
+│   ├── jfox-organize/    # 知识库整理与提炼（fleeting → permanent）
+│   ├── jfox-search/      # 知识库搜索与图谱查询
+│   ├── jfox-session-summary/  # 会话总结写入知识库
+│   └── jfox-common/      # 知识库管理 + 健康检查
+└── kimi-cli/             # Kimi CLI 适配版 SKILL.md
+    ├── jfox-ingest/
+    ├── jfox-organize/
+    ├── jfox-search/
+    ├── jfox-session-summary/
+    └── jfox-common/
 ```
 
 ## 使用方法
@@ -35,15 +41,36 @@ cp -r skills-recommend/claude-code/jfox-search ~/.claude/skills/
 - `/jfox-search` — 搜索笔记、图谱查询、链接推荐
 - `/jfox-session-summary` — 将会话总结写入知识库作为 fleeting 笔记
 
-### OpenCode / Codex / Kimi CLI 等
+### Kimi CLI
 
-这些 Agent 的 skill/instruction 格式各不相同，但核心逻辑是通用的。参考 `claude-code/` 下的 SKILL.md 内容，将其适配为对应平台的格式：
+Kimi CLI 使用与 Claude Code 相同的 SKILL.md 格式，通过 `description` 中的关键词自然语言触发：
+
+```bash
+# 复制全部 skills
+mkdir -p ~/.config/agents/skills/
+cp -r skills-recommend/kimi-cli/* ~/.config/agents/skills/
+
+# 或复制单个 skill
+cp -r skills-recommend/kimi-cli/jfox-search ~/.config/agents/skills/
+```
+
+复制后 Kimi CLI 会根据对话内容自动触发对应的 skill：
+- **jfox-common** — 创建/管理知识库、健康检查
+- **jfox-ingest** — 从仓库导入 git log / PR / Issues 为 fleeting 笔记
+- **jfox-organize** — 整理知识库、提炼 permanent 笔记、生成 [[wiki links]]
+- **jfox-search** — 搜索笔记、图谱查询、链接推荐
+- **jfox-session-summary** — 将会话总结写入知识库作为 fleeting 笔记
+
+Kimi CLI 也兼容 `~/.kimi/skills/` 和 `~/.claude/skills/` 目录。
+
+### OpenCode / Codex / Cursor 等
+
+这些 Agent 的 skill/instruction 格式各不相同，但核心逻辑是通用的。参考 `claude-code/` 或 `kimi-cli/` 下的 SKILL.md 内容，将其适配为对应平台的格式：
 
 | 平台 | 适配方式 |
 |------|---------|
 | **OpenCode** | 将 SKILL.md 内容放入 agent 指令或 custom instruction |
 | **Codex** | 写入 `codex.md` 或 AGENTS.md 中的指令段落 |
-| **Kimi CLI** | 放入 `.claude/skills/` 目录（兼容 Claude Code 格式） |
 | **Cursor** | 写入 `.cursor/rules/` 下的 rule 文件 |
 | **其他** | 将命令参考和工作流提取为 system prompt 片段 |
 

--- a/skills-recommend/kimi-cli/jfox-common/SKILL.md
+++ b/skills-recommend/kimi-cli/jfox-common/SKILL.md
@@ -1,0 +1,314 @@
+---
+name: jfox-common
+description: |
+  Manage and maintain Zettelkasten knowledge bases through jfox CLI.
+  Use when user wants to create a knowledge base, switch between knowledge bases, check knowledge base status, run health checks, diagnose problems, or perform any knowledge base management operations.
+  Triggers on: "创建知识库", "初始化", "知识库管理", "检查知识库", "知识库健康", "知识库体检", "health check", "create knowledge base", "init", "kb management", "知识库诊断", "switch kb", "list kb", "remove kb".
+---
+
+# JFox Knowledge Base Management & Health Check
+
+Manage the full lifecycle of knowledge bases: create, switch, inspect status, and run periodic health checks with decay signal detection.
+
+## Prerequisites
+
+Confirm jfox is installed:
+```bash
+jfox --version
+```
+If not installed: `uv tool install jfox-cli`
+
+## Knowledge Base Path Convention
+
+All knowledge bases live under `~/.zettelkasten/`:
+
+| Command | KB Name | Path |
+|---------|---------|------|
+| `jfox init` | default | `~/.zettelkasten/default/` |
+| `jfox init --name work` | work | `~/.zettelkasten/work/` |
+| `jfox init --name research` | research | `~/.zettelkasten/research/` |
+
+Custom paths must be under `~/.zettelkasten/` (enforced by CLI).
+
+## Knowledge Base Management
+
+### List Existing Knowledge Bases
+
+```bash
+jfox kb list --format json
+```
+
+If knowledge bases exist, inform the user and ask whether to use an existing one or create a new one.
+
+### Create Knowledge Base
+
+**Default (first-time use):**
+```bash
+jfox init
+```
+
+**Named knowledge base:**
+```bash
+jfox init --name <name> --desc "<description>"
+```
+
+Examples:
+```bash
+jfox init --name work --desc "Work notes"
+jfox init --name research --desc "Research notes"
+jfox init --name personal --desc "Personal knowledge base"
+```
+
+**Custom path (must be under ~/.zettelkasten/):**
+```bash
+jfox init --name <name> --path ~/.zettelkasten/<custom-path>
+```
+
+### Verify After Creation
+
+```bash
+jfox kb current --format json
+jfox status --format json
+```
+
+Confirm the KB is registered, directory structure is created, and status shows 0 notes.
+
+### Management Commands
+
+```bash
+jfox kb switch <name>               # Switch active KB
+jfox kb info <name> --format json   # View details
+jfox kb current --format json       # Current KB
+jfox kb rename <old> <new>          # Rename
+jfox kb remove <name>               # Unregister (keep files)
+jfox kb remove <name> --force       # Delete (irreversible)
+```
+
+## Note CRUD
+
+### Add Note
+
+```bash
+# Quick add
+jfox add "Note content with [[Other Note Title]] links" --title "Note Title"
+
+# Specify type and tags
+jfox add "Content" --title "Title" --type permanent --tag design --tag backend
+
+# From file (v0.2.1+, for long text)
+jfox add --content-file notes/draft.md --title "Title" --type literature
+
+# From stdin
+cat notes.txt | jfox add --content-file - --title "Title"
+
+# Use template
+jfox add --template meeting --title "Weekly Meeting Notes"
+```
+
+Note types:
+- `fleeting` (default) — quick capture, refine later
+- `literature` — reading notes
+- `permanent` — distilled knowledge
+
+### Edit Note
+
+```bash
+jfox edit <note_id> --content "New content" --title "New Title"
+jfox edit <note_id> --content-file updated.md
+jfox edit <note_id> --tag new-tag1 --tag new-tag2 --type permanent
+jfox edit <note_id> --kb work --content "New content"
+```
+
+Editing preserves original note ID and creation time.
+
+### Delete Note
+
+```bash
+jfox delete <note_id>               # Confirm required
+jfox delete <note_id> --force       # Skip confirmation
+```
+
+### List & View Notes
+
+```bash
+jfox list --format json --limit 50
+jfox list --type permanent --format json
+jfox daily --json
+jfox daily --date 2026-04-01 --json
+jfox refs --search "<title>" --format json
+jfox show <id_or_title>
+```
+
+All commands support `--kb <name>` to target a specific KB.
+
+## Health Check
+
+Collect metrics from multiple jfox commands and synthesize a health assessment. No single "health" command exists — data must be gathered and analyzed.
+
+> If user specifies a target KB name, append `--kb <name>` to all commands below. Omit if unspecified to use the current default KB.
+
+### 6 Metric Collection Commands
+
+```bash
+# 1. Overall status
+jfox status --format json [--kb <name>]
+
+# 2. Graph metrics
+jfox graph --stats --json [--kb <name>]
+
+# 3. Orphaned notes
+jfox graph --orphans --json [--kb <name>]
+
+# 4. Index integrity
+jfox index verify [--kb <name>]
+
+# 5. Note inventory
+jfox list --format json --limit 500 [--kb <name>]
+
+# 6. Unprocessed inbox
+jfox inbox --json --limit 100 [--kb <name>]
+```
+
+### Health Metrics Table
+
+| Metric | Source | Healthy | Warning | Danger |
+|--------|--------|---------|---------|--------|
+| **Orphan ratio** | `isolated_nodes / total_nodes` | < 20% | 20-40% | > 40% |
+| **Avg degree** | `avg_degree` (graph stats) | > 2.0 | 1.0-2.0 | < 1.0 |
+| **Inbox backlog** | fleeting note count | < 10 | 10-30 | > 30 |
+| **Index integrity** | `jfox index verify` result | All pass | — | Any failure |
+| **Connectivity** | `(total - isolated) / total` | > 0.8 | 0.6-0.8 | < 0.6 |
+| **Type balance** | fleeting / total ratio | < 30% | 30-50% | > 50% |
+
+### Decay Signal Detection
+
+Analyze metrics to detect 5 decay patterns:
+
+**1. Knowledge islands (high orphan ratio)**
+- Signal: > 40% notes have no links
+- Cause: Notes recorded but not connected to existing knowledge
+- Fix: Use `jfox-organize` skill to find and add links
+
+**2. Inbox backlog (too many unprocessed)**
+- Signal: > 30 fleeting notes
+- Cause: Capturing ideas without reflection
+- Fix: Use `jfox-organize` skill to process inbox
+
+**3. Low connectivity (avg degree too low)**
+- Signal: Avg links per note < 1.0
+- Cause: Not using `[[links]]` syntax when adding notes
+- Fix: Use `jfox suggest-links` to find connections
+
+**4. Index stale (out of sync)**
+- Signal: `jfox index verify` reports mismatches
+- Cause: Files modified outside jfox CLI
+- Fix: `jfox index rebuild`
+
+**5. Hub dependency (fragile structure)**
+- Signal: Top 3 hubs hold > 50% of all edges
+- Cause: Over-reliance on few hub notes
+- Fix: Create intermediate notes to distribute connections
+
+### Scoring System
+
+```
+Score = 100
+- min(orphan_ratio * 100, 40)
+- min(max(0, 2.0 - avg_degree) * 10, 20)
+- min(max(0, inbox_count - 10), 20)
+- (0 if verify_result["healthy"] else 20)
+```
+
+| Score | Grade | Status |
+|-------|-------|--------|
+| 90-100 | A | Excellent — healthy and well-connected |
+| 75-89 | B | Good — minor issues |
+| 60-74 | C | Fair — decay signals detected |
+| 40-59 | D | Poor — significant decay |
+| 0-39 | F | Critical — immediate action needed |
+
+### Report Format
+
+```
+📊 Knowledge Base Health Report [KB: {kb_name}]
+
+Overall Score: {grade} ({score}/100)
+
+✅ Index Integrity: {pass/fail}
+✅ Total Notes: {N} (permanent: {X}, fleeting: {Y})
+⚠️ Orphaned Notes: {orphans}/{total} ({ratio}%) — {recommendation}
+⚠️ Avg Degree: {degree} — {recommendation}
+⚠️ Inbox: {inbox_count} unprocessed — {recommendation}
+
+Detailed Metrics:
+- Clusters: {clusters}
+- Top Hubs: {hub_list}
+- Connectivity: {connectivity_ratio}
+
+Recommended Actions:
+1. {highest priority action}
+2. {secondary action}
+3. {optional optimization}
+```
+
+Use emoji indicators: ✅ healthy, ⚠️ warning, ❌ danger.
+
+### When to Run
+
+- **Weekly**: Regular knowledge management health check
+- **After bulk import**: Verify index and connections
+- **Before organizing**: Identify priority areas
+- **When stuck**: Detect specific decay patterns
+
+## Command Reference
+
+```bash
+# KB Management
+jfox init --name <name> --desc "<desc>"
+jfox kb list --format json
+jfox kb switch <name>
+jfox kb info <name> --format json
+jfox kb current --format json
+jfox kb rename <old> <new>
+jfox kb remove <name>
+jfox kb remove <name> --force
+jfox status --format json
+
+# Note CRUD
+jfox add "<content>" --title "<title>" --type <type> --tag <tags>
+jfox add --content-file <path> --title "<title>"
+jfox edit <id> --content "<new>" --title "<title>"
+jfox edit <id> --content-file <path>
+jfox delete <id> --force
+jfox show <id_or_title>
+jfox list --format json --limit <N>
+jfox daily --json
+jfox daily --date YYYY-MM-DD --json
+jfox refs --search "<title>" --format json
+
+# Import & Health
+jfox ingest-log <repo-path> --limit <N> --type fleeting --kb <name>
+jfox bulk-import <file.json> --type fleeting --kb <name>
+jfox graph --stats --json
+jfox graph --orphans --json
+jfox index verify
+jfox index rebuild
+jfox inbox --json --limit <N>
+
+# Daemon
+jfox daemon start
+jfox daemon stop
+jfox daemon status
+```
+
+All commands support `--kb <name>` and `--format json` (or `--json`).
+
+## Error Handling
+
+| Scenario | Resolution |
+|----------|------------|
+| "Knowledge base already exists" | Use `jfox kb switch <name>` or create with a different name |
+| "Path is outside managed directory" | All KBs must be under `~/.zettelkasten/` |
+| `jfox: command not found` | Install: `uv tool install jfox-cli` |
+| Index stale or verify failure | Run `jfox index rebuild` |
+| `ingest-log` "Not a git repository" | Provide correct Git repository path |

--- a/skills-recommend/kimi-cli/jfox-ingest/SKILL.md
+++ b/skills-recommend/kimi-cli/jfox-ingest/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: jfox-ingest
+description: |
+  Import data from local git repositories into a Zettelkasten knowledge base as fleeting notes.
+  Use when user wants to ingest a repository, import git log, import GitHub PRs, import GitHub Issues, or bulk import project information.
+  Triggers on: "导入仓库", "导入 git log", "导入 PR", "导入 issues", "读一下这个仓库", "抓取仓库信息", "ingest repo", "import notes from repository", "bulk import from git", "导入项目信息", "ingest repository", "import git history".
+---
+
+# JFox Repository Data Ingestion
+
+Ingest git log, GitHub PRs, and GitHub Issues from local repositories as fleeting notes.
+
+## Prerequisites
+
+1. Knowledge base exists:
+   ```bash
+   jfox kb list --format json
+   ```
+   If none exists, prompt user to use `jfox-common` skill to create one first.
+
+2. `git` command available.
+
+3. For GitHub PR/Issues: `gh` CLI authenticated:
+   ```bash
+   gh auth status
+   ```
+
+## Workflow
+
+### Step 1: Detect Repository
+
+User provides a local repository path.
+
+Detect if GitHub repository:
+```bash
+git -C <path> remote get-url origin
+```
+
+Check output for `github.com`. If present, extract `owner/repo`:
+- `git@github.com:owner/repo.git` → `owner/repo`
+- `https://github.com/owner/repo.git` → `owner/repo`
+
+Extract repo name for tags: `source:<repo-name>`.
+
+### Step 2: Select Data Source
+
+| Source | Scenario | Needs GitHub |
+|--------|----------|--------------|
+| git-log | Commit history | No |
+| github-pr | Pull Requests | Yes |
+| github-issue | Issues | Yes |
+
+If user says "import this repo" without specifying source, import all available sources (all three for GitHub repos; only git-log for non-GitHub).
+
+### Step 3: Ingest Git Log
+
+Single command for extraction + conversion + import:
+
+```bash
+jfox ingest-log path/to/repo --limit 50 --kb <name> --type fleeting
+```
+
+This command:
+- Calls `git log` to extract commit history
+- Parses structured data (hash, subject, author, date, body)
+- Converts to fleeting notes and bulk imports
+- Auto-adds tags: `source:<repo-name>`, `source:git-log`
+
+Example generated note:
+```
+Commit: a1b2c3d
+Author: Zhang San
+Date: 2026-04-10
+
+feat: add user authentication module
+
+Implemented JWT authentication with refresh token support.
+```
+
+> All commands support `--format json` or `--json`. Examples below use `--json`.
+
+### Step 4: Collect GitHub PRs
+
+Only for GitHub repositories.
+
+```bash
+gh pr list --repo <owner/repo> --state all --limit 20 --json number,title,body,state,author,createdAt,updatedAt,labels
+```
+
+Optional: fetch comments per PR:
+```bash
+gh pr view <number> --repo <owner/repo> --json comments
+```
+
+Transform to note structure:
+- **title**: PR title
+- **content**: PR number, state, description, key comments, metadata
+- **tags**: `source:<repo-name>`, `source:pr`
+
+### Step 5: Collect GitHub Issues
+
+Only for GitHub repositories.
+
+```bash
+gh issue list --repo <owner/repo> --state all --limit 30 --json number,title,body,state,author,createdAt,labels,comments
+```
+
+Transform to note structure:
+- **title**: Issue title
+- **content**: Issue number, state, description, comments, metadata
+- **tags**: `source:<repo-name>`, `source:issue`
+
+### Step 6: Import GitHub Data
+
+Git-log was already imported in Step 3. This step handles PRs/Issues only.
+
+**Deduplication**: Check for existing data before importing:
+```bash
+jfox search "<repo-name>" --format json
+```
+
+If records exist, only import new entries (by PR/Issue number).
+
+**Build JSON array** for PRs/Issues:
+
+```json
+[
+  {
+    "title": "Add user authentication",
+    "content": "PR #42: Add user authentication\nState: merged\nAuthor: zhangsan\n...",
+    "tags": ["source:my-app", "source:pr"]
+  },
+  {
+    "title": "Login page crashes on mobile",
+    "content": "Issue #15: Login page crashes on mobile\nState: closed\n...",
+    "tags": ["source:my-app", "source:issue"]
+  }
+]
+```
+
+Save to temp file, then import:
+```bash
+jfox bulk-import temp-file.json --type fleeting --kb <name>
+```
+
+> `jfox bulk-import` defaults to table output. Use `--json` for JSON format.
+
+### Step 7: Confirmation Report
+
+```
+Ingestion complete!
+  - git log: 50 entries
+  - GitHub PRs: 15 entries
+  - GitHub Issues: 10 entries
+  - Total: 75 fleeting notes imported to <kb-name>
+```
+
+## Manual Input Support
+
+If user pastes text without a repository path, organize as a single fleeting note:
+```bash
+jfox add "<content>" --title "<title>" --type fleeting --tag <tags> [--kb <name>]
+```
+
+## Note Format Reference
+
+| Source | Title | Content | Extra Tags |
+|--------|-------|---------|------------|
+| git-log | commit subject | hash, author, date, body | `source:<repo>`, `source:git-log` |
+| PR | PR title | number, state, description, comments | `source:<repo>`, `source:pr` |
+| Issue | Issue title | number, state, description, comments | `source:<repo>`, `source:issue` |
+
+All notes include `source:<repo-name>` for later retrieval by repository.
+**Fleeting notes do NOT contain `[[wiki links]]`** — they are raw data capture. Links are added during refinement (use `jfox-organize` skill).
+
+## GitLab Note
+
+For non-GitHub repos, only import git log. GitLab CLI support is a future extension.
+
+## Full Command Reference
+
+```bash
+# Detect repository type
+git -C path/to/repo remote get-url origin
+gh auth status
+
+# Ingest git log
+jfox ingest-log path/to/repo --limit 50 --kb <name> --type fleeting
+
+# Collect GitHub data
+gh pr list --repo owner/repo --state all --limit 20 --json number,title,body,state,author,createdAt,updatedAt,labels
+gh pr view <number> --repo owner/repo --json comments
+gh issue list --repo owner/repo --state all --limit 30 --json number,title,body,state,author,createdAt,labels,comments
+
+# Deduplication check
+jfox search "<repo-name>" --format json
+
+# Import GitHub data
+jfox bulk-import file.json --type fleeting --kb <name>
+
+# Manual single note
+jfox add "<content>" --title "<title>" --type fleeting --kb <name>
+
+# Verify import
+jfox show <note_id> --kb <name>
+
+# Speed up with daemon (optional)
+jfox daemon start
+jfox daemon stop
+```
+
+## Error Handling
+
+- **"Not a git repository"**: `jfox ingest-log` will error; prompt for correct path
+- **`gh` not found or `gh auth status` fails**: Skip PR/Issue import; use git-log only
+- **"Knowledge base not found"**: Prompt user to create KB first via `jfox-common`
+- **Partial bulk import failure**: Report success/failure counts; do not retry failures

--- a/skills-recommend/kimi-cli/jfox-organize/SKILL.md
+++ b/skills-recommend/kimi-cli/jfox-organize/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: jfox-organize
+description: |
+  Organize, refine, and optimize a Zettelkasten knowledge base.
+  Use when user wants to organize their knowledge base, process inbox, refine fleeting notes into permanent notes, add wiki links, merge notes, or optimize the knowledge graph.
+  Triggers on: "整理知识库", "清理 inbox", "提炼笔记", "组织笔记", "看看有什么可以整理的", "合并笔记", "生成链接", "organize", "process inbox", "refine notes", "knowledge graph optimization", "clean up notes", "link notes".
+---
+
+# JFox Knowledge Base Organization & Refinement
+
+Core refinement skill. Transform raw fleeting notes into well-structured, interlinked permanent knowledge.
+
+Three-step flow: inbox analysis → refinement (fleeting → permanent with `[[wiki links]]`) → graph optimization.
+
+Also supports direct note creation and editing during organization.
+
+## Prerequisites
+
+Knowledge base must have notes. If empty, suggest using `jfox-ingest` skill first.
+
+## Step 1: Inbox Analysis
+
+```bash
+jfox inbox --json --limit 50
+```
+
+List all fleeting (unprocessed) notes. Group and analyze:
+
+1. **Group by `source:*` tag**: e.g., all `source:git-log` notes together
+2. **Identify mergeable subgroups**: related commits/issues form subgroups
+3. Present refinement suggestions:
+
+```
+Inbox: N fleeting notes
+
+Refinement suggestions:
+1. [Merge] 15 jfox git-log commits → "JFox Recent Development Summary" (permanent)
+2. [Merge] 5 jfox PRs → "JFox PR Technical Decisions Summary" (permanent)
+3. [Individual] 3 manually entered notes → process one by one
+4. [Delete] 2 outdated notes → clean up
+```
+
+Wait for user confirmation on which suggestions to execute.
+
+## Step 2: Refinement (fleeting → permanent)
+
+Core capability. For each user-confirmed suggestion:
+
+1. **Analyze**: Read the group of fleeting notes; extract core knowledge points
+2. **Find connections**:
+   ```bash
+   jfox suggest-links "<refined content summary>" --format json
+   ```
+   Filter results with score >= 0.6
+3. **Generate permanent note**: Structure core knowledge with embedded `[[wiki links]]` to existing notes
+4. **Cross-link within batch**: If creating multiple permanent notes in one batch, add `[[links]]` between them too
+5. **Insert**:
+   ```bash
+   jfox add "<content with [[links]]>" --title "<title>" --type permanent --tag <tag1> --tag <tag2> [--kb <name>]
+   ```
+6. **Delete source fleeting**:
+   ```bash
+   jfox delete <original-id> --force
+   ```
+
+> All commands support `--format json` or `--json`. Examples use `--json`.
+
+### Refinement Strategy Table
+
+| Source | Strategy | Permanent Example |
+|--------|----------|-------------------|
+| git-log (multiple commits) | Merge by time/topic; extract technical decisions | "JFox v0.1.4 Technical Changes Summary" |
+| github-pr (multiple PRs) | Extract core design decisions, debates, final solutions | "JFox PR#94 Edit Command Design Discussion" |
+| github-issue (multiple issues) | Extract problem essence, solutions, lessons learned | "JFox BM25 Index Issue and Fix" |
+| Manual input | Judge maturity; convert to permanent if substantial enough | — |
+
+## Step 3: Graph Optimization
+
+### Find Orphaned Notes
+
+```bash
+jfox graph --orphans --json
+```
+
+For each orphaned permanent note:
+1. Read note content
+2. Find connections:
+   ```bash
+   jfox suggest-links "<content>" --format json
+   ```
+3. If matches with score >= 0.6, suggest adding links:
+   ```bash
+   jfox edit <orphan-id> --content "Original content... [[Related Note Title]]"
+   jfox edit <orphan-id> --content-file updated.md
+   ```
+
+### Verify Improvement
+
+```bash
+jfox graph --stats --json
+```
+
+Report before/after comparison:
+
+| Metric | Meaning | Healthy Target |
+|--------|---------|----------------|
+| `avg_degree` | Avg links per note | > 2.0 |
+| `isolated_nodes` | Notes with no links | < 20% of total |
+
+## Direct Note Creation
+
+Users may want to create or edit notes during organization:
+
+**Create note:**
+```bash
+jfox add "<content>" --title "<title>" --type <fleeting|permanent> --tag <tags> [--kb <name>]
+jfox add --content-file notes/draft.md --title "<title>" --type permanent --tag <tags> [--kb <name>]
+echo "<content>" | jfox add --content-file - --title "<title>" --type fleeting
+```
+
+For permanent notes, run `jfox suggest-links` first to find `[[wiki links]]` before inserting.
+
+**Edit existing note:**
+```bash
+jfox edit <note_id> --content "New content" --title "New Title" --tag <tag>
+jfox edit <note_id> --kb <kb-name> --content "New content"
+```
+
+**Type selection guide:**
+
+| Type | Use Case | Example |
+|------|----------|---------|
+| `fleeting` | Quick ideas, temporary records to refine later | "Sudden API design idea" |
+| `permanent` | Mature knowledge, long-lasting insights | "Summarized design principle" |
+
+Default type: `fleeting` (quick capture, refine later with this skill).
+
+## Command Reference
+
+```bash
+jfox inbox --json --limit <N>
+jfox add "<content>" --type permanent --title "<title>" --tag <tags>
+jfox edit <id> --content "New content"
+jfox delete <id> --force
+jfox suggest-links "<content>" --format json
+jfox graph --orphans --json
+jfox graph --stats --json
+jfox list --format json --limit <N>
+jfox daily --json
+jfox daily --date YYYY-MM-DD --json
+jfox show <id_or_title>
+
+# Speed up with daemon (optional)
+jfox daemon start
+jfox daemon stop
+```
+
+## Error Handling
+
+- **Empty inbox**: Inform user "Inbox is empty, nothing to organize"; skip to Step 3 graph optimization
+- **`jfox suggest-links` low score** (< 0.6): Skip link recommendation; do not force-add
+- **`jfox delete` ID not found**: Report error; continue processing other notes
+- **`jfox add` / `jfox edit` / `jfox delete`**: Support `--format json` or `--json`
+
+## Usage Tips
+
+- **Organize regularly**: Process inbox weekly to avoid > 30 fleeting notes
+- **Link liberally**: Zettelkasten value comes from connections, not quantity. Use `[[links]]` generously
+- **Tags group, links express thought**: `--tag` categorizes by topic; `[[links]]` expresses conceptual relationships

--- a/skills-recommend/kimi-cli/jfox-search/SKILL.md
+++ b/skills-recommend/kimi-cli/jfox-search/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: jfox-search
+description: |
+  Search and retrieve notes from a Zettelkasten knowledge base.
+  Use when user wants to search notes, find information, look up knowledge, query the knowledge graph, find related notes, discover backlinks, or get link suggestions.
+  Triggers on: "搜索", "查找", "找一下", "查一下", "搜一下", "帮我找", "有没有关于", "search notes", "look up", "find", "find related notes", "search knowledge base", "notes about", "query knowledge graph", "backlinks", "suggest links".
+---
+
+# JFox Knowledge Base Search
+
+Search and retrieve notes from the Zettelkasten knowledge base.
+
+## Prerequisites
+
+Knowledge base must be initialized (`jfox init`). If search index is stale, run `jfox index rebuild` first.
+
+## Search Strategy Selection
+
+Match search approach to user intent:
+
+| User Intent | Strategy | Command |
+|-------------|----------|---------|
+| Exact keyword | Keyword (BM25) | `jfox search "<keyword>" --mode keyword --format json` |
+| Concept or idea (fuzzy) | Hybrid (BM25 + semantic) | `jfox search "<concept>" --mode hybrid --format json` |
+| Pure semantic similarity | Semantic | `jfox search "<idea>" --mode semantic --format json` |
+| Explore related topics | Graph traversal | `jfox query "<topic>" --depth 2 --json` |
+| What links to note X | Backlinks | `jfox refs --search "<title>" --format json` |
+| What should I link to | Link suggestions | `jfox suggest-links "<content>" --format json` |
+
+**Default strategy**: `--mode hybrid` (best balance of precision and recall).
+
+## Workflow
+
+### Single Search
+
+```bash
+jfox search "<query>" --mode hybrid --top 10 --format json
+```
+
+Parse JSON output and present as:
+
+```
+Found N related notes:
+
+1. [Title] (score: 0.85)
+   Type: permanent | Tags: tag1, tag2
+   Summary: First 100 chars...
+
+2. [Title] (score: 0.72)
+   ...
+```
+
+Tip: Use `jfox show <note_id>` for full note content.
+
+### Graph-Aware Search
+
+For exploring connections around a topic:
+```bash
+jfox query "<topic>" --top 10 --depth 2 --json
+```
+
+Returns both search results AND their graph neighbors for broader knowledge landscape view.
+
+### Backlink Discovery
+
+Find what references a specific note:
+```bash
+jfox refs --search "<title>" --format json
+```
+
+### Link Recommendations
+
+Find notes that should be linked from given content:
+```bash
+jfox suggest-links "<content>" --top 10 --threshold 0.6 --format json
+```
+
+Default threshold: `0.6`. Lower to `0.3-0.5` for broader suggestions; raise to `0.7-0.8` for stricter matching.
+
+## Full Command Reference
+
+```bash
+# Basic search
+jfox search "<query>" --mode <hybrid|keyword|semantic> --top <N> --format json
+
+# Filter by note type
+jfox search "<query>" --type permanent --format json
+
+# Graph query with traversal
+jfox query "<query>" --top <N> --depth <D> --json
+
+# Link suggestions
+jfox suggest-links "<content>" --top <N> --threshold <T> --format json
+
+# Backlinks / references
+jfox refs --search "<title>" --format json
+jfox refs --note "<note-id>" --format json
+```
+
+## Multi-KB Search
+
+All search commands support `--kb <name>` to target a specific KB:
+```bash
+jfox search "<query>" --kb work --format json
+```
+
+## Error Handling
+
+- **"Index not found"**: Run `jfox index rebuild`
+- **Empty results**: Try broader query, switch to `hybrid` mode, or lower `--threshold`
+- **Slow search**: First search loads embedding model (30-60s). Subsequent searches are fast. Use `jfox daemon start` to avoid repeated loading.

--- a/skills-recommend/kimi-cli/jfox-session-summary/SKILL.md
+++ b/skills-recommend/kimi-cli/jfox-session-summary/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: jfox-session-summary
+description: |
+  Save the current conversation or session summary into a Zettelkasten knowledge base.
+  Use when user wants to save session summary, log conversation to knowledge base, write discussion to notes, or summarize chat into the knowledge base.
+  Triggers on: "保存会话", "总结到知识库", "记录这次对话", "写入知识库", "save session", "summarize to knowledge base", "log this conversation", "save chat", "conversation to notes".
+---
+
+# JFox Session Summary
+
+Save the current session summary into the jfox knowledge base (with user confirmation and note type selection).
+
+## Prerequisites
+
+- Knowledge base initialized (`jfox init`)
+- Confirm target KB (via `--kb` or current default)
+
+## Workflow
+
+### Step 1: Generate Session Summary
+
+Review current conversation and generate structured summary:
+
+```markdown
+## Session Summary
+
+### Topic
+[One-sentence description of main topic]
+
+### Completed Work
+- [Specific completed task 1]
+- [Specific completed task 2]
+- ...
+
+### Key Decisions
+- [Decision 1 and rationale]
+- [Decision 2 and rationale]
+
+### TODO / Follow-up
+- [Incomplete items]
+- [Next steps]
+```
+
+### Step 2: User Confirmation
+
+Output the generated summary as plain text for user review. Then use `AskUserQuestion`:
+
+- Question: `Is the summary content OK?`
+- Options:
+  - `Content is fine` → proceed to Step 3
+  - `Needs changes` → user inputs modifications in "Other", adjust summary and return to Step 2
+
+Loop until user is satisfied.
+
+### Step 3: Select Note Type
+
+After user confirms content, use `AskUserQuestion`:
+
+- Question: `Select note type`
+- Options:
+  - `fleeting` (recommended) — session records are temporary; can be refined to permanent later
+  - `literature` — if session has clear reference sources
+  - `permanent` — if summary is already mature knowledge
+
+### Step 4: Write to Knowledge Base
+
+Use the selected type:
+
+```bash
+jfox add "<markdown-escaped-summary>" \
+  --title "Session: <topic>" \
+  --type <selected-type> \
+  --tag session \
+  --kb <kb-name> \
+  --format json
+```
+
+**Notes**:
+- Title format: `Session: <short topic>`
+- Type: use Step 3 selection, do not hardcode `fleeting`
+- Tag: always `session`
+- Escape double quotes in content, or use `--content-file`
+
+### Step 5: Handle Long Content
+
+If summary exceeds 500 chars or contains special characters, prefer `--content-file`:
+
+```bash
+# Write to temp file
+cat > /tmp/session-summary.md << 'EOF'
+<summary content>
+EOF
+
+# Import from file
+jfox add --content-file /tmp/session-summary.md \
+  --title "Session: <topic>" \
+  --type <selected-type> \
+  --tag session \
+  --kb <kb-name> \
+  --format json
+```
+
+On Windows, use a temp path like `$env:TEMP\session-summary.md`.
+
+## Command Reference
+
+```bash
+# Direct add (short content)
+jfox add "<summary>" --title "Session: <topic>" --type <type> --tag session --kb <name>
+
+# From file (long content or special characters)
+jfox add --content-file <path> --title "Session: <topic>" --type <type> --tag session --kb <name>
+
+# Verify write
+jfox show <note_id>
+```
+
+## Error Handling
+
+- **"Knowledge base not found"**: Prompt user to create KB first via `jfox-common`
+- **Content too long for shell**: Switch to `--content-file` approach
+- **Special character escaping issues**: Use single quotes or write to temp file


### PR DESCRIPTION
## Summary

为 Kimi CLI 创建一套完整的 skill 集合，解决 #166。

## Changes

### 新增 5 个 Kimi CLI skill

| Skill | 功能 |
|-------|------|
| jfox-common | 知识库管理 + 健康检查 |
| jfox-ingest | 仓库数据导入（git log / PR / Issues） |
| jfox-organize | 知识库整理与提炼（fleeting → permanent） |
| jfox-search | 搜索 + 图谱查询 + 链接推荐 |
| jfox-session-summary | 会话总结写入知识库 |

### 适配要点

- **自然语言触发**：扩展 description frontmatter，覆盖中英文触发词
- **命令式语气**：正文统一使用 imperative/infinitive 风格
- **移除斜杠命令引用**：Kimi CLI 没有 /skill 语法，改为 use jfox-xxx skill
- **保留完整 CLI 参考**：所有 jfox 命令和工作流与 Claude Code 版本保持一致

### README 更新

- 添加 kimi-cli/ 目录结构说明
- 新增 Kimi CLI 安装和使用指南（~/.config/agents/skills/）
- 调整平台适配表格，区分 Kimi CLI 与其他平台

## 测试方式

`ash
# 本地安装到 Kimi CLI
mkdir -p ~/.config/agents/skills/
cp -r skills-recommend/kimi-cli/* ~/.config/agents/skills/

# 验证文件存在
ls ~/.config/agents/skills/jfox-common/SKILL.md
`

## Checklist

- [x] 5 个 skill 全部创建
- [x] YAML frontmatter 包含 
ame + description
- [x] 正文控制在 500 行以内
- [x] README 已更新
- [x] 关联 issue #166