### PR TITLE
chore: bump version to 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to jfox-cli will be documented in this file.
 
+## [0.4.3] - 2026-04-28
+
+### Features
+- 内网模型自动下载（3步降级重试链） (#173)
+
+### Fixes
+- **daemon**: eliminate deprecation warnings in daemon log (#171)
+
+[0.4.3]: https://github.com/zhuxixi/jfox/compare/v0.4.2...v0.4.3
+
 ## [0.4.2] - 2026-04-22
 
 ### Features

--- a/jfox/__init__.py
+++ b/jfox/__init__.py
@@ -1,5 +1,5 @@
 """JFox - Zettelkasten 知识管理工具"""
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 __author__ = "User"
 __email__ = "user@example.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jfox-cli"
-version = "0.4.2"
+version = "0.4.3"
 description = "JFox - Zettelkasten 知识管理 CLI 工具"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -867,7 +867,7 @@ wheels = [
 
 [[package]]
 name = "jfox-cli"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary
Bump version from 0.4.2 to 0.4.3

## [0.4.3] - 2026-04-28

### Features
- 内网模型自动下载（3步降级重试链） (#173)

### Fixes
- **daemon**: eliminate deprecation warnings in daemon log (#171)

[0.4.3]: https://github.com/zhuxixi/jfox/compare/v0.4.2...v0.4.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)