### PR TITLE
chore: bump version to 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to jfox-cli will be documented in this file.
 
+## [0.4.2] - 2026-04-22
+
+### Features
+- add Kimi CLI skill collection (#166)
+- **skills**: add release skill with full workflow instructions
+- **skills**: add release helper script with version bump and CHANGELOG generation
+
+### Fixes
+- **lint**: remove unused pytest import
+- **skills**: improve git Chinese encoding and fix pluralization in release helper
+- **skills**: address code review issues in release helper
+- **cli**: list 命令 table 输出显示完整 18 位笔记 ID
+
+### Changes
+- style(lint): format test_release_helper.py with black
+- Merge pull request #167 from zhuxixi/feat/kimi-cli-skills
+- Merge pull request #165 from zhuxixi/fix-list-id-truncation
+
+[0.4.2]: https://github.com/zhuxixi/jfox/compare/v0.4.1...v0.4.2
+
 ## [0.2.0] - 2026-04-13
 
 ### Features

--- a/jfox/__init__.py
+++ b/jfox/__init__.py
@@ -1,5 +1,5 @@
 """JFox - Zettelkasten 知识管理工具"""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 __author__ = "User"
 __email__ = "user@example.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jfox-cli"
-version = "0.4.1"
+version = "0.4.2"
 description = "JFox - Zettelkasten 知识管理 CLI 工具"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -867,7 +867,7 @@ wheels = [
 
 [[package]]
 name = "jfox-cli"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary
Bump version from 0.4.1 to 0.4.2

## [0.4.2] - 2026-04-22

### Features
- add Kimi CLI skill collection (#166)
- **skills**: add release skill with full workflow instructions
- **skills**: add release helper script with version bump and CHANGELOG generation

### Fixes
- **lint**: remove unused pytest import
- **skills**: improve git Chinese encoding and fix pluralization in release helper
- **skills**: address code review issues in release helper
- **cli**: list table display truncation for 18-digit IDs

### Changes
- style(lint): format test_release_helper.py with black
- Merge pull request #167 from zhuxixi/feat/kimi-cli-skills
- Merge pull request #165 from zhuxixi/fix-list-id-truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)