### PR TITLE
feat: 支持通过标签召回笔记 (#170)

### DIFF
--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -790,11 +790,12 @@ def _list_impl(
         table.add_column("ID", style="dim")
         table.add_column("Title", style="cyan")
         table.add_column("Type", style="green")
+        table.add_column("Tags", style="yellow")
         table.add_column("Created", style="dim")
 
         for n in notes:
             created_str = n.created.strftime("%Y-%m-%d") if n.created else ""
-            table.add_row(n.id, n.title[:40], n.type.value, created_str)
+            table.add_row(n.id, n.title[:40], n.type.value, ", ".join(n.tags) if n.tags else "", created_str)
 
         console.print(table)
     elif output_format == "tree":
@@ -802,7 +803,7 @@ def _list_impl(
     elif output_format in ["csv", "yaml", "paths"]:
         # 对于 csv, yaml, paths，只输出 notes 列表
         if output_format == "csv":
-            console.print(OutputFormatter.to_csv(data, headers=["id", "title", "type", "created"]))
+            console.print(OutputFormatter.to_csv(data, headers=["id", "title", "type", "tags", "created"]))
         elif output_format == "yaml":
             print(OutputFormatter.to_yaml(result))
         elif output_format == "paths":

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -532,7 +532,9 @@ def search(
     query: str = typer.Argument(..., help="搜索查询"),
     top: int = typer.Option(5, "--top", "-n", help="返回结果数量"),
     note_type: Optional[str] = typer.Option(None, "--type", "-t", help="筛选笔记类型"),
-    tags: Optional[List[str]] = typer.Option(None, "--tag", help="按标签筛选（可多次使用，AND 逻辑）"),
+    tags: Optional[List[str]] = typer.Option(
+        None, "--tag", help="按标签筛选（可多次使用，AND 逻辑）"
+    ),
     search_mode: str = typer.Option(
         "hybrid", "--mode", "-m", help="搜索模式: hybrid, semantic, keyword"
     ),
@@ -795,7 +797,9 @@ def _list_impl(
 
         for n in notes:
             created_str = n.created.strftime("%Y-%m-%d") if n.created else ""
-            table.add_row(n.id, n.title[:40], n.type.value, ", ".join(n.tags) if n.tags else "", created_str)
+            table.add_row(
+                n.id, n.title[:40], n.type.value, ", ".join(n.tags) if n.tags else "", created_str
+            )
 
         console.print(table)
     elif output_format == "tree":
@@ -803,7 +807,9 @@ def _list_impl(
     elif output_format in ["csv", "yaml", "paths"]:
         # 对于 csv, yaml, paths，只输出 notes 列表
         if output_format == "csv":
-            console.print(OutputFormatter.to_csv(data, headers=["id", "title", "type", "tags", "created"]))
+            console.print(
+                OutputFormatter.to_csv(data, headers=["id", "title", "type", "tags", "created"])
+            )
         elif output_format == "yaml":
             print(OutputFormatter.to_yaml(result))
         elif output_format == "paths":
@@ -815,7 +821,9 @@ def _list_impl(
 @app.command()
 def list(
     note_type: Optional[str] = typer.Option(None, "--type", "-t", help="筛选笔记类型"),
-    tags: Optional[List[str]] = typer.Option(None, "--tag", help="按标签筛选（可多次使用，AND 逻辑）"),
+    tags: Optional[List[str]] = typer.Option(
+        None, "--tag", help="按标签筛选（可多次使用，AND 逻辑）"
+    ),
     limit: int = typer.Option(10, "--limit", "-n", help="显示数量"),
     output_format: str = typer.Option(
         "table", "--format", "-f", help="输出格式: json, table, csv, yaml, paths, tree"

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -451,13 +451,14 @@ def _search_impl(
     query: str,
     top: int,
     note_type: Optional[str],
+    tags: Optional[List[str]],
     search_mode: str,
     output_format: str,
 ):
     """搜索笔记的内部实现"""
     from .formatters import OutputFormatter
 
-    results = note.search_notes(query, top_k=top, note_type=note_type, mode=search_mode)
+    results = note.search_notes(query, top_k=top, note_type=note_type, tags=tags, mode=search_mode)
 
     result = {
         "query": query,
@@ -531,6 +532,7 @@ def search(
     query: str = typer.Argument(..., help="搜索查询"),
     top: int = typer.Option(5, "--top", "-n", help="返回结果数量"),
     note_type: Optional[str] = typer.Option(None, "--type", "-t", help="筛选笔记类型"),
+    tags: Optional[List[str]] = typer.Option(None, "--tag", help="按标签筛选（可多次使用，AND 逻辑）"),
     search_mode: str = typer.Option(
         "hybrid", "--mode", "-m", help="搜索模式: hybrid, semantic, keyword"
     ),
@@ -562,9 +564,9 @@ def search(
             from .config import use_kb
 
             with use_kb(kb):
-                _search_impl(query, top, note_type, search_mode, output_format)
+                _search_impl(query, top, note_type, tags, search_mode, output_format)
         else:
-            _search_impl(query, top, note_type, search_mode, output_format)
+            _search_impl(query, top, note_type, tags, search_mode, output_format)
 
     except Exception as e:
         result = {
@@ -758,6 +760,7 @@ def status(
 
 def _list_impl(
     note_type: Optional[str],
+    tags: Optional[List[str]],
     limit: int,
     output_format: str,
 ):
@@ -772,7 +775,7 @@ def _list_impl(
         except ValueError:
             raise ValueError(f"Invalid note type: {note_type}")
 
-    notes = note.list_notes(note_type=nt, limit=limit)
+    notes = note.list_notes(note_type=nt, tags=tags, limit=limit)
     data = [n.to_dict() for n in notes]
 
     result = {
@@ -811,6 +814,7 @@ def _list_impl(
 @app.command()
 def list(
     note_type: Optional[str] = typer.Option(None, "--type", "-t", help="筛选笔记类型"),
+    tags: Optional[List[str]] = typer.Option(None, "--tag", help="按标签筛选（可多次使用，AND 逻辑）"),
     limit: int = typer.Option(10, "--limit", "-n", help="显示数量"),
     output_format: str = typer.Option(
         "table", "--format", "-f", help="输出格式: json, table, csv, yaml, paths, tree"
@@ -839,9 +843,9 @@ def list(
             from .config import use_kb
 
             with use_kb(kb):
-                _list_impl(note_type, limit, output_format)
+                _list_impl(note_type, tags, limit, output_format)
         else:
-            _list_impl(note_type, limit, output_format)
+            _list_impl(note_type, tags, limit, output_format)
 
     except Exception as e:
         result = {

--- a/jfox/note.py
+++ b/jfox/note.py
@@ -142,6 +142,7 @@ def list_notes(
     note_type: Optional[NoteType] = None,
     limit: Optional[int] = None,
     cfg: Optional[ZKConfig] = None,
+    tags: Optional[List[str]] = None,
 ) -> List[Note]:
     """
     列出笔记
@@ -150,6 +151,7 @@ def list_notes(
         note_type: 笔记类型筛选
         limit: 数量限制
         cfg: 可选的配置对象，默认使用全局 config
+        tags: 标签筛选列表（AND 逻辑）
 
     Returns:
         笔记列表
@@ -174,6 +176,10 @@ def list_notes(
 
         if limit and len(notes) >= limit:
             break
+
+    # 标签过滤（AND 逻辑）
+    if tags:
+        notes = [n for n in notes if all(t in n.tags for t in tags)]
 
     return notes
 
@@ -320,6 +326,7 @@ def search_notes(
     top_k: int = 5,
     note_type: Optional[str] = None,
     mode: str = "hybrid",
+    tags: Optional[List[str]] = None,
 ) -> List[Dict[str, Any]]:
     """
     搜索笔记
@@ -329,6 +336,7 @@ def search_notes(
         top_k: 返回结果数量
         note_type: 笔记类型筛选
         mode: 搜索模式 - "hybrid"(混合), "semantic"(语义), "keyword"(关键词)
+        tags: 标签筛选列表（AND 逻辑）
 
     Returns:
         搜索结果列表
@@ -345,7 +353,7 @@ def search_notes(
     }
     search_mode = mode_map.get(mode.lower(), SearchMode.HYBRID)
 
-    return search_engine.search(query, top_k=top_k, mode=search_mode, note_type=note_type)
+    return search_engine.search(query, top_k=top_k, mode=search_mode, note_type=note_type, tags=tags)
 
 
 def extract_keywords(content: str, max_keywords: int = 10) -> List[str]:

--- a/jfox/note.py
+++ b/jfox/note.py
@@ -171,15 +171,13 @@ def list_notes(
             if note:
                 notes.append(note)
 
-            if limit and len(notes) >= limit:
-                break
-
-        if limit and len(notes) >= limit:
-            break
-
-    # 标签过滤（AND 逻辑）
+    # 标签过滤（AND 逻辑）—— 先过滤再截断，避免 limit + tags 组合时数量不足
     if tags:
         notes = [n for n in notes if all(t in n.tags for t in tags)]
+
+    # 截断到 limit
+    if limit:
+        notes = notes[:limit]
 
     return notes
 

--- a/jfox/note.py
+++ b/jfox/note.py
@@ -353,7 +353,9 @@ def search_notes(
     }
     search_mode = mode_map.get(mode.lower(), SearchMode.HYBRID)
 
-    return search_engine.search(query, top_k=top_k, mode=search_mode, note_type=note_type, tags=tags)
+    return search_engine.search(
+        query, top_k=top_k, mode=search_mode, note_type=note_type, tags=tags
+    )
 
 
 def extract_keywords(content: str, max_keywords: int = 10) -> List[str]:

--- a/jfox/search_engine.py
+++ b/jfox/search_engine.py
@@ -54,6 +54,7 @@ class HybridSearchEngine:
         top_k: int = 5,
         mode: SearchMode = SearchMode.HYBRID,
         note_type: Optional[str] = None,
+        tags: Optional[List[str]] = None,
     ) -> List[Dict[str, Any]]:
         """
         执行搜索
@@ -63,26 +64,28 @@ class HybridSearchEngine:
             top_k: 返回结果数量
             mode: 搜索模式
             note_type: 笔记类型筛选
+            tags: 标签筛选
 
         Returns:
             搜索结果列表
         """
         if mode == SearchMode.SEMANTIC:
-            return self._semantic_search(query, top_k, note_type)
+            return self._semantic_search(query, top_k, note_type, tags)
         elif mode == SearchMode.KEYWORD:
-            return self._keyword_search(query, top_k)
+            return self._keyword_search(query, top_k, tags)
         else:  # HYBRID
-            return self._hybrid_search(query, top_k, note_type)
+            return self._hybrid_search(query, top_k, note_type, tags)
 
     def _semantic_search(
         self,
         query: str,
         top_k: int,
         note_type: Optional[str] = None,
+        tags: Optional[List[str]] = None,
     ) -> List[Dict[str, Any]]:
         """纯语义搜索"""
         try:
-            results = self.vector_store.search(query, top_k=top_k, note_type=note_type)
+            results = self.vector_store.search(query, top_k=top_k, note_type=note_type, tags=tags)
             # 添加搜索模式标记
             for r in results:
                 r["search_mode"] = "semantic"
@@ -91,7 +94,7 @@ class HybridSearchEngine:
             logger.error(f"Semantic search failed: {e}")
             return []
 
-    def _keyword_search(self, query: str, top_k: int) -> List[Dict[str, Any]]:
+    def _keyword_search(self, query: str, top_k: int, tags: Optional[List[str]] = None) -> List[Dict[str, Any]]:
         """纯关键词搜索 (BM25)"""
         try:
             bm25_results = self.bm25_index.search(query, top_k=top_k)
@@ -104,6 +107,10 @@ class HybridSearchEngine:
 
                 note = note_module.load_note_by_id(r["note_id"])
                 if note:
+                    # 如果有标签筛选，检查是否匹配所有标签
+                    if tags and not all(t in note.tags for t in tags):
+                        continue
+
                     results.append(
                         {
                             "id": r["note_id"],
@@ -115,6 +122,7 @@ class HybridSearchEngine:
                             "metadata": {
                                 "title": note.title,
                                 "type": note.type.value,
+                                "tags": ",".join(note.tags),
                             },
                             "score": r["score"],
                             "search_mode": "keyword",
@@ -131,6 +139,7 @@ class HybridSearchEngine:
         query: str,
         top_k: int,
         note_type: Optional[str] = None,
+        tags: Optional[List[str]] = None,
     ) -> List[Dict[str, Any]]:
         """
         混合搜索：RRF 融合
@@ -144,7 +153,7 @@ class HybridSearchEngine:
         bm25_results = []
 
         try:
-            semantic_results = self.vector_store.search(query, top_k=search_k, note_type=note_type)
+            semantic_results = self.vector_store.search(query, top_k=search_k, note_type=note_type, tags=tags)
         except Exception as e:
             logger.warning(f"Semantic search failed in hybrid mode: {e}")
 
@@ -157,13 +166,27 @@ class HybridSearchEngine:
         if not semantic_results and not bm25_results:
             return []
         elif not semantic_results:
-            return self._keyword_search(query, top_k)
+            return self._keyword_search(query, top_k, tags)
         elif not bm25_results:
             for r in semantic_results[:top_k]:
                 r["search_mode"] = "semantic"
             return semantic_results[:top_k]
 
-        # 2. RRF 融合
+        # 2. 如果有标签筛选，过滤 BM25 结果
+        if tags:
+            filtered_bm25_results = []
+            from . import note as note_module
+
+            for result in bm25_results:
+                note_id = result.get("note_id")
+                if note_id:
+                    note = note_module.load_note_by_id(note_id)
+                    if note and all(t in note.tags for t in tags):
+                        filtered_bm25_results.append(result)
+
+            bm25_results = filtered_bm25_results
+
+        # 3. RRF 融合
         fused_scores: Dict[str, float] = {}
         result_data: Dict[str, Dict] = {}
 
@@ -195,6 +218,7 @@ class HybridSearchEngine:
                             "metadata": {
                                 "title": note.title,
                                 "type": note.type.value,
+                                "tags": ",".join(note.tags),
                             },
                         }
 

--- a/jfox/search_engine.py
+++ b/jfox/search_engine.py
@@ -94,7 +94,9 @@ class HybridSearchEngine:
             logger.error(f"Semantic search failed: {e}")
             return []
 
-    def _keyword_search(self, query: str, top_k: int, tags: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+    def _keyword_search(
+        self, query: str, top_k: int, tags: Optional[List[str]] = None
+    ) -> List[Dict[str, Any]]:
         """纯关键词搜索 (BM25)"""
         try:
             bm25_results = self.bm25_index.search(query, top_k=top_k)
@@ -153,7 +155,9 @@ class HybridSearchEngine:
         bm25_results = []
 
         try:
-            semantic_results = self.vector_store.search(query, top_k=search_k, note_type=note_type, tags=tags)
+            semantic_results = self.vector_store.search(
+                query, top_k=search_k, note_type=note_type, tags=tags
+            )
         except Exception as e:
             logger.warning(f"Semantic search failed in hybrid mode: {e}")
 

--- a/jfox/search_engine.py
+++ b/jfox/search_engine.py
@@ -99,7 +99,9 @@ class HybridSearchEngine:
     ) -> List[Dict[str, Any]]:
         """纯关键词搜索 (BM25)"""
         try:
-            bm25_results = self.bm25_index.search(query, top_k=top_k)
+            # 请求更多结果以补偿标签过滤后的数量损失
+            search_k = top_k * 3 if tags else top_k
+            bm25_results = self.bm25_index.search(query, top_k=search_k)
 
             # 转换为与语义搜索一致的格式
             results = []

--- a/jfox/vector_store.py
+++ b/jfox/vector_store.py
@@ -1,4 +1,4 @@
-"""ChromaDB 向量存储封装 """
+"""ChromaDB 向量存储封装"""
 
 import logging
 import re
@@ -106,7 +106,11 @@ class VectorStore:
             return False
 
     def search(
-        self, query: str, top_k: int = 5, note_type: Optional[str] = None, tags: Optional[List[str]] = None
+        self,
+        query: str,
+        top_k: int = 5,
+        note_type: Optional[str] = None,
+        tags: Optional[List[str]] = None,
     ) -> List[Dict[str, Any]]:
         """语义搜索"""
         if self.collection is None:

--- a/jfox/vector_store.py
+++ b/jfox/vector_store.py
@@ -1,4 +1,4 @@
-"""ChromaDB 向量存储封装"""
+"""ChromaDB 向量存储封装 """
 
 import logging
 import re
@@ -106,7 +106,7 @@ class VectorStore:
             return False
 
     def search(
-        self, query: str, top_k: int = 5, note_type: Optional[str] = None
+        self, query: str, top_k: int = 5, note_type: Optional[str] = None, tags: Optional[List[str]] = None
     ) -> List[Dict[str, Any]]:
         """语义搜索"""
         if self.collection is None:
@@ -123,6 +123,17 @@ class VectorStore:
             where = {}
             if note_type:
                 where["type"] = note_type
+
+            if tags:
+                tag_clauses = [{"tags": {"$contains": t}} for t in tags]
+                if where:
+                    # 已有 note_type 条件，合并到 $and
+                    combined = [where] + tag_clauses
+                    where = {"$and": combined}
+                elif len(tag_clauses) > 1:
+                    where = {"$and": tag_clauses}
+                else:
+                    where = tag_clauses[0]
 
             # 搜索
             results = self.collection.query(

--- a/tests/integration/test_tag_filter_cli.py
+++ b/tests/integration/test_tag_filter_cli.py
@@ -1,0 +1,83 @@
+"""
+测试类型: 集成测试（CLI 层）
+目标模块: jfox.cli (list --tag, search --tag)
+预估耗时: < 5秒
+依赖要求: 不需要 embedding
+
+测试 CLI 层面的 --tag 标签过滤功能
+"""
+
+import json
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.fast]
+
+
+class TestListTagFilterCLI:
+    """jfox list --tag CLI 集成测试"""
+
+    def test_list_filter_single_tag(self, cli):
+        """单标签过滤"""
+        cli.add("Python 编程基础", title="Python 基础", tags=["python", "编程"])
+        cli.add("Java 编程入门", title="Java 入门", tags=["java", "编程"])
+        cli.add("今日想法", title="想法")
+
+        result = cli.list(tags=["python"])
+        assert result.success
+        data = result.json()
+        assert data["total"] == 1
+        assert data["notes"][0]["title"] == "Python 基础"
+
+    def test_list_filter_multiple_tags_and(self, cli):
+        """多标签 AND 逻辑"""
+        cli.add("Python 编程基础", title="Python 基础", tags=["python", "编程"])
+        cli.add("Python 机器学习", title="ML 笔记", tags=["python", "机器学习"])
+        cli.add("Java 编程入门", title="Java 入门", tags=["java", "编程"])
+
+        result = cli.list(tags=["python", "编程"])
+        assert result.success
+        data = result.json()
+        assert data["total"] == 1
+        assert data["notes"][0]["title"] == "Python 基础"
+
+    def test_list_filter_nonexistent_tag(self, cli):
+        """不存在的标签返回空"""
+        cli.add("一些内容", title="测试笔记")
+
+        result = cli.list(tags=["nonexistent"])
+        assert result.success
+        data = result.json()
+        assert data["total"] == 0
+
+    def test_list_filter_no_tag(self, cli):
+        """不传 --tag 返回全部"""
+        cli.add("笔记1", title="笔记1", tags=["tag1"])
+        cli.add("笔记2", title="笔记2")
+
+        result = cli.list()
+        assert result.success
+        data = result.json()
+        assert data["total"] == 2
+
+
+class TestSearchTagFilterCLI:
+    """jfox search --tag CLI 集成测试
+
+    注意：search 需要 embedding，标记为 embedding。
+    仅在 core/full CI job 中运行。
+    """
+
+    pytestmark = [pytest.mark.integration, pytest.mark.embedding]
+
+    def test_search_filter_by_tag(self, cli):
+        """search --tag 按标签预过滤"""
+        cli.add("Python 编程基础教程", title="Python 基础", tags=["python"])
+        cli.add("Java 编程入门教程", title="Java 入门", tags=["java"])
+
+        result = cli.search("编程教程", tags=["python"])
+        assert result.success
+        data = result.json()
+        assert data["total"] >= 1
+        for r in data["results"]:
+            assert "python" in r.get("metadata", {}).get("tags", "")

--- a/tests/integration/test_tag_filter_cli.py
+++ b/tests/integration/test_tag_filter_cli.py
@@ -7,8 +7,6 @@
 测试 CLI 层面的 --tag 标签过滤功能
 """
 
-import json
-
 import pytest
 
 pytestmark = [pytest.mark.integration, pytest.mark.fast]

--- a/tests/unit/test_tag_filter.py
+++ b/tests/unit/test_tag_filter.py
@@ -28,8 +28,6 @@ class TestListNotesTagFilter:
         cfg = ZKConfig(base_dir=temp_kb)
         cfg.ensure_dirs()
 
-        from jfox.note import save_note
-
         notes = [
             Note(
                 id="20260428001",
@@ -70,7 +68,11 @@ class TestListNotesTagFilter:
         ]
 
         for n in notes:
-            save_note(n, cfg=cfg)
+            # 直接写入文件（save_note 不接受 cfg 参数）
+            note_dir = cfg.notes_dir / n.type.value
+            note_dir.mkdir(parents=True, exist_ok=True)
+            note_file = note_dir / f"{n.id}.md"
+            note_file.write_text(n.to_markdown(), encoding="utf-8")
 
         return cfg
 

--- a/tests/unit/test_tag_filter.py
+++ b/tests/unit/test_tag_filter.py
@@ -1,0 +1,112 @@
+"""
+测试类型: 单元测试
+目标模块: jfox.note (list_notes tags 过滤)
+预估耗时: < 1秒
+依赖要求: 无外部依赖
+
+测试 list_notes 的 tags 过滤功能（AND 逻辑）
+"""
+
+from datetime import datetime
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+from jfox.models import Note, NoteType
+from jfox.note import list_notes
+
+
+class TestListNotesTagFilter:
+    """list_notes tags 过滤测试"""
+
+    @pytest.fixture
+    def kb_with_tagged_notes(self, temp_kb):
+        """创建带标签笔记的知识库"""
+        from jfox.config import ZKConfig
+
+        cfg = ZKConfig(base_dir=temp_kb)
+        cfg.ensure_dirs()
+
+        from jfox.note import save_note
+
+        notes = [
+            Note(
+                id="20260428001",
+                title="Python 基础",
+                content="Python 编程基础",
+                type=NoteType.PERMANENT,
+                tags=["python", "编程"],
+                created=datetime(2026, 4, 28, 0, 1),
+                updated=datetime(2026, 4, 28, 0, 1),
+            ),
+            Note(
+                id="20260428002",
+                title="Java 入门",
+                content="Java 编程入门",
+                type=NoteType.PERMANENT,
+                tags=["java", "编程"],
+                created=datetime(2026, 4, 28, 0, 2),
+                updated=datetime(2026, 4, 28, 0, 2),
+            ),
+            Note(
+                id="20260428003",
+                title="机器学习笔记",
+                content="机器学习相关内容",
+                type=NoteType.LITERATURE,
+                tags=["python", "机器学习"],
+                created=datetime(2026, 4, 28, 0, 3),
+                updated=datetime(2026, 4, 28, 0, 3),
+            ),
+            Note(
+                id="20260428004",
+                title="今日想法",
+                content="随手记录",
+                type=NoteType.FLEETING,
+                tags=[],
+                created=datetime(2026, 4, 28, 0, 4),
+                updated=datetime(2026, 4, 28, 0, 4),
+            ),
+        ]
+
+        for n in notes:
+            save_note(n, cfg=cfg)
+
+        return cfg
+
+    def test_filter_single_tag(self, kb_with_tagged_notes):
+        """单标签过滤"""
+        results = list_notes(tags=["python"], cfg=kb_with_tagged_notes)
+        assert len(results) == 2
+        titles = {n.title for n in results}
+        assert titles == {"Python 基础", "机器学习笔记"}
+
+    def test_filter_multiple_tags_and_logic(self, kb_with_tagged_notes):
+        """多标签 AND 逻辑"""
+        results = list_notes(tags=["python", "编程"], cfg=kb_with_tagged_notes)
+        assert len(results) == 1
+        assert results[0].title == "Python 基础"
+
+    def test_filter_nonexistent_tag(self, kb_with_tagged_notes):
+        """不存在的标签返回空"""
+        results = list_notes(tags=["nonexistent"], cfg=kb_with_tagged_notes)
+        assert len(results) == 0
+
+    def test_filter_no_tag_param(self, kb_with_tagged_notes):
+        """不传 tags 参数返回全部"""
+        results = list_notes(cfg=kb_with_tagged_notes)
+        assert len(results) == 4
+
+    def test_filter_empty_notes(self, kb_with_tagged_notes):
+        """无标签笔记不会被选中"""
+        results = list_notes(tags=["python"], cfg=kb_with_tagged_notes)
+        for n in results:
+            assert "今日想法" not in n.title
+
+    def test_filter_with_note_type(self, kb_with_tagged_notes):
+        """标签 + 类型联合过滤"""
+        results = list_notes(
+            tags=["python"], note_type=NoteType.PERMANENT, cfg=kb_with_tagged_notes
+        )
+        assert len(results) == 1
+        assert results[0].title == "Python 基础"

--- a/tests/unit/test_tag_filter.py
+++ b/tests/unit/test_tag_filter.py
@@ -112,3 +112,14 @@ class TestListNotesTagFilter:
         )
         assert len(results) == 1
         assert results[0].title == "Python 基础"
+
+    def test_filter_with_limit_returns_correct_count(self, kb_with_tagged_notes):
+        """limit + tags 组合：先过滤标签再截断，确保数量正确"""
+        # 共 4 条笔记，"编程" 标签有 2 条（Python 基础、Java 入门）
+        # limit=5 应返回 2 条（不过度截断）
+        results = list_notes(tags=["编程"], limit=5, cfg=kb_with_tagged_notes)
+        assert len(results) == 2
+
+        # limit=1 应返回 1 条
+        results = list_notes(tags=["编程"], limit=1, cfg=kb_with_tagged_notes)
+        assert len(results) == 1

--- a/tests/utils/jfox_cli.py
+++ b/tests/utils/jfox_cli.py
@@ -209,6 +209,7 @@ class ZKCLI:
 
     def list(
         self,
+        *,
         note_type: Optional[str] = None,
         tags: Optional[List[str]] = None,
         limit: Optional[int] = None,
@@ -228,6 +229,7 @@ class ZKCLI:
     def search(
         self,
         query: str,
+        *,
         top: int = 5,
         note_type: Optional[str] = None,
         tags: Optional[List[str]] = None,

--- a/tests/utils/jfox_cli.py
+++ b/tests/utils/jfox_cli.py
@@ -207,21 +207,38 @@ class ZKCLI:
 
         return self._run("add", *args)
 
-    def list(self, note_type: Optional[str] = None, limit: Optional[int] = None) -> CLIResult:
+    def list(
+        self,
+        note_type: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+    ) -> CLIResult:
         """列出笔记"""
         args = []
         if note_type:
             args.extend(["--type", note_type])
+        if tags:
+            for tag in tags:
+                args.extend(["--tag", tag])
         if limit:
             args.extend(["--limit", str(limit)])
 
         return self._run("list", *args)
 
-    def search(self, query: str, top: int = 5, note_type: Optional[str] = None) -> CLIResult:
+    def search(
+        self,
+        query: str,
+        top: int = 5,
+        note_type: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+    ) -> CLIResult:
         """语义搜索"""
         args = [query, "--top", str(top)]
         if note_type:
             args.extend(["--type", note_type])
+        if tags:
+            for tag in tags:
+                args.extend(["--tag", tag])
 
         return self._run("search", *args)
 


### PR DESCRIPTION
## Summary

- Add `--tag` (repeatable, AND logic) to `jfox list` and `jfox search` commands
- Thread `tags` parameter through all layers: CLI → note.py → search_engine.py → vector_store.py
- ChromaDB `$contains` metadata filter for semantic/hybrid search, post-filter for BM25, in-memory filter for list
- Add Tags column to `jfox list` table output

## Changes

| File | Change |
|------|--------|
| `jfox/vector_store.py` | Add `tags` param to `search()`, build ChromaDB `$contains` where clause |
| `jfox/search_engine.py` | Add `tags` param to `search()`, pass through + BM25 post-filter |
| `jfox/note.py` | Add `tags` param to `list_notes()` and `search_notes()` |
| `jfox/cli.py` | Add `--tag` option to `search`/`list` commands, show Tags column in table |
| `tests/unit/test_tag_filter.py` | 6 unit tests for list_notes tags filtering |
| `tests/integration/test_tag_filter_cli.py` | 4 CLI integration tests (list) + 1 embedding test (search) |
| `tests/utils/jfox_cli.py` | Add `tags` param to `list()` and `search()` wrapper methods |

## Usage

```bash
jfox list --tag python --tag async           # List notes tagged with BOTH python AND async
jfox search --tag python "concurrency"       # Pre-filter by tag, then search
```

## Test plan

- [x] Unit tests: `list_notes(tags=...)` AND logic (6 tests, fast)
- [x] CLI integration tests: `jfox list --tag` (4 tests, fast)
- [ ] Search integration test: `jfox search --tag` (requires embedding, CI core/full)
- [ ] Full test suite passes on CI

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)