### PR TITLE
chore: add superpowers plans and specs docs, update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,13 @@ Thumbs.db
 chroma_db/
 *.sqlite3
 cache/
+
+# Claude Code runtime files
+.claude/scheduled_tasks.json
+.claude/scheduled_tasks.lock
+.claude/worktrees/
+
+# Temporary analysis files
+analysis_report.md
+kimi-export-*.md
+review_body*.md

--- a/docs/superpowers/plans/2026-04-13-add-content-file.md
+++ b/docs/superpowers/plans/2026-04-13-add-content-file.md
@@ -1,0 +1,301 @@
+# add --content-file Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `jfox add` 支持 `--content-file` 选项，从文件或 stdin 读取笔记内容。
+
+**Architecture:** 在 `add` 命令中将 `content` 从必需位置参数改为可选参数，新增 `--content-file` 选项。文件读取逻辑复用 `edit` 命令已有的模式（`cli.py` L975-986），两者互斥校验。stdin 支持通过 `--content-file -` 实现。`_add_note_impl` 签名不变。
+
+**Tech Stack:** Python, Typer, pathlib
+
+---
+
+### Task 1: 文件读取逻辑提取为公共函数
+
+**Files:**
+- Modify: `jfox/cli.py` (在 `_edit_impl` 之前添加公共函数)
+- Modify: `jfox/cli.py:970-986` (`_edit_impl` 调用改为使用公共函数)
+
+**为什么先做：** `add` 和 `edit` 都需要读取 `--content-file`，提取公共函数避免重复代码，也方便单独测试。
+
+- [ ] **Step 1: 在 `_edit_impl` 之前添加 `_read_content_file()` 函数**
+
+在 `jfox/cli.py` 约第 958 行（`_edit_impl` 定义之前）插入：
+
+```python
+def _read_content_file(content_file: str) -> str:
+    """从文件或 stdin 读取内容（--content-file 共用逻辑）"""
+    if content_file == "-":
+        import sys
+
+        return sys.stdin.read()
+
+    p = Path(content_file)
+    if not p.exists():
+        raise ValueError(f"文件不存在: {content_file}")
+    if not p.is_file():
+        raise ValueError(f"路径不是文件: {content_file}")
+    try:
+        return p.read_text(encoding="utf-8")
+    except PermissionError:
+        raise ValueError(f"无权限读取文件: {content_file}")
+    except UnicodeDecodeError:
+        raise ValueError(f"文件编码错误（需要 UTF-8）: {content_file}")
+```
+
+- [ ] **Step 2: 重构 `_edit_impl` 使用公共函数**
+
+将 `jfox/cli.py` L974-986（`_edit_impl` 中的文件读取代码）：
+
+```python
+    # 从文件读取内容
+    if content_file is not None:
+        p = Path(content_file)
+        if not p.exists():
+            raise ValueError(f"文件不存在: {content_file}")
+        if not p.is_file():
+            raise ValueError(f"路径不是文件: {content_file}")
+        try:
+            content = p.read_text(encoding="utf-8")
+        except PermissionError:
+            raise ValueError(f"无权限读取文件: {content_file}")
+        except UnicodeDecodeError:
+            raise ValueError(f"文件编码错误（需要 UTF-8）: {content_file}")
+```
+
+替换为：
+
+```python
+    # 从文件读取内容
+    if content_file is not None:
+        content = _read_content_file(content_file)
+```
+
+- [ ] **Step 3: 运行快速回归测试，确认 edit 功能不变**
+
+Run: `uv run pytest tests/test_cli_format.py::TestAddAndDeleteFormat -v`
+Expected: 全部 PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add jfox/cli.py
+git commit -m "refactor: extract _read_content_file() for shared --content-file logic"
+```
+
+---
+
+### Task 2: add 命令支持 --content-file 选项
+
+**Files:**
+- Modify: `jfox/cli.py:366-383` (`add` 函数签名和调用)
+
+- [ ] **Step 1: 修改 `add()` 函数签名**
+
+将 `jfox/cli.py` L367-368：
+
+```python
+@app.command()
+def add(
+    content: str = typer.Argument(..., help="笔记内容（支持 [[笔记标题]] 格式链接）"),
+```
+
+改为：
+
+```python
+@app.command()
+def add(
+    content: Optional[str] = typer.Argument(None, help="笔记内容（支持 [[笔记标题]] 格式链接）"),
+```
+
+- [ ] **Step 2: 在 `--template` 选项之后添加 `--content-file` 参数**
+
+在 `jfox/cli.py` L375-377（`template` 参数定义之后）插入：
+
+```python
+    content_file: Optional[str] = typer.Option(
+        None, "--content-file", help="从文件读取内容（用 - 表示 stdin）"
+    ),
+```
+
+- [ ] **Step 3: 在 `add()` 函数体中添加互斥校验和文件读取逻辑**
+
+将 `jfox/cli.py` L384-397：
+
+```python
+    """添加新笔记（内容中可用 [[笔记标题]] 引用其他笔记）"""
+    try:
+        # 向后兼容：--json 快捷方式
+        if json_output:
+            output_format = "json"
+
+        # 如果指定了知识库，临时切换
+        if kb:
+            from .config import use_kb
+
+            with use_kb(kb):
+                _add_note_impl(content, title, note_type, tags, source, output_format, template)
+        else:
+            _add_note_impl(content, title, note_type, tags, source, output_format, template)
+```
+
+改为：
+
+```python
+    """添加新笔记（内容中可用 [[笔记标题]] 引用其他笔记）"""
+    try:
+        # 向后兼容：--json 快捷方式
+        if json_output:
+            output_format = "json"
+
+        # content 和 --content-file 互斥
+        if content is not None and content_file is not None:
+            raise ValueError("不能同时指定内容参数和 --content-file，请选择其一")
+
+        # 从文件读取内容
+        if content_file is not None:
+            content = _read_content_file(content_file)
+
+        # 至少提供一种内容来源
+        if not content:
+            raise ValueError("请提供笔记内容（位置参数或 --content-file）")
+
+        # 如果指定了知识库，临时切换
+        if kb:
+            from .config import use_kb
+
+            with use_kb(kb):
+                _add_note_impl(content, title, note_type, tags, source, output_format, template)
+        else:
+            _add_note_impl(content, title, note_type, tags, source, output_format, template)
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add jfox/cli.py
+git commit -m "feat: add --content-file option to jfox add command"
+```
+
+---
+
+### Task 3: 测试 --content-file 功能
+
+**Files:**
+- Modify: `tests/test_cli_format.py` (在 `TestAddAndDeleteFormat` 类中添加测试)
+
+- [ ] **Step 1: 在 `test_add_format_json` 之前添加 --content-file 测试**
+
+在 `tests/test_cli_format.py` 的 `TestAddAndDeleteFormat` 类中，`test_add_format_json` (L327) 之前插入：
+
+```python
+    def test_add_content_file(self, cli, tmp_path):
+        """测试 add 命令 --content-file 从文件读取内容"""
+        content_file = tmp_path / "note.md"
+        content_file.write_text("从文件读取的笔记内容", encoding="utf-8")
+
+        result = cli.run("add", "--content-file", str(content_file), "--title", "FileContent")
+
+        assert result.success
+        data = result.data
+        assert data["success"] is True
+        assert data["note"]["title"] == "FileContent"
+
+    def test_add_content_file_mutual_exclusive(self, cli, tmp_path):
+        """测试 add 命令 content 参数和 --content-file 不能同时指定"""
+        content_file = tmp_path / "note.md"
+        content_file.write_text("file content", encoding="utf-8")
+
+        result = cli.run("add", "直接内容", "--content-file", str(content_file))
+
+        assert not result.success
+        assert "不能同时指定" in result.stderr or "不能同时指定" in result.stdout
+
+    def test_add_content_file_not_found(self, cli):
+        """测试 add 命令 --content-file 文件不存在时报错"""
+        result = cli.run("add", "--content-file", "/nonexistent/file.md")
+
+        assert not result.success
+        assert "文件不存在" in result.stderr or "文件不存在" in result.stdout
+
+    def test_add_content_file_empty(self, cli, tmp_path):
+        """测试 add 命令不提供内容时报错"""
+        result = cli.run("add")
+
+        assert not result.success
+
+    def test_add_content_file_with_wiki_links(self, cli, tmp_path):
+        """测试 add 命令 --content-file 内容中的 [[wiki链接]] 正常解析"""
+        # 先创建一个目标笔记
+        cli.add("目标笔记内容", title="目标笔记")
+
+        content_file = tmp_path / "linked.md"
+        content_file.write_text("引用 [[目标笔记]] 的内容", encoding="utf-8")
+
+        result = cli.run("add", "--content-file", str(content_file), "--title", "带链接的笔记")
+
+        assert result.success
+        data = result.data
+        assert data["note"]["links"]
+```
+
+- [ ] **Step 2: 运行测试确认全部通过**
+
+Run: `uv run pytest tests/test_cli_format.py::TestAddAndDeleteFormat -v`
+Expected: 全部 PASS（包括新增的 5 个测试）
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_cli_format.py
+git commit -m "test: add --content-file tests for jfox add command"
+```
+
+---
+
+### Task 4: 验证 edit --content-file 回归
+
+**Files:** 无修改
+
+- [ ] **Step 1: 确认 edit 的 --content-file 仍然正常工作**
+
+检查现有 edit 测试是否覆盖 --content-file：
+
+```bash
+uv run pytest tests/test_cli_format.py -v -k "edit"
+```
+
+如果 edit 的 --content-file 没有现有测试，手动验证：
+
+```bash
+uv run jfox add "原始内容" --title "编辑测试" --json
+# 记录返回的 note_id
+echo "新内容" > /tmp/test_edit.md
+uv run jfox edit <note_id> --content-file /tmp/test_edit.md --json
+```
+
+Expected: edit 成功，内容更新为 "新内容"
+
+- [ ] **Step 2: 确认 add 的原有行为不受影响**
+
+```bash
+uv run jfox add "直接输入的内容" --title "位置参数测试" --json
+```
+
+Expected: add 成功，内容为 "直接输入的内容"
+
+---
+
+## Self-Review Checklist
+
+| 检查项 | 状态 |
+|--------|------|
+| `_read_content_file` 覆盖文件不存在/非文件/权限/编码错误 | Done (Task 1) |
+| stdin 支持 (`--content-file -`) | Done (Task 1, `content_file == "-"` 分支) |
+| `content` 和 `--content-file` 互斥校验 | Done (Task 2) |
+| 都不指定时报错提示 | Done (Task 2) |
+| `--content-file` 与 `--template` 交互正确（内容作为 `{{content}}` 变量） | Done (Task 2, `_add_note_impl` 未修改，`content` 变量直接传入) |
+| `-f` 短选项不被占用 | Done (Task 2, `--content-file` 无短选项) |
+| `wiki_links` 提取仍正常工作 | Done (Task 3 测试覆盖) |
+| `edit` 命令回归安全 | Done (Task 1 提取公共函数，Task 4 验证) |
+| `_add_note_impl` 签名未修改 | Done (Task 2 只在 `add()` 中读取文件后传入 `content: str`) |

--- a/docs/superpowers/plans/2026-04-13-bulk-import-vectorstore-init.md
+++ b/docs/superpowers/plans/2026-04-13-bulk-import-vectorstore-init.md
@@ -1,0 +1,270 @@
+# Bulk-Import VectorStore 初始化修复 实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修复 `bulk_import_notes()` 中 VectorStore.collection 未初始化导致批量索引静默失败的问题，同时让 `index rebuild` 命令同时重建 BM25 索引。
+
+**Architecture:** 两处独立修复：(1) `performance.py` 在批量索引前确保 VectorStore 已初始化；(2) `cli.py` 的 `index rebuild` 命令增加 BM25 重建步骤。两处修复互不依赖。
+
+**Tech Stack:** Python 3.10+, pytest, unittest.mock
+
+---
+
+## Task 1: 修复 bulk_import_notes 中 VectorStore 未初始化的 bug
+
+**Files:**
+- Modify: `jfox/performance.py:266`
+- Test: `tests/unit/test_bm25_batch.py`
+
+- [ ] **Step 1: 写一个能复现 bug 的失败测试**
+
+在 `tests/unit/test_bm25_batch.py` 的 `TestBulkImportBM25Integration` 类中，添加一个测试：模拟 `VectorStore` 的 `collection` 为 `None`（即真实场景），验证 `bulk_import_notes` 不会抛异常。
+
+```python
+@patch("jfox.bm25_index.get_bm25_index")
+@patch("jfox.embedding_backend.get_backend")
+@patch("jfox.note.create_note")
+def test_bulk_import_with_uninitialized_vectorstore(
+    self, mock_create_note, mock_get_backend, mock_get_bm25, tmp_path
+):
+    """bulk_import_notes 应在 collection.add() 前自动初始化 VectorStore"""
+    import numpy as np
+
+    from jfox.models import Note, NoteType
+    from jfox.performance import bulk_import_notes
+
+    # 准备 mock note
+    mock_note = MagicMock(spec=Note)
+    mock_note.id = "20260413120000"
+    mock_note.title = "测试初始化"
+    mock_note.content = "内容"
+    mock_note.type = NoteType.PERMANENT
+    mock_note.tags = []
+    mock_note.filepath = tmp_path / "notes" / "permanent" / "test.md"
+    mock_note.to_markdown.return_value = "# 测试初始化\n内容"
+    mock_create_note.return_value = mock_note
+
+    # mock embedding backend
+    mock_backend = MagicMock()
+    mock_backend.model = MagicMock()
+    mock_backend.encode.return_value = np.array([[0.1] * 384])
+    mock_get_backend.return_value = mock_backend
+
+    # mock BM25
+    mock_bm25 = MagicMock()
+    mock_bm25.add_documents_batch.return_value = True
+    mock_get_bm25.return_value = mock_bm25
+
+    # 不 mock get_vector_store，让真实的 VectorStore 被创建
+    # 但 patch 掉 VectorStore.init 来验证它被调用了
+    with patch("jfox.performance.get_vector_store") as mock_get_vs:
+        mock_vs = MagicMock()
+        # 关键：collection 初始为 None，模拟真实场景
+        mock_vs.collection = None
+
+        # init() 会设置 collection
+        def fake_init():
+            mock_vs.collection = MagicMock()
+
+        mock_vs.init.side_effect = fake_init
+        mock_get_vs.return_value = mock_vs
+
+        notes_data = [{"title": "测试初始化", "content": "内容"}]
+        result = bulk_import_notes(notes_data, show_progress=False)
+
+        # 验证 init 被调用了
+        mock_vs.init.assert_called()
+        # 导入成功
+        assert result["imported"] == 1
+```
+
+- [ ] **Step 2: 运行测试确认它失败**
+
+Run: `uv run pytest tests/unit/test_bm25_batch.py::TestBulkImportBM25Integration::test_bulk_import_with_uninitialized_vectorstore -v`
+Expected: FAIL — 当前代码直接访问 `vector_store.collection.add()`，不会调用 `init()`，mock 的 `collection` 仍为 None，会抛 `AttributeError`。
+
+- [ ] **Step 3: 修复 performance.py — 在 collection.add() 前添加初始化**
+
+在 `jfox/performance.py` 第 266 行之前，添加初始化检查。修改 `# 批量添加到 ChromaDB` 注释后的代码块：
+
+```python
+                # 确保 VectorStore 已初始化
+                if vector_store.collection is None:
+                    vector_store.init()
+
+                # 批量添加到 ChromaDB
+                vector_store.collection.add(
+                    ids=ids, documents=documents, embeddings=embeddings, metadatas=metadatas
+                )
+```
+
+完整上下文（`performance.py` 约第 254-268 行）修改后为：
+
+```python
+                # 批量添加到 ChromaDB
+                ids = [n.id for n in notes]
+                metadatas = [
+                    {
+                        "title": n.title,
+                        "type": n.type.value,
+                        "filepath": str(n.filepath),
+                        "tags": ",".join(n.tags),
+                    }
+                    for n in notes
+                ]
+
+                # 确保 VectorStore 已初始化
+                if vector_store.collection is None:
+                    vector_store.init()
+
+                vector_store.collection.add(
+                    ids=ids, documents=documents, embeddings=embeddings, metadatas=metadatas
+                )
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `uv run pytest tests/unit/test_bm25_batch.py -v`
+Expected: ALL PASS（包括新测试和原有测试）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add jfox/performance.py tests/unit/test_bm25_batch.py
+git commit -m "fix: bulk_import_notes 中 VectorStore.collection 未初始化导致索引失败
+
+performance.py 的 bulk_import_notes() 直接访问 vector_store.collection.add()，
+绕过了 add_note() 中的 init() 保护。在新会话中直接执行 bulk-import 时，
+collection 为 None 导致 'NoneType' object has no attribute 'add' 错误。
+
+在 collection.add() 前添加 if vector_store.collection is None: vector_store.init()。
+
+Closes #126 (修复 1/2)"
+```
+
+---
+
+## Task 2: 让 index rebuild 同时重建 BM25 索引
+
+**Files:**
+- Modify: `jfox/cli.py:1701-1713`
+- Test: `tests/unit/test_index_kb_param.py`（在已有文件中添加测试）
+
+- [ ] **Step 1: 写失败测试 — 验证 rebuild 时也调用了 BM25 重建**
+
+在 `tests/unit/test_index_kb_param.py` 中添加测试：
+
+```python
+class TestIndexRebuildIncludesBM25:
+    """验证 index rebuild 同时重建 BM25 索引"""
+
+@patch("jfox.cli.note")
+@patch("jfox.cli.get_bm25_index")
+@patch("jfox.cli.Indexer")
+@patch("jfox.cli.get_vector_store")
+def test_rebuild_calls_bm25_rebuild(
+    self, mock_get_vs, mock_indexer_cls, mock_get_bm25, mock_note, tmp_path
+):
+    """index rebuild 应在 ChromaDB 重建后调用 BM25 rebuild_from_notes"""
+    from jfox.cli import _index_impl
+
+    # mock vector store
+    mock_vs = MagicMock()
+    mock_get_vs.return_value = mock_vs
+
+    # mock indexer
+    mock_indexer = MagicMock()
+    mock_indexer.index_all.return_value = 10
+    mock_indexer_cls.return_value = mock_indexer
+
+    # mock note.list_notes
+    mock_notes = [MagicMock() for _ in range(3)]
+    mock_note.list_notes.return_value = mock_notes
+
+    # mock BM25
+    mock_bm25 = MagicMock()
+    mock_bm25.rebuild_from_notes.return_value = True
+    mock_get_bm25.return_value = mock_bm25
+
+    _index_impl("rebuild", "text")
+
+    # 验证 ChromaDB 重建被调用
+    mock_indexer.index_all.assert_called_once()
+    # 验证 BM25 重建也被调用
+    mock_get_bm25.assert_called_once()
+    mock_bm25.rebuild_from_notes.assert_called_once_with(mock_notes)
+```
+
+- [ ] **Step 2: 运行测试确认它失败**
+
+Run: `uv run pytest tests/unit/test_index_kb_param.py::TestIndexRebuildIncludesBM25 -v`
+Expected: FAIL — 当前 `rebuild` 分支不调用 BM25 重建。
+
+- [ ] **Step 3: 修改 cli.py 的 rebuild 分支，增加 BM25 重建**
+
+修改 `jfox/cli.py` 第 1701-1713 行的 `rebuild` 分支。修改后：
+
+```python
+        elif action == "rebuild":
+            console.print("[yellow]Rebuilding index...[/yellow]")
+            count = indexer.index_all()
+
+            # 同时重建 BM25 索引
+            from . import note as note_module
+            from .bm25_index import get_bm25_index
+
+            bm25_index = get_bm25_index()
+            notes = note_module.list_notes(limit=10000)
+            bm25_success = bm25_index.rebuild_from_notes(notes)
+
+            result = {
+                "success": True,
+                "indexed": count,
+                "bm25_rebuilt": bm25_success,
+                "bm25_indexed": len(notes),
+            }
+
+            if output_format == "json":
+                print(output_json(result))
+            else:
+                console.print(f"[green]✓[/green] Indexed {count} notes")
+                if bm25_success:
+                    console.print(f"[green]✓[/green] BM25 index rebuilt: {len(notes)} notes")
+                else:
+                    console.print("[yellow]⚠[/yellow] ChromaDB rebuilt, but BM25 rebuild failed")
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `uv run pytest tests/unit/test_index_kb_param.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: 验证现有 rebuild-bm25 单独命令仍正常**
+
+Run: `uv run pytest tests/unit/test_index_kb_param.py -v -k "not RebuildIncludesBM25"`
+Expected: ALL PASS（原有测试不受影响）
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add jfox/cli.py tests/unit/test_index_kb_param.py
+git commit -m "fix: index rebuild 同时重建 BM25 索引
+
+之前 index rebuild 只重建 ChromaDB，用户需额外手动执行 rebuild-bm25。
+现在 rebuild 操作自动同时重建两个索引，输出中显示各自的重建状态。
+
+Refs #126 (修复 2/2)"
+```
+
+---
+
+## 自查清单
+
+| 检查项 | 状态 |
+|--------|------|
+| 修复 1: performance.py VectorStore 初始化 | Task 1 覆盖 |
+| 修复 2: cli.py rebuild 含 BM25 | Task 2 覆盖 |
+| 现有测试不受影响 | Task 1/2 的 Step 4 验证 |
+| 无 placeholder / TBD | 已检查，每步都有完整代码 |
+| 类型/方法签名一致 | `rebuild_from_notes(notes)` 在 bm25_index.py:369 和 cli.py 一致 |
+| `rebuild-bm25` 独立命令仍可用 | Task 2 Step 5 验证，独立命令逻辑未被修改 |

--- a/docs/superpowers/plans/2026-04-13-ingest-log-command.md
+++ b/docs/superpowers/plans/2026-04-13-ingest-log-command.md
@@ -1,0 +1,809 @@
+# ingest-log 子命令 实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新增 `jfox ingest-log` 子命令，从本地 Git 仓库提取 commit 历史并直接导入为 fleeting 笔记，解决当前 jfox-ingest skill 依赖手工解析 git log 的不健壮问题。
+
+**Architecture:** 新增 `jfox/git_extractor.py` 模块封装 git log 提取逻辑（使用 block 分隔符 + UTF-8 编码 + 路径规范化），在 `cli.py` 新增 `ingest_log` 命令调用提取器并将结果传给已有的 `bulk_import_notes()` 函数。新模块与现有代码完全解耦——仅通过返回 `List[dict]` 与 `bulk_import_notes` 的输入格式对接。
+
+**Tech Stack:** Python 3.10+, subprocess, pathlib, typer, pytest, unittest.mock
+
+---
+
+## File Structure
+
+| 文件 | 职责 |
+|------|------|
+| `jfox/git_extractor.py` | Git log 提取 + 解析（纯函数，无依赖 jfox 其他模块） |
+| `jfox/cli.py` | 新增 `ingest_log` 命令（~40 行） |
+| `tests/unit/test_git_extractor.py` | git_extractor 单元测试 |
+
+---
+
+## Task 1: 创建 git_extractor.py 核心提取模块
+
+**Files:**
+- Create: `jfox/git_extractor.py`
+
+- [ ] **Step 1: 写失败测试——parse_git_log_output 解析 block 格式**
+
+创建 `tests/unit/test_git_extractor.py`，测试解析函数能正确处理 block 分隔符格式的 git log 输出：
+
+```python
+"""git_extractor 单元测试"""
+
+import textwrap
+from pathlib import Path
+
+from jfox.git_extractor import parse_git_log_output
+
+
+class TestParseGitLogOutput:
+    """测试 git log 输出解析"""
+
+    def test_single_commit(self):
+        """解析单条 commit"""
+        raw = textwrap.dedent("""\
+            ---COMMIT_START---
+            Hash: abc123def456
+            Subject: feat: add login
+            Author: 张三
+            Date: 2026-04-10
+
+            实现了登录功能
+        """)
+        result = parse_git_log_output(raw)
+        assert len(result) == 1
+        assert result[0]["hash"] == "abc123def456"
+        assert result[0]["subject"] == "feat: add login"
+        assert result[0]["author"] == "张三"
+        assert result[0]["date"] == "2026-04-10"
+        assert result[0]["body"] == "实现了登录功能"
+
+    def test_multiple_commits(self):
+        """解析多条 commit"""
+        raw = textwrap.dedent("""\
+            ---COMMIT_START---
+            Hash: aaa111
+            Subject: first commit
+            Author: Alice
+            Date: 2026-04-01
+
+            body of first
+            ---COMMIT_START---
+            Hash: bbb222
+            Subject: second commit
+            Author: Bob
+            Date: 2026-04-02
+
+            body of second
+        """)
+        result = parse_git_log_output(raw)
+        assert len(result) == 2
+        assert result[0]["hash"] == "aaa111"
+        assert result[1]["hash"] == "bbb222"
+
+    def test_empty_body(self):
+        """空 body 的 commit"""
+        raw = textwrap.dedent("""\
+            ---COMMIT_START---
+            Hash: abc123
+            Subject: chore: version bump
+            Author: Bot
+            Date: 2026-04-10
+        """)
+        result = parse_git_log_output(raw)
+        assert len(result) == 1
+        assert result[0]["body"] == ""
+
+    def test_body_with_special_chars(self):
+        """body 包含特殊字符（|、中文、换行）"""
+        raw = textwrap.dedent("""\
+            ---COMMIT_START---
+            Hash: abc123
+            Subject: fix: parser | handling
+            Author: 张三
+            Date: 2026-04-10
+
+            修复 | 分隔符问题
+            和中文内容
+            Co-Authored-By: Claude <noreply@anthropic.com>
+        """)
+        result = parse_git_log_output(raw)
+        assert len(result) == 1
+        assert "|" in result[0]["body"]
+        assert "中文" in result[0]["body"]
+
+    def test_empty_input(self):
+        """空输入返回空列表"""
+        result = parse_git_log_output("")
+        assert result == []
+
+    def test_multiline_body_preserved(self):
+        """多行 body 完整保留"""
+        raw = textwrap.dedent("""\
+            ---COMMIT_START---
+            Hash: abc123
+            Subject: feat: big change
+            Author: Alice
+            Date: 2026-04-10
+
+            line 1
+            line 2
+            line 3
+        """)
+        result = parse_git_log_output(raw)
+        assert result[0]["body"] == "line 1\nline 2\nline 3"
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `uv run pytest tests/unit/test_git_extractor.py -v`
+Expected: FAIL（`ModuleNotFoundError: No module named 'jfox.git_extractor'`）
+
+- [ ] **Step 3: 实现 parse_git_log_output 函数**
+
+创建 `jfox/git_extractor.py`：
+
+```python
+"""Git 仓库数据提取模块
+
+从本地 Git 仓库提取 commit 历史，转换为结构化数据。
+"""
+
+import logging
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# git log block 分隔符
+_COMMIT_DELIMITER = "---COMMIT_START---"
+# git log format 模板
+_GIT_LOG_FORMAT = (
+    f"{_COMMIT_DELIMITER}%n"
+    f"Hash: %H%n"
+    f"Subject: %s%n"
+    f"Author: %an%n"
+    f"Date: %ad%n"
+    f"%n%b"
+)
+
+
+def parse_git_log_output(raw: str) -> List[Dict[str, str]]:
+    """
+    解析 git log block 分隔符格式的输出
+
+    Args:
+        raw: git log 原始输出
+
+    Returns:
+        commit 列表，每项包含 hash, subject, author, date, body
+    """
+    if not raw.strip():
+        return []
+
+    commits = []
+    blocks = raw.split(_COMMIT_DELIMITER)
+
+    for block in blocks:
+        block = block.strip()
+        if not block:
+            continue
+
+        commit: Dict[str, str] = {
+            "hash": "",
+            "subject": "",
+            "author": "",
+            "date": "",
+            "body": "",
+        }
+
+        lines = block.split("\n")
+        # 前四行是 Hash/Subject/Author/Date
+        header_keys = ["hash", "subject", "author", "date"]
+        header_idx = 0
+
+        body_start = -1
+        for i, line in enumerate(lines):
+            if header_idx < len(header_keys):
+                # 匹配 "Key: Value" 格式
+                match = re.match(rf"^{header_keys[header_idx]}:\s*(.*)", line)
+                if match:
+                    commit[header_keys[header_idx]] = match.group(1).strip()
+                    header_idx += 1
+                    # Subject 后紧跟空行，然后是 body
+                    if header_idx == len(header_keys):
+                        # 跳过 Subject 后的空行
+                        if i + 1 < len(lines) and lines[i + 1].strip() == "":
+                            body_start = i + 2
+                        else:
+                            body_start = i + 1
+                continue
+
+        if body_start > 0 and body_start < len(lines):
+            commit["body"] = "\n".join(lines[body_start:])
+
+        if commit["hash"]:
+            commits.append(commit)
+
+    return commits
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `uv run pytest tests/unit/test_git_extractor.py -v`
+Expected: 6 passed
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add jfox/git_extractor.py tests/unit/test_git_extractor.py
+git commit -m "feat: add git_extractor module with block-delimited git log parser"
+```
+
+---
+
+## Task 2: 实现 extract_commits 函数（subprocess 调用）
+
+**Files:**
+- Modify: `jfox/git_extractor.py`
+- Modify: `tests/unit/test_git_extractor.py`
+
+- [ ] **Step 1: 写失败测试——extract_commits 调用 git 并返回解析结果**
+
+在 `tests/unit/test_git_extractor.py` 中添加：
+
+```python
+from unittest.mock import MagicMock, patch
+
+
+class TestExtractCommits:
+    """测试 git 仓库 commit 提取"""
+
+    @patch("jfox.git_extractor.subprocess.run")
+    def test_basic_extraction(self, mock_run):
+        """基本提取流程"""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="---COMMIT_START---\nHash: abc123\nSubject: feat: test\nAuthor: Alice\nDate: 2026-04-10\n\nbody\n"
+        )
+
+        from jfox.git_extractor import extract_commits
+
+        result = extract_commits("/fake/repo", limit=10)
+        assert len(result) == 1
+        assert result[0]["hash"] == "abc123"
+        assert result[0]["subject"] == "feat: test"
+
+        # 验证 subprocess 调用参数
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args
+        assert call_args[1]["encoding"] == "utf-8"
+        assert call_args[1]["errors"] == "replace"
+        assert "--format" in call_args[0][0]
+        assert "-10" in call_args[0][0]
+
+    @patch("jfox.git_extractor.subprocess.run")
+    def test_path_normalization(self, mock_run):
+        """路径规范化（Windows / Git Bash 路径处理）"""
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+
+        from jfox.git_extractor import extract_commits
+
+        # Git Bash 风格路径
+        extract_commits("/c/Users/test/repo")
+        # 路径应该被 resolve 处理
+        called_cmd = mock_run.call_args[0][0]
+        assert "-C" in called_cmd
+
+    @patch("jfox.git_extractor.subprocess.run")
+    def test_git_not_repo_error(self, mock_run):
+        """非 git 仓库应抛出 ValueError"""
+        mock_run.return_value = MagicMock(
+            returncode=128,
+            stderr="fatal: not a git repository",
+        )
+
+        from jfox.git_extractor import extract_commits
+
+        with pytest.raises(ValueError, match="not a git repository"):
+            extract_commits("/not/a/repo")
+
+    @patch("jfox.git_extractor.subprocess.run")
+    def test_default_limit_50(self, mock_run):
+        """默认 limit 为 50"""
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+
+        from jfox.git_extractor import extract_commits
+
+        extract_commits("/fake/repo")
+        called_cmd = mock_run.call_args[0][0]
+        assert "-50" in called_cmd
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `uv run pytest tests/unit/test_git_extractor.py::TestExtractCommits -v`
+Expected: FAIL（`ImportError: cannot import name 'extract_commits'`）
+
+- [ ] **Step 3: 实现 extract_commits 函数**
+
+在 `jfox/git_extractor.py` 中追加：
+
+```python
+def extract_commits(
+    repo_path: str,
+    limit: int = 50,
+) -> List[Dict[str, str]]:
+    """
+    从 Git 仓库提取 commit 历史
+
+    Args:
+        repo_path: 仓库路径（支持 Windows / Git Bash 路径）
+        limit: 最大提取条数
+
+    Returns:
+        commit 列表，每项包含 hash, subject, author, date, body
+
+    Raises:
+        ValueError: 路径不是 Git 仓库
+    """
+    repo = Path(repo_path).resolve()
+
+    cmd = [
+        "git",
+        "-C",
+        str(repo),
+        "log",
+        f"--format={_GIT_LOG_FORMAT}",
+        "--date=short",
+        f"-{limit}",
+    ]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except FileNotFoundError:
+        raise ValueError("git 命令未找到，请确认 git 已安装")
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        raise ValueError(f"git log 执行失败: {stderr}")
+
+    return parse_git_log_output(result.stdout)
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `uv run pytest tests/unit/test_git_extractor.py -v`
+Expected: 10 passed
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add jfox/git_extractor.py tests/unit/test_git_extractor.py
+git commit -m "feat: add extract_commits with UTF-8 encoding and path normalization"
+```
+
+---
+
+## Task 3: 实现 commits_to_notes 转换函数
+
+**Files:**
+- Modify: `jfox/git_extractor.py`
+- Modify: `tests/unit/test_git_extractor.py`
+
+- [ ] **Step 1: 写失败测试——commits_to_notes 转换格式**
+
+在 `tests/unit/test_git_extractor.py` 中添加：
+
+```python
+from jfox.git_extractor import commits_to_notes
+
+
+class TestCommitsToNotes:
+    """测试 commit → note 转换"""
+
+    def test_basic_conversion(self):
+        """基本转换"""
+        commits = [
+            {
+                "hash": "abc123def456",
+                "subject": "feat: add login",
+                "author": "张三",
+                "date": "2026-04-10",
+                "body": "实现了 JWT 认证",
+            }
+        ]
+        result = commits_to_notes(commits, repo_name="my-app")
+        assert len(result) == 1
+        assert result[0]["title"] == "feat: add login"
+        assert "abc123def456" in result[0]["content"]
+        assert "张三" in result[0]["content"]
+        assert "2026-04-10" in result[0]["content"]
+        assert "JWT" in result[0]["content"]
+        assert "source:my-app" in result[0]["tags"]
+        assert "source:git-log" in result[0]["tags"]
+
+    def test_empty_commits(self):
+        """空列表返回空列表"""
+        result = commits_to_notes([], repo_name="test")
+        assert result == []
+
+    def test_long_hash_truncated(self):
+        """hash 截断为短 hash"""
+        commits = [
+            {
+                "hash": "a" * 40,
+                "subject": "test",
+                "author": "A",
+                "date": "2026-01-01",
+                "body": "",
+            }
+        ]
+        result = commits_to_notes(commits, repo_name="test")
+        assert "a" * 7 in result[0]["content"]
+        assert len(result[0]["content"].split("\n")[0].split()[-1]) <= 7
+
+    def test_body_with_co_authored_by_stripped(self):
+        """body 末尾的 Co-authored-by 行被清理"""
+        commits = [
+            {
+                "hash": "abc1234",
+                "subject": "feat: something",
+                "author": "Alice",
+                "date": "2026-04-10",
+                "body": "real content\n\nCo-authored-by: Bob <bob@example.com>\nCo-authored-by: Claude <noreply@anthropic.com>",
+            }
+        ]
+        result = commits_to_notes(commits, repo_name="test")
+        content = result[0]["content"]
+        assert "real content" in content
+        assert "Co-authored-by" not in content
+
+    def test_repo_name_from_path(self):
+        """repo_name=None 时从路径提取目录名"""
+        commits = [{"hash": "abc1234", "subject": "test", "author": "A", "date": "2026-01-01", "body": ""}]
+        result = commits_to_notes(commits, repo_path="/home/user/my-project")
+        assert "source:my-project" in result[0]["tags"]
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `uv run pytest tests/unit/test_git_extractor.py::TestCommitsToNotes -v`
+Expected: FAIL（`ImportError: cannot import name 'commits_to_notes'`）
+
+- [ ] **Step 3: 实现 commits_to_notes 函数**
+
+在 `jfox/git_extractor.py` 中追加：
+
+```python
+def commits_to_notes(
+    commits: List[Dict[str, str]],
+    repo_name: Optional[str] = None,
+    repo_path: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """
+    将 commit 列表转换为 bulk-import 兼容的笔记格式
+
+    Args:
+        commits: parse_git_log_output 的返回值
+        repo_name: 仓库名称（用于标签），None 时从 repo_path 提取
+        repo_path: 仓库路径（repo_name 为 None 时使用）
+
+    Returns:
+        笔记数据列表，兼容 bulk_import_notes() 输入格式
+    """
+    if not commits:
+        return []
+
+    if not repo_name:
+        if repo_path:
+            repo_name = Path(repo_path).resolve().name
+        else:
+            repo_name = "unknown"
+
+    notes = []
+    for c in commits:
+        # 短 hash（前 7 位）
+        short_hash = c["hash"][:7]
+
+        # 清理 body：去掉 Co-authored-by 行和末尾空行
+        body = c.get("body", "")
+        body_lines = [
+            line
+            for line in body.split("\n")
+            if line.strip() and not line.strip().lower().startswith("co-authored-by:")
+        ]
+        clean_body = "\n".join(body_lines).strip()
+
+        # 构建笔记内容
+        content_parts = [
+            f"Commit: {short_hash}",
+            f"Author: {c['author']}",
+            f"Date: {c['date']}",
+        ]
+        if clean_body:
+            content_parts.append("")
+            content_parts.append(clean_body)
+
+        notes.append(
+            {
+                "title": c["subject"],
+                "content": "\n".join(content_parts),
+                "tags": [f"source:{repo_name}", "source:git-log"],
+            }
+        )
+
+    return notes
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `uv run pytest tests/unit/test_git_extractor.py -v`
+Expected: 15 passed
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add jfox/git_extractor.py tests/unit/test_git_extractor.py
+git commit -m "feat: add commits_to_notes conversion with Co-authored-by cleanup"
+```
+
+---
+
+## Task 4: 在 cli.py 添加 ingest-log 命令
+
+**Files:**
+- Modify: `jfox/cli.py`（在 `bulk_import` 命令附近追加）
+- Modify: `tests/unit/test_git_extractor.py`（添加集成级别测试）
+
+- [ ] **Step 1: 写失败测试——CLI ingest-log 命令可执行**
+
+在 `tests/unit/test_git_extractor.py` 中添加：
+
+```python
+class TestIngestLogCommand:
+    """测试 ingest-log CLI 命令"""
+
+    @patch("jfox.cli.bulk_import_notes")
+    @patch("jfox.git_extractor.extract_commits")
+    def test_ingest_log_basic(self, mock_extract, mock_import, tmp_path):
+        """基本 ingest-log 流程"""
+        # mock git 提取
+        mock_extract.return_value = [
+            {
+                "hash": "abc123def456",
+                "subject": "feat: test feature",
+                "author": "Alice",
+                "date": "2026-04-10",
+                "body": "test body",
+            }
+        ]
+        # mock 导入
+        mock_import.return_value = {"imported": 1, "failed": 0, "total": 1}
+
+        from click.testing import CliRunner
+
+        from jfox.cli import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["ingest-log", str(tmp_path)])
+        print(f"stdout: {result.output}")
+        print(f"exit_code: {result.exit_code}")
+        if result.exception:
+            raise result.exception
+
+        assert result.exit_code == 0
+        mock_extract.assert_called_once()
+        mock_import.assert_called_once()
+
+        # 验证传入 bulk_import 的 notes 格式
+        import_args = mock_import.call_args
+        notes_data = import_args[1]["notes_data"]
+        assert len(notes_data) == 1
+        assert notes_data[0]["title"] == "feat: test feature"
+        assert "abc123d" in notes_data[0]["content"]
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `uv run pytest tests/unit/test_git_extractor.py::TestIngestLogCommand -v`
+Expected: FAIL（命令不存在或 import 错误）
+
+- [ ] **Step 3: 在 cli.py 添加 ingest-log 命令**
+
+在 `cli.py` 的 `bulk_import` 命令定义之前（约 L2157），添加：
+
+```python
+@app.command()
+def ingest_log(
+    repo_path: str = typer.Argument(..., help="本地 Git 仓库路径"),
+    limit: int = typer.Option(50, "--limit", "-n", help="提取 commit 数量"),
+    note_type: str = typer.Option("fleeting", "--type", "-t", help="笔记类型"),
+    batch_size: int = typer.Option(32, "--batch-size", "-b", help="批处理大小"),
+    kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
+    json_output: bool = typer.Option(True, "--json/--no-json", help="JSON 输出"),
+):
+    """
+    从 Git 仓库提取 commit 历史并导入为笔记
+
+    使用 block 分隔符格式提取 git log，自动处理 UTF-8 编码和路径规范化。
+
+    示例:
+        jfox ingest-log ./my-project --limit 50
+        jfox ingest-log ./my-project --kb work --type permanent
+    """
+    try:
+        from .git_extractor import commits_to_notes, extract_commits
+
+        # 提取 commits
+        commits = extract_commits(repo_path, limit=limit)
+
+        if not commits:
+            result = {"success": True, "imported": 0, "total": 0, "message": "没有找到 commit 记录"}
+            if json_output:
+                print(output_json(result))
+            else:
+                console.print("[yellow]![/yellow] 没有找到 commit 记录")
+            return
+
+        # 转换为笔记格式
+        notes_data = commits_to_notes(commits, repo_path=repo_path)
+
+        console.print(f"[yellow]提取了 {len(notes_data)} 条 commit，正在导入...[/yellow]")
+
+        # 批量导入
+        from .performance import bulk_import_notes
+
+        if kb:
+            from .config import use_kb
+
+            with use_kb(kb):
+                import_result = bulk_import_notes(
+                    notes_data=notes_data,
+                    note_type=note_type,
+                    batch_size=batch_size,
+                    show_progress=not json_output,
+                )
+        else:
+            import_result = bulk_import_notes(
+                notes_data=notes_data,
+                note_type=note_type,
+                batch_size=batch_size,
+                show_progress=not json_output,
+            )
+
+        result = {
+            "success": True,
+            "repo_path": str(Path(repo_path).resolve()),
+            "commits_extracted": len(commits),
+            **import_result,
+        }
+
+        if json_output:
+            print(output_json(result))
+        else:
+            console.print(f"[green]✓[/green] 导入: {import_result['imported']}")
+            console.print(f"[red]✗[/red] 失败: {import_result['failed']}")
+            console.print(f"总计: {import_result['total']}")
+
+    except ValueError as e:
+        result = {"success": False, "error": str(e)}
+        if json_output:
+            print(output_json(result))
+        else:
+            console.print(f"[red]✗[/red] {e}")
+        raise typer.Exit(1)
+    except Exception as e:
+        result = {"success": False, "error": str(e)}
+        if json_output:
+            print(output_json(result))
+        else:
+            console.print(f"[red]✗[/red] Error: {e}")
+        raise typer.Exit(1)
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `uv run pytest tests/unit/test_git_extractor.py -v`
+Expected: 16 passed
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add jfox/cli.py tests/unit/test_git_extractor.py
+git commit -m "feat: add ingest-log CLI command for git history import"
+```
+
+---
+
+## Task 5: lint + 格式检查 + 快速测试
+
+- [ ] **Step 1: 运行 ruff 检查**
+
+Run: `uv run ruff check jfox/git_extractor.py jfox/cli.py tests/unit/test_git_extractor.py`
+Expected: No errors
+
+- [ ] **Step 2: 运行 black 格式化**
+
+Run: `uv run black jfox/git_extractor.py jfox/cli.py tests/unit/test_git_extractor.py`
+
+- [ ] **Step 3: 运行全部 git_extractor 测试**
+
+Run: `uv run pytest tests/unit/test_git_extractor.py -v`
+Expected: All passed
+
+- [ ] **Step 4: 运行快速测试套件确认无破坏**
+
+Run: `uv run pytest tests/unit/ -v -m "not slow"`
+Expected: All passed（包括已有的测试）
+
+- [ ] **Step 5: 提交（如有格式修复）**
+
+```bash
+git add -A
+git commit -m "style: lint and format git_extractor module"
+```
+
+---
+
+## Task 6: 手动端到端验证（用户执行）
+
+以下步骤需要用户在终端手动执行，因为涉及真实 git 仓库和 embedding 模型加载。
+
+- [ ] **Step 1: 验证命令帮助**
+
+```bash
+jfox ingest-log --help
+```
+
+Expected: 显示命令帮助，包括 `--limit`、`--type`、`--kb` 等参数说明。
+
+- [ ] **Step 2: 导入 jfox 自身仓库**
+
+```bash
+jfox ingest-log . --limit 5 --type fleeting
+```
+
+Expected: 成功导入 5 条 commit 为 fleeting 笔记，输出 JSON 格式的导入结果。
+
+- [ ] **Step 3: 验证导入结果**
+
+```bash
+jfox list --type fleeting --limit 5
+```
+
+Expected: 看到刚导入的 commit 笔记，title 为 commit subject。
+
+- [ ] **Step 4: 导入到指定知识库**
+
+```bash
+jfox ingest-log . --limit 3 --kb homework
+```
+
+Expected: 成功导入到 homework 知识库。
+
+---
+
+## Self-Review 检查清单
+
+| 检查项 | 状态 |
+|--------|------|
+| #125 所有 5 个根因是否被覆盖 | ✅ (1) block 分隔符  (2) UTF-8 encoding  (3) 路径 resolve  (4) 内置命令替代手工脚本  (5) 输出直接对接 bulk_import |
+| 无 placeholder（TBD/TODO） | ✅ |
+| 所有测试代码完整可运行 | ✅ |
+| 文件路径精确 | ✅ |
+| 遵循现有 CLI 命令模式（`@app.command()` + `_impl()`） | ✅（直接在命令中实现，逻辑简单无需额外 `_impl`） |
+| `--kb` 参数支持 | ✅ |
+| `--json/--no-json` 输出 | ✅ |
+| 错误处理（非 git 仓库、git 未安装） | ✅ |
+| TDD 流程（先测试后实现） | ✅ |

--- a/docs/superpowers/plans/2026-04-13-ingest-skill-sync.md
+++ b/docs/superpowers/plans/2026-04-13-ingest-skill-sync.md
@@ -1,0 +1,338 @@
+# jfox-ingest Skill 与 ingest-log 命令打通 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 更新 jfox-ingest skill 文档，将 git log 采集步骤从手动 `git log` + 解析 + `bulk-import` 简化为调用 `jfox ingest-log` CLI 命令。
+
+**Architecture:** 纯文档更新，不涉及代码变更。修改项目内 `skills-recommend/` 目录的 SKILL.md，然后同步到全局 `~/.claude/skills/`。
+
+**Tech Stack:** Markdown (SKILL.md)
+
+---
+
+## File Structure
+
+| 文件 | 操作 | 职责 |
+|------|------|------|
+| `skills-recommend/claude-code/jfox-ingest/SKILL.md` | 修改 | 项目内的 skill 定义 |
+| `~/.claude/skills/jfox-ingest/SKILL.md` | 同步 | 全局 skill（与项目保持一致） |
+
+不涉及 `jfox/git_extractor.py`、`jfox/cli.py` 或任何 Python 代码变更。
+
+---
+
+### Task 1: 更新 Step 3 — 用 `jfox ingest-log` 替代手动 git log
+
+**Files:**
+- Modify: `skills-recommend/claude-code/jfox-ingest/SKILL.md:58-79`
+
+- [ ] **Step 1: 替换 Step 3 的内容**
+
+将原文（第 58-79 行）：
+
+```
+### Step 3: 采集 git log
+
+\`\`\`bash
+git -C <path> log --format="%H|%s|%b|%an|%ad" --date=short -50
+\`\`\`
+
+解析每条 commit，转化为笔记结构：
+
+- **title**: commit subject（第一行 `%s`）
+- **content**: 包含 commit hash、完整 body、作者、日期
+- **tags**: `source:<repo-name>`, `source:git-log`
+
+示例笔记内容：
+\`\`\`
+Commit: a1b2c3d
+Author: 张三
+Date: 2026-04-10
+
+feat: add user authentication module
+
+实现了 JWT 认证，支持 refresh token 机制。
+\`\`\`
+```
+
+替换为：
+
+```
+### Step 3: 采集 git log
+
+使用 `jfox ingest-log` 命令（基于 `jfox/git_extractor.py` 模块），一行完成提取 + 转换 + 导入：
+
+\`\`\`bash
+jfox ingest-log <path> --limit 50 [--kb <name>] [--type fleeting]
+\`\`\`
+
+该命令会：
+- 调用 `git log` 提取 commit 历史
+- 自动解析为结构化数据（hash, subject, author, date, body）
+- 转换为 fleeting 笔记并批量导入知识库
+- 自动添加标签：`source:<repo-name>`, `source:git-log`
+
+生成笔记示例：
+\`\`\`
+Commit: a1b2c3d
+Author: 张三
+Date: 2026-04-10
+
+feat: add user authentication module
+
+实现了 JWT 认证，支持 refresh token 机制。
+\`\`\`
+
+> **注意**: `jfox ingest-log` 使用 `--json`/`--no-json`（默认开启），不要使用 `--format json`。输出格式控制用 `--format`。
+```
+
+- [ ] **Step 2: 验证修改后文档的 Markdown 格式正确**
+
+Run: `cat skills-recommend/claude-code/jfox-ingest/SKILL.md`
+
+Expected: Step 3 部分显示 `jfox ingest-log` 命令，不再有手动 `git log` 解析步骤。
+
+---
+
+### Task 2: 更新 Step 6 — 简化 git-log 导入，保留 PR/Issues 的 bulk-import
+
+**Files:**
+- Modify: `skills-recommend/claude-code/jfox-ingest/SKILL.md:142-173`
+
+- [ ] **Step 1: 替换 Step 6 的内容**
+
+将原文（第 142-173 行）：
+
+```
+### Step 6: 去重与导入
+
+**去重检查**：导入前检查知识库中是否已有该仓库的数据：
+\`\`\`bash
+jfox search "<repo-name>" --format json
+\`\`\`
+
+如果已有记录，只导入新增的条目（通过 commit hash、PR 编号、Issue 编号判断）。
+
+**生成临时 JSON 文件**：将所有待导入记录组装为 JSON 数组：
+
+\`\`\`json
+[
+  {
+    "title": "feat: add user authentication module",
+    "content": "Commit: a1b2c3d\\nAuthor: 张三\\nDate: 2026-04-10\\n\\n实现了 JWT 认证，支持 refresh token 机制。",
+    "tags": ["source:my-app", "source:git-log"]
+  },
+  {
+    "title": "Add user authentication",
+    "content": "PR #42: Add user authentication\\nState: merged\\nAuthor: zhangsan\\n...",
+    "tags": ["source:my-app", "source:pr"]
+  }
+]
+\`\`\`
+
+保存到临时文件（使用跨平台路径），然后执行导入：
+\`\`\`bash
+jfox bulk-import <temp-file.json> --type fleeting [--kb <name>]
+\`\`\`
+
+> **注意**: `jfox bulk-import` 使用 `--json`/`--no-json`（默认开启），不要使用 `--format json`。
+```
+
+替换为：
+
+```
+### Step 6: 导入 GitHub 数据（git-log 已在 Step 3 完成）
+
+git-log 数据已通过 `jfox ingest-log` 完成导入，此步骤仅处理 GitHub PR/Issues 数据。
+
+**去重检查**：导入前检查知识库中是否已有该仓库的数据：
+\`\`\`bash
+jfox search "<repo-name>" --format json
+\`\`\`
+
+如果已有记录，只导入新增的条目（通过 PR 编号、Issue 编号判断）。
+
+**生成临时 JSON 文件**：将 PR/Issues 数据组装为 JSON 数组（仅 GitHub 数据）：
+
+\`\`\`json
+[
+  {
+    "title": "Add user authentication",
+    "content": "PR #42: Add user authentication\\nState: merged\\nAuthor: zhangsan\\n...",
+    "tags": ["source:my-app", "source:pr"]
+  },
+  {
+    "title": "Login page crashes on mobile",
+    "content": "Issue #15: Login page crashes on mobile\\nState: closed\\n...",
+    "tags": ["source:my-app", "source:issue"]
+  }
+]
+\`\`\`
+
+保存到临时文件（使用跨平台路径），然后执行导入：
+\`\`\`bash
+jfox bulk-import <temp-file.json> --type fleeting [--kb <name>]
+\`\`\`
+
+> **注意**: `jfox bulk-import` 使用 `--json`/`--no-json`（默认开启），不要使用 `--format json`。
+```
+
+- [ ] **Step 2: 验证修改后文档的 Markdown 格式正确**
+
+Run: `cat skills-recommend/claude-code/jfox-ingest/SKILL.md`
+
+Expected: Step 6 标题改为"导入 GitHub 数据"，JSON 示例中不再包含 git-log 数据，说明仅处理 PR/Issues。
+
+---
+
+### Task 3: 更新命令参考和错误处理
+
+**Files:**
+- Modify: `skills-recommend/claude-code/jfox-ingest/SKILL.md:211-237`
+
+- [ ] **Step 1: 替换命令参考部分**
+
+将原文（第 211-230 行）：
+
+```
+## 命令参考
+
+\`\`\`bash
+# 检测仓库类型
+git -C <path> remote get-url origin
+gh auth status
+
+# 采集数据
+git -C <path> log --format="%H|%s|%b|%an|%ad" --date=short -50
+gh pr list --repo <owner/repo> --state all --limit 20 --json number,title,body,state,author,createdAt,updatedAt,labels
+gh pr view <number> --repo <owner/repo> --json comments
+gh issue list --repo <owner/repo> --state all --limit 30 --json number,title,body,state,author,createdAt,labels,comments
+
+# 去重检查
+jfox search "<repo-name>" --format json
+
+# 导入
+jfox bulk-import <file.json> --type fleeting [--kb <name>]
+jfox add "<content>" --title "<title>" --type fleeting [--kb <name>]
+\`\`\`
+```
+
+替换为：
+
+```
+## 命令参考
+
+\`\`\`bash
+# 检测仓库类型
+git -C <path> remote get-url origin
+gh auth status
+
+# 采集 git log（一行完成提取+导入）
+jfox ingest-log <path> --limit 50 [--kb <name>] [--type fleeting]
+
+# 采集 GitHub 数据
+gh pr list --repo <owner/repo> --state all --limit 20 --json number,title,body,state,author,createdAt,updatedAt,labels
+gh pr view <number> --repo <owner/repo> --json comments
+gh issue list --repo <owner/repo> --state all --limit 30 --json number,title,body,state,author,createdAt,labels,comments
+
+# 去重检查
+jfox search "<repo-name>" --format json
+
+# 导入 GitHub 数据
+jfox bulk-import <file.json> --type fleeting [--kb <name>]
+
+# 手动添加单条笔记
+jfox add "<content>" --title "<title>" --type fleeting [--kb <name>]
+\`\`\`
+```
+
+- [ ] **Step 2: 替换错误处理部分**
+
+将原文（第 232-237 行）：
+
+```
+## 错误处理
+
+- **"Not a git repository"**: 提示用户提供正确的仓库路径
+- **\`gh: not found\`** 或 \`gh auth status\` 失败: 跳过 GitHub PR/Issues 导入，仅导入 git log
+- **"Knowledge base not found"**: 提示用户先运行 \`/jfox-common\` 创建知识库
+- **Bulk import 部分失败**: 报告成功/失败数量，失败记录不重试
+```
+
+替换为：
+
+```
+## 错误处理
+
+- **"Not a git repository"**: `jfox ingest-log` 会报错，提示用户提供正确的仓库路径
+- **\`gh: not found\`** 或 \`gh auth status\` 失败: 跳过 GitHub PR/Issues 导入，仅用 `jfox ingest-log` 导入 git log
+- **"Knowledge base not found"**: 提示用户先运行 \`/jfox-common\` 创建知识库
+- **Bulk import 部分失败**: 报告成功/失败数量，失败记录不重试
+```
+
+- [ ] **Step 3: 验证修改后文档完整**
+
+Run: `cat skills-recommend/claude-code/jfox-ingest/SKILL.md`
+
+Expected: 命令参考中 `git log` 原生命令被 `jfox ingest-log` 替代，错误处理中提到 `jfox ingest-log` 的报错行为。
+
+---
+
+### Task 4: 更新笔记格式规范说明
+
+**Files:**
+- Modify: `skills-recommend/claude-code/jfox-ingest/SKILL.md:196-205`
+
+- [ ] **Step 1: 在笔记格式规范表格前添加说明**
+
+在表格上方（第 196 行前）添加一行说明：
+
+```
+> git-log 格式由 `jfox ingest-log` 自动处理，以下规范主要供理解输出结构参考，以及手动处理 GitHub PR/Issues 数据时使用。
+```
+
+- [ ] **Step 2: 验证格式正确**
+
+Expected: 笔记格式规范表格上方出现说明文字，注明 git-log 部分由 `ingest-log` 自动处理。
+
+---
+
+### Task 5: 同步到全局 skills 目录
+
+**Files:**
+- Copy to: `~/.claude/skills/jfox-ingest/SKILL.md`
+
+- [ ] **Step 1: 复制更新后的 SKILL.md 到全局目录**
+
+```bash
+cp skills-recommend/claude-code/jfox-ingest/SKILL.md ~/.claude/skills/jfox-ingest/SKILL.md
+```
+
+- [ ] **Step 2: 验证两边内容一致**
+
+```bash
+diff skills-recommend/claude-code/jfox-ingest/SKILL.md ~/.claude/skills/jfox-ingest/SKILL.md
+```
+
+Expected: 无输出（文件完全一致）。
+
+---
+
+### Task 6: Commit
+
+**Files:**
+- Commit: `skills-recommend/claude-code/jfox-ingest/SKILL.md`
+
+- [ ] **Step 1: 提交变更**
+
+```bash
+git add skills-recommend/claude-code/jfox-ingest/SKILL.md
+git commit -m "refactor(skills): jfox-ingest 使用 ingest-log 替代手动 git log 流程
+
+- Step 3: 替换手动 git log 解析为 jfox ingest-log 命令
+- Step 6: 简化为仅处理 GitHub PR/Issues 的 bulk-import
+- 更新命令参考和错误处理
+- 添加笔记格式规范说明
+
+Closes #131"
+```

--- a/docs/superpowers/plans/2026-04-13-suppress-third-party-logging.md
+++ b/docs/superpowers/plans/2026-04-13-suppress-third-party-logging.md
@@ -1,0 +1,115 @@
+# 抑制第三方库 INFO 日志污染 CLI 输出 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 抑制第三方库（sentence_transformers、torch、chromadb 等）的 INFO/DEBUG 日志，使其不出现在 CLI 输出中。
+
+**Architecture:** 在 `cli.py` 的 `logging.basicConfig()` 之后，将已知第三方库的 logger 级别设为 WARNING。jfox 自身日志不受影响。
+
+**Tech Stack:** Python stdlib `logging`
+
+**Issue:** #134
+
+---
+
+### Task 1: 添加测试验证第三方库日志被抑制
+
+**Files:**
+- Create: `tests/unit/test_logging_config.py`
+
+- [ ] **Step 1: Write the failing test**
+
+验证 `cli.py` 模块导入后，第三方库 logger 级别为 WARNING。
+
+```python
+"""测试日志配置：第三方库日志级别应被抑制为 WARNING"""
+
+import logging
+import importlib
+
+
+def test_third_party_loggers_suppressed():
+    """导入 jfox.cli 后，第三方库的日志级别应为 WARNING 或更高"""
+    import jfox.cli  # noqa: F401
+
+    noisy_libs = [
+        "sentence_transformers",
+        "torch",
+        "chromadb",
+        "tqdm",
+        "urllib3",
+        "watchdog",
+        "PIL",
+    ]
+    for lib in noisy_libs:
+        lib_logger = logging.getLogger(lib)
+        assert lib_logger.level >= logging.WARNING, (
+            f"{lib} logger level is {lib_logger.level}, expected >= {logging.WARNING}"
+        )
+
+
+def test_jfox_own_logger_unchanged():
+    """jfox 自身的日志级别应保持 INFO"""
+    import jfox.cli  # noqa: F401
+
+    jfox_logger = logging.getLogger("jfox")
+    assert jfox_logger.level == logging.INFO
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_logging_config.py -v`
+Expected: FAIL — 第三方库 logger 级别仍为 NOTSET/DEBUG
+
+---
+
+### Task 2: 实现第三方库日志级别抑制
+
+**Files:**
+- Modify: `jfox/cli.py:36-40`
+
+- [ ] **Step 1: 在 `logging.basicConfig()` 之后添加第三方库日志抑制**
+
+将 `jfox/cli.py` 第 36-40 行替换为：
+
+```python
+# 配置日志
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+
+# 抑制第三方库的 INFO/DEBUG 日志，避免污染 CLI 输出
+for _lib in (
+    "sentence_transformers",
+    "torch",
+    "chromadb",
+    "tqdm",
+    "urllib3",
+    "watchdog",
+    "PIL",
+):
+    logging.getLogger(_lib).setLevel(logging.WARNING)
+
+logger = logging.getLogger(__name__)
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/test_logging_config.py -v`
+Expected: PASS
+
+---
+
+### Task 3: 手动验证
+
+- [ ] **Step 1: 运行 suggest-links 确认输出干净**
+
+Run: `uv run jfox suggest-links "test content" --kb default --format json`
+Expected: 无第三方库日志，仅输出 JSON
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add jfox/cli.py tests/unit/test_logging_config.py
+git commit -m "fix: suppress third-party library INFO logs from CLI output (#134)"
+```

--- a/docs/superpowers/plans/2026-04-13-sync-skills-with-cli.md
+++ b/docs/superpowers/plans/2026-04-13-sync-skills-with-cli.md
@@ -1,0 +1,340 @@
+# Sync jfox Skills with CLI #137 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update all 4 jfox skill files to accurately reflect the current CLI commands, parameters, and defaults.
+
+**Architecture:** Pure documentation task — modify 3 Markdown skill files in `~/.claude/skills/jfox-*/SKILL.md`. No code changes. The skill files are outside the git repo but will be committed as a plan doc and a tracking issue comment.
+
+**Tech Stack:** Markdown, jfox CLI (for verification)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `~/.claude/skills/jfox-common/SKILL.md` | Major rewrite | Add CRUD commands, new params, new commands |
+| `~/.claude/skills/jfox-ingest/SKILL.md` | Minor edit | Fix `--json` description |
+| `~/.claude/skills/jfox-organize/SKILL.md` | Minor edit | Fix `--json` description, add `--content-file` |
+| `~/.claude/skills/jfox-search/SKILL.md` | No change | Already accurate |
+
+---
+
+## Cross-cutting convention: `--json` vs `--format json`
+
+**Current state:** jfox-ingest and jfox-organize say "不要用 `--format json`", implying it's wrong. In reality, `--json` is defined as a shorthand for `--format json` and they are equivalent.
+
+**Fix:** Replace all instances of the misleading note with a neutral convention statement. The convention used throughout all skills should be:
+
+> **约定**：所有命令均支持 `--format json` 输出 JSON，也可使用快捷方式 `--json`（两者等价）。下文示例统一使用 `--json`。
+
+This applies to:
+- `jfox-ingest/SKILL.md` lines 83, 179 (two note blocks)
+- `jfox-organize/SKILL.md` lines 65, 96, 161 (three note blocks)
+
+---
+
+### Task 1: Fix `--json` descriptions in jfox-ingest
+
+**Files:**
+- Modify: `~/.claude/skills/jfox-ingest/SKILL.md`
+
+- [ ] **Step 1: Replace first note block (around line 83)**
+
+Replace:
+```
+> **注意**: `jfox ingest-log` 使用 `--json`（默认关闭）/`--format`（默认 table）控制输出。JSON 模式用 `--json`，不要用 `--format json`。
+```
+
+With:
+```
+> **约定**：`jfox ingest-log` 支持 `--format json` 输出 JSON，也可使用快捷方式 `--json`（两者等价）。下文示例统一使用 `--json`。
+```
+
+- [ ] **Step 2: Replace second note block (around line 179)**
+
+Replace:
+```
+> **注意**: `jfox bulk-import` 使用 `--json`（默认开启）/`--no-json` 控制输出。不要使用 `--format json`。
+```
+
+With:
+```
+> **约定**：`jfox bulk-import` 默认输出 JSON。使用 `--no-json` 切换为 table 格式，或 `--format table` 显式指定。
+```
+
+- [ ] **Step 3: Verify changes are consistent**
+
+Read the full file and confirm both note blocks are updated and no other "不要用" or "不要使用" warnings about `--format json` remain.
+
+---
+
+### Task 2: Fix `--json` descriptions and add `--content-file` in jfox-organize
+
+**Files:**
+- Modify: `~/.claude/skills/jfox-organize/SKILL.md`
+
+- [ ] **Step 1: Replace first note block (around line 65)**
+
+Replace:
+```
+> **注意**：`jfox add` 和 `jfox delete` 使用 `--json`/`--no-json`（默认开启），不要用 `--format json`。
+```
+
+With:
+```
+> **约定**：所有命令均支持 `--format json` 输出 JSON，也可使用快捷方式 `--json`（两者等价）。下文示例统一使用 `--json`。
+```
+
+- [ ] **Step 2: Replace second note block (around line 96)**
+
+Replace:
+```
+> **注意**：`jfox edit` 使用 `--json`/`--no-json`（默认开启），不要用 `--format json`。
+```
+
+With:
+```
+> **约定**：`jfox edit` 支持 `--format json`，也可使用快捷方式 `--json`（两者等价）。
+```
+
+- [ ] **Step 3: Replace third note block in error handling (around line 161)**
+
+Replace:
+```
+- **`jfox add` / `jfox edit` / `jfox delete` 使用 `--json`/`--no-json`**，不要用 `--format json`
+```
+
+With:
+```
+- **`jfox add` / `jfox edit` / `jfox delete`** 支持 `--format json`，也可使用快捷方式 `--json`
+```
+
+- [ ] **Step 4: Add `--content-file` to "直接创建笔记" section**
+
+In the **创建笔记** subsection (around line 118-120), after the existing `jfox add` example, add:
+
+```bash
+# 从文件读取内容（适合长文本，避免 shell 转义问题）
+jfox add --content-file notes/draft.md --title "<标题>" --type permanent --tag <tags> [--kb <name>]
+
+# 从 stdin 读取
+echo "内容" | jfox add --content-file - --title "<标题>" --type fleeting
+```
+
+- [ ] **Step 5: Add `--content-file` to edit example in Step 3 (around line 93)**
+
+In the 图谱优化 section, after the existing `jfox edit` example, add:
+
+```bash
+# 使用文件内容编辑（适合长文本）
+jfox edit <孤立笔记_id> --content-file updated.md
+```
+
+- [ ] **Step 6: Add `--date` to `jfox daily` in command reference (around line 153)**
+
+Replace:
+```bash
+jfox daily --json                             # 查看今天的笔记
+```
+
+With:
+```bash
+jfox daily --json                             # 查看今天的笔记
+jfox daily --date 2026-04-01 --json           # 查看指定日期的笔记
+```
+
+- [ ] **Step 7: Verify full file is consistent**
+
+Read the full file and confirm no remaining "不要用" or "不要使用" warnings about `--format json`.
+
+---
+
+### Task 3: Major update to jfox-common
+
+**Files:**
+- Modify: `~/.claude/skills/jfox-common/SKILL.md`
+
+This is the largest change. The skill currently covers only KB management and health check. It needs a new "笔记 CRUD" section and updates to the command reference.
+
+- [ ] **Step 1: Add "笔记 CRUD" section after "管理命令" and before "删除知识库"**
+
+Insert the following after the `jfox kb rename` / `jfox kb remove` block (after line ~87):
+
+```markdown
+## 笔记 CRUD
+
+### 添加笔记
+
+```bash
+# 快速添加（内容直接作为参数）
+jfox add "笔记内容，支持 [[其他笔记标题]] 链接" --title "笔记标题"
+
+# 指定类型和标签
+jfox add "内容" --title "标题" --type permanent --tag design --tag backend
+
+# 从文件读取内容（v0.2.1+，适合长文本）
+jfox add --content-file notes/draft.md --title "标题" --type literature
+
+# 从 stdin 读取
+cat notes.txt | jfox add --content-file - --title "标题"
+
+# 使用模板
+jfox add --template meeting --title "周会记录"
+```
+
+笔记类型：
+- `fleeting`（默认）— 快速捕获，稍后提炼
+- `literature` — 阅读笔记
+- `permanent` — 已提炼的知识
+
+### 编辑笔记
+
+```bash
+# 编辑内容和标题
+jfox edit <note_id> --content "新内容" --title "新标题"
+
+# 从文件读取内容（v0.2.1+，适合长文本）
+jfox edit <note_id> --content-file updated.md
+
+# 修改标签和类型
+jfox edit <note_id> --tag new-tag1 --tag new-tag2 --type permanent
+
+# 在指定知识库中编辑
+jfox edit <note_id> --kb work --content "新内容"
+```
+
+编辑会保留原始笔记 ID 和创建时间。
+
+### 删除笔记
+
+```bash
+jfox delete <note_id>               # 需确认
+jfox delete <note_id> --force       # 跳过确认
+```
+
+### 查看笔记
+
+```bash
+jfox list --format json --limit 50              # 列出笔记
+jfox list --type permanent --format json         # 按类型筛选
+jfox daily --json                                # 今天的笔记
+jfox daily --date 2026-04-01 --json              # 指定日期
+jfox refs --search "<标题>" --format json        # 查看反向链接
+```
+```
+
+- [ ] **Step 2: Update "命令参考" section to include all commands**
+
+Replace the entire "命令参考" section (starting at "## 命令参考") with:
+
+```markdown
+## 命令参考
+
+以下仅列出知识库管理、笔记 CRUD 和健康检查相关命令。所有命令支持 `--kb <name>` 指定知识库，省略时使用当前默认知识库。
+
+**约定**：所有命令均支持 `--format json` 输出 JSON，也可使用快捷方式 `--json`（两者等价）。下文示例统一使用 `--json`。
+
+### 知识库管理
+
+```bash
+jfox init --name <name> --desc "<desc>"     # 创建知识库
+jfox kb list --format json                  # 列出所有知识库
+jfox kb switch <name>                       # 切换知识库
+jfox kb info <name> --format json           # 查看知识库详情
+jfox kb current --format json               # 当前知识库
+jfox kb rename <old> <new>                  # 重命名
+jfox kb remove <name>                       # 注销（保留文件）
+jfox kb remove <name> --force               # 删除（含文件，不可恢复）
+jfox status --format json                   # 知识库状态
+```
+
+### 笔记 CRUD
+
+```bash
+jfox add "<content>" --title "<title>" --type <type> --tag <tags>  # 添加笔记
+jfox add --content-file <path> --title "<title>"                   # 从文件添加
+jfox edit <id> --content "<new>" --title "<title>"                 # 编辑笔记
+jfox edit <id> --content-file <path>                               # 从文件编辑
+jfox delete <id> --force                                           # 删除笔记
+jfox list --format json --limit <N>                                # 列出笔记
+jfox daily --json                                                  # 今天的笔记
+jfox daily --date YYYY-MM-DD --json                                # 指定日期
+jfox refs --search "<title>" --format json                         # 反向链接
+```
+
+### 数据导入
+
+```bash
+jfox ingest-log <repo-path> --limit <N> --type fleeting --kb <name>  # Git 仓库导入
+jfox bulk-import <file.json> --type fleeting --kb <name>             # 批量导入
+```
+
+### 健康检查
+
+```bash
+jfox graph --stats --json                    # 图谱指标（与 --orphans 互斥，分开运行）
+jfox graph --orphans --json                  # 孤立笔记列表
+jfox index verify                            # 索引完整性验证
+jfox index rebuild                           # 重建索引
+jfox inbox --json --limit <N>                # 未处理笔记
+```
+
+> 搜索、导入、整理等高频操作命令见对应技能文档（jfox-search、jfox-ingest、jfox-organize）。
+```
+
+- [ ] **Step 3: Add `ingest-log` to "错误处理" table**
+
+Add a row to the error handling table:
+
+```
+| `ingest-log` 报 "Not a git repository" | 提供正确的 Git 仓库路径 |
+```
+
+- [ ] **Step 4: Verify full file reads correctly**
+
+Read the entire updated file end-to-end. Check:
+1. Section order is logical: 前置条件 → 路径约定 → KB 管理 → 笔记 CRUD → 健康检查 → 命令参考 → 错误处理
+2. No duplicate content
+3. All CLI parameters match `jfox <cmd> --help` output
+4. No "不要用" warnings about `--format json`
+
+---
+
+### Task 4: Final verification
+
+- [ ] **Step 1: Verify each skill against CLI help**
+
+For each of the 3 modified skills, cross-check every command and parameter mentioned in the skill against `uv run jfox <cmd> --help`:
+
+```bash
+uv run jfox add --help
+uv run jfox edit --help
+uv run jfox delete --help
+uv run jfox daily --help
+uv run jfox ingest-log --help
+uv run jfox list --help
+uv run jfox graph --help
+uv run jfox inbox --help
+uv run jfox index --help
+uv run jfox suggest-links --help
+uv run jfox bulk-import --help
+uv run jfox refs --help
+uv run jfox status --help
+uv run jfox kb --help
+```
+
+- [ ] **Step 2: Comment on issue #137**
+
+Post a comment on zhuxixi/jfox#137 linking to the plan and confirming completion:
+
+```
+Skills synced with CLI as of v0.2.1. Plan: `docs/superpowers/plans/2026-04-13-sync-skills-with-cli.md`
+```
+
+- [ ] **Step 3: Close issue #137**
+
+```bash
+gh issue close 137 --comment "All 4 skills audited and 3 updated to match CLI v0.2.1."
+```

--- a/docs/superpowers/plans/2026-04-15-gpu-embedding.md
+++ b/docs/superpowers/plans/2026-04-15-gpu-embedding.md
@@ -1,0 +1,905 @@
+# GPU 加速 Embedding 实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 打通 config.py 的 device/embedding_model 配置到 EmbeddingBackend，让 GPU 自动生效并支持更大的 embedding 模型。
+
+**Architecture:** EmbeddingBackend 新增 device 参数和自动检测逻辑，get_backend() 从 config 读取配置传入。CLI 新增 `config set` 命令，daemon/server.py 启动时读 config 并在 /health 报告 device。
+
+**Tech Stack:** Python 3.10+, sentence-transformers, torch (CUDA), Typer, ChromaDB
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `jfox/embedding_backend.py` | Modify | 构造函数加 device，load() 传 device，dimension 动态化 |
+| `jfox/config.py` | Modify | 默认值变更（embedding_model → "auto", embedding_dimension → 0） |
+| `jfox/cli.py` | Modify | 新增 config set 命令，status 显示实际 device |
+| `jfox/daemon/server.py` | Modify | /health 加 device 字段，启动读 config |
+| `jfox/daemon/client.py` | Modify | dimension 从 /health 动态获取（已做，确认兼容） |
+| `jfox/daemon/process.py` | Modify | get_daemon_status() 透传 device 字段 |
+| `tests/test_embedding_device.py` | Create | device 检测和模型选择的单元测试 |
+| `tests/test_config_unit.py` | Modify | 更新默认值断言 |
+| `tests/conftest.py` | Modify | MockEmbeddingBackend 适配新接口 |
+
+---
+
+### Task 1: EmbeddingBackend 构造函数和 device 解析
+
+**Files:**
+- Modify: `jfox/embedding_backend.py:12-18` (EmbeddingBackend class)
+- Create: `tests/test_embedding_device.py`
+
+- [ ] **Step 1: Write failing tests for device resolution**
+
+Create `tests/test_embedding_device.py`:
+
+```python
+"""Tests for EmbeddingBackend device detection and model selection"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from jfox.embedding_backend import EmbeddingBackend
+
+
+class TestDeviceResolution:
+    """测试 device 解析逻辑"""
+
+    @patch("jfox.embedding_backend.torch", create=True)
+    def test_auto_resolves_to_cuda_when_available(self, mock_torch_module):
+        """auto 模式下，CUDA 可用时解析为 cuda"""
+        # 在 load() 中 import torch，所以 mock torch.cuda.is_available
+        with patch("torch.cuda.is_available", return_value=True):
+            with patch("torch.cuda.get_device_name", return_value="NVIDIA RTX 4000"):
+                backend = EmbeddingBackend(device="auto")
+                # 不实际加载模型，只测 device 解析
+                resolved = backend._resolve_device()
+                assert resolved == "cuda"
+
+    def test_auto_resolves_to_cpu_when_no_cuda(self):
+        """auto 模式下，CUDA 不可用时解析为 cpu"""
+        with patch("torch.cuda.is_available", return_value=False):
+            backend = EmbeddingBackend(device="auto")
+            resolved = backend._resolve_device()
+            assert resolved == "cpu"
+
+    def test_explicit_cuda_skips_detection(self):
+        """手动指定 cuda 时跳过自动检测"""
+        backend = EmbeddingBackend(device="cuda")
+        resolved = backend._resolve_device()
+        assert resolved == "cuda"
+
+    def test_explicit_cpu_skips_detection(self):
+        """手动指定 cpu 时跳过自动检测"""
+        backend = EmbeddingBackend(device="cpu")
+        resolved = backend._resolve_device()
+        assert resolved == "cpu"
+
+
+class TestModelSelection:
+    """测试模型自动选择"""
+
+    def test_none_model_with_cuda_selects_bge_m3(self):
+        """model_name=None + device=cuda → 选择 bge-m3"""
+        with patch("torch.cuda.is_available", return_value=True):
+            with patch("torch.cuda.get_device_name", return_value="NVIDIA RTX 4000"):
+                backend = EmbeddingBackend(model_name=None, device="cuda")
+                resolved_model = backend._resolve_model_name("cuda")
+                assert resolved_model == "BAAI/bge-m3"
+
+    def test_none_model_with_cpu_selects_minilm(self):
+        """model_name=None + device=cpu → 选择 MiniLM"""
+        backend = EmbeddingBackend(model_name=None, device="cpu")
+        resolved_model = backend._resolve_model_name("cpu")
+        assert resolved_model == "sentence-transformers/all-MiniLM-L6-v2"
+
+    def test_explicit_model_overrides_auto(self):
+        """手动指定模型时优先使用手动值"""
+        backend = EmbeddingBackend(
+            model_name="BAAI/bge-large-zh-v1.5", device="cpu"
+        )
+        resolved_model = backend._resolve_model_name("cpu")
+        assert resolved_model == "BAAI/bge-large-zh-v1.5"
+
+    def test_auto_model_string_selects_by_device(self):
+        """model_name='auto' 等同于 None，根据 device 选模型"""
+        with patch("torch.cuda.is_available", return_value=True):
+            with patch("torch.cuda.get_device_name", return_value="NVIDIA RTX 4000"):
+                backend = EmbeddingBackend(model_name="auto", device="cuda")
+                resolved_model = backend._resolve_model_name("cuda")
+                assert resolved_model == "BAAI/bge-m3"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_embedding_device.py -v`
+Expected: FAIL — `EmbeddingBackend` has no `_resolve_device()` or `_resolve_model_name()` methods.
+
+- [ ] **Step 3: Implement device resolution and model selection in EmbeddingBackend**
+
+Replace the `EmbeddingBackend` class in `jfox/embedding_backend.py` with:
+
+```python
+# 默认模型
+_GPU_DEFAULT_MODEL = "BAAI/bge-m3"
+_CPU_DEFAULT_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+class EmbeddingBackend:
+    """嵌入模型后端（支持 daemon 代理 + GPU 加速）"""
+
+    def __init__(self, model_name: Optional[str] = None, device: str = "auto"):
+        self.model_name = model_name  # None/"auto" 表示由 device 自动决定
+        self.device = device
+        self.model = None
+        self._daemon_client = None  # 延迟初始化
+        self._use_daemon: Optional[bool] = None  # None=未检测
+        self._resolved_device: Optional[str] = None  # 实际解析后的设备
+        self._resolved_dim: Optional[int] = None  # 实际嵌入维度
+
+    def _resolve_device(self) -> str:
+        """解析 device 字符串为实际设备名"""
+        if self.device != "auto":
+            return self.device
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                device_name = torch.cuda.get_device_name(0)
+                logger.info(f"检测到 CUDA 可用 ({device_name}), 使用 GPU")
+                return "cuda"
+        except ImportError:
+            pass
+        logger.info("CUDA 不可用, 使用 CPU")
+        return "cpu"
+
+    def _resolve_model_name(self, resolved_device: str) -> str:
+        """根据 device 和用户配置决定使用哪个模型"""
+        if self.model_name is not None and self.model_name != "auto":
+            return self.model_name
+        return _GPU_DEFAULT_MODEL if resolved_device == "cuda" else _CPU_DEFAULT_MODEL
+
+    def _check_daemon(self) -> bool:
+        """检测是否使用 daemon（仅检测一次，缓存结果）"""
+        if self._use_daemon is not None:
+            return self._use_daemon
+
+        # daemon 进程内不应连接自己
+        if os.environ.get("JFOX_DAEMON_PROCESS"):
+            self._use_daemon = False
+            return False
+
+        try:
+            from .daemon.process import _get_daemon_url, is_daemon_running
+
+            if is_daemon_running():
+                from .daemon.client import DaemonClient
+
+                url = _get_daemon_url()
+                client = DaemonClient(url)
+                if client.available:
+                    self._daemon_client = client
+                    self._use_daemon = True
+                    logger.info("使用远程 embedding daemon")
+                    return True
+        except Exception:
+            pass
+
+        self._use_daemon = False
+        return False
+
+    def load(self):
+        """加载模型（支持 device 自动检测和 GPU 加速）"""
+        if self.model is not None:
+            return
+        if self._check_daemon():
+            return  # daemon 已持有模型，无需本地加载
+
+        # 解析 device 和 model
+        self._resolved_device = self._resolve_device()
+        actual_model_name = self._resolve_model_name(self._resolved_device)
+        self.model_name = actual_model_name  # 更新为实际模型名
+
+        try:
+            from sentence_transformers import SentenceTransformer
+
+            self.model = SentenceTransformer(actual_model_name, device=self._resolved_device)
+            self._resolved_dim = self.model.get_sentence_embedding_dimension()
+            logger.info(
+                f"模型已加载: {actual_model_name} "
+                f"(device={self._resolved_device}, dimension={self._resolved_dim})"
+            )
+        except Exception as e:
+            logger.error(f"加载模型失败: {e}")
+            raise
+
+    def encode(self, texts: List[str], batch_size: int = 32) -> np.ndarray:
+        """文本编码（优先使用 daemon）"""
+        # 优先使用 daemon
+        if self._check_daemon() and self._daemon_client is not None:
+            try:
+                return self._daemon_client.encode(texts, batch_size=batch_size)
+            except Exception as e:
+                logger.warning(f"Daemon 编码失败，回退到本地: {e}")
+                self._use_daemon = False
+
+        if self.model is None:
+            self.load()
+
+        try:
+            return self.model.encode(
+                texts, batch_size=batch_size, show_progress_bar=False, convert_to_numpy=True
+            )
+        except Exception as e:
+            logger.error(f"编码失败: {e}")
+            raise
+
+    def encode_single(self, text: str) -> np.ndarray:
+        """单文本编码"""
+        return self.encode([text])[0]
+
+    @property
+    def dimension(self) -> int:
+        """返回嵌入维度（动态读取）"""
+        if self._resolved_dim is not None:
+            return self._resolved_dim
+        if self.model is not None:
+            return self.model.get_sentence_embedding_dimension()
+        # 未加载时：如果 model_name 已确定，估算维度
+        if self.model_name and self.model_name != "auto":
+            if "bge-m3" in self.model_name or "bge-large" in self.model_name:
+                return 1024
+        return 384  # 默认 MiniLM 维度
+
+
+# Global backend instance
+_backend: Optional[EmbeddingBackend] = None
+
+
+def get_backend() -> EmbeddingBackend:
+    """获取全局 embedding 后端实例（从 config 读取配置）"""
+    global _backend
+    if _backend is None:
+        from .config import config
+
+        model_name = config.embedding_model
+        if model_name == "auto":
+            model_name = None  # 交给 EmbeddingBackend 根据 device 自动决定
+        _backend = EmbeddingBackend(model_name=model_name, device=config.device)
+    return _backend
+
+
+def reset_backend():
+    """重置全局 embedding 后端（用于测试或特殊场景）"""
+    global _backend
+    _backend = None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_embedding_device.py -v`
+Expected: All 8 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add jfox/embedding_backend.py tests/test_embedding_device.py
+git commit -m "feat: add device auto-detection and model selection to EmbeddingBackend
+
+- _resolve_device() auto-detects CUDA availability
+- _resolve_model_name() selects bge-m3 for GPU, MiniLM for CPU
+- dimension property is now dynamic (reads from model)
+- get_backend() reads config.embedding_model and config.device"
+```
+
+---
+
+### Task 2: Config 默认值变更
+
+**Files:**
+- Modify: `jfox/config.py:32-33` (ZKConfig default values)
+- Modify: `tests/test_config_unit.py:49-51,94,124,147` (update assertions)
+
+- [ ] **Step 1: Update config defaults and fix test assertions**
+
+In `jfox/config.py`, change lines 32-33:
+
+```python
+    # NPU 配置
+    embedding_model: str = "auto"
+    embedding_dimension: int = 0  # 0 表示动态，由模型决定
+```
+
+In `tests/test_config_unit.py`, update `test_default_values` (line 49-50):
+
+```python
+        assert config.embedding_model == "auto"
+        assert config.embedding_dimension == 0
+```
+
+Update `test_save_writes_yaml` (line 94):
+
+```python
+        assert data["embedding_model"] == "auto"
+```
+
+Update `test_load_returns_default_if_file_not_exists` (line 147):
+
+```python
+        assert config.embedding_model == "auto"
+```
+
+- [ ] **Step 2: Run config tests to verify**
+
+Run: `uv run pytest tests/test_config_unit.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add jfox/config.py tests/test_config_unit.py
+git commit -m "refactor: change config defaults to 'auto' for embedding model selection
+
+- embedding_model default: 'auto' (device-driven selection)
+- embedding_dimension default: 0 (dynamic, read from model)
+- Update test assertions to match new defaults"
+```
+
+---
+
+### Task 3: MockEmbeddingBackend 适配 + get_backend 测试
+
+**Files:**
+- Modify: `tests/conftest.py:64-80` (MockEmbeddingBackend)
+- Modify: `tests/test_embedding_device.py` (add get_backend tests)
+
+- [ ] **Step 1: Update MockEmbeddingBackend in conftest.py**
+
+Replace `MockEmbeddingBackend` class (lines 64-80) with:
+
+```python
+    class MockEmbeddingBackend:
+        """Mock embedding backend - 返回随机向量（适配新接口）"""
+
+        def __init__(self):
+            self.model_name = "mock-model"
+            self.device = "cpu"
+            self._resolved_device = "cpu"
+            self._resolved_dim = 384
+            self.dimension = 384
+
+        def encode(self, texts, **kwargs):
+            """返回随机向量"""
+            if isinstance(texts, str):
+                texts = [texts]
+            return np.random.rand(len(texts), self.dimension).astype("float32")
+
+        def encode_batch(self, texts, batch_size=32):
+            """批量编码"""
+            return self.encode(texts)
+
+        def _resolve_device(self):
+            return "cpu"
+
+        def _resolve_model_name(self, resolved_device):
+            return "mock-model"
+```
+
+- [ ] **Step 2: Add get_backend tests to test_embedding_device.py**
+
+Append to `tests/test_embedding_device.py`:
+
+```python
+class TestGetBackend:
+    """测试 get_backend() 从 config 读取配置"""
+
+    def test_reads_config_device(self):
+        """get_backend() 从 config.device 读取"""
+        from jfox.embedding_backend import _backend, get_backend, reset_backend
+
+        reset_backend()
+        with patch("jfox.config.config") as mock_config:
+            mock_config.embedding_model = "BAAI/bge-m3"
+            mock_config.device = "cuda"
+            backend = get_backend()
+            assert backend.device == "cuda"
+            assert backend.model_name == "BAAI/bge-m3"
+        reset_backend()
+
+    def test_auto_model_resolves_to_none(self):
+        """config.embedding_model='auto' 传 None 给 EmbeddingBackend"""
+        from jfox.embedding_backend import reset_backend
+
+        reset_backend()
+        with patch("jfox.config.config") as mock_config:
+            mock_config.embedding_model = "auto"
+            mock_config.device = "cpu"
+            from jfox.embedding_backend import get_backend
+
+            backend = get_backend()
+            assert backend.model_name is None  # None = auto-select
+        reset_backend()
+
+    def test_reset_backend_clears_singleton(self):
+        """reset_backend() 清除全局单例"""
+        from jfox.embedding_backend import _backend, reset_backend
+
+        reset_backend()
+        from jfox.embedding_backend import _backend as check1
+
+        assert check1 is None
+```
+
+- [ ] **Step 3: Run all embedding device tests**
+
+Run: `uv run pytest tests/test_embedding_device.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/conftest.py tests/test_embedding_device.py
+git commit -m "test: add get_backend config tests and update MockEmbeddingBackend
+
+- MockEmbeddingBackend now has _resolved_device, _resolved_dim attributes
+- Test get_backend() reads config.embedding_model and config.device
+- Test reset_backend() clears singleton"
+```
+
+---
+
+### Task 4: CLI `config set` 命令
+
+**Files:**
+- Modify: `jfox/cli.py` (add config command)
+- Create: `tests/test_config_set_unit.py`
+
+- [ ] **Step 1: Write failing tests for config set**
+
+Create `tests/test_config_set_unit.py`:
+
+```python
+"""Unit tests for 'jfox config set' command"""
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+import yaml
+
+
+class TestConfigSet:
+    """测试 jfox config set 命令"""
+
+    def test_set_device_writes_to_yaml(self, tmp_path):
+        """config set device cuda 写入 config.yaml"""
+        from jfox.cli import _config_set_impl
+
+        zk_dir = tmp_path / ".zk"
+        zk_dir.mkdir(parents=True)
+        config_file = zk_dir / "config.yaml"
+
+        with patch("jfox.cli.config") as mock_config:
+            mock_config.zk_dir = zk_dir
+            mock_config.device = "auto"
+            mock_config.embedding_model = "auto"
+            _config_set_impl("device", "cuda")
+
+        with open(config_file) as f:
+            data = yaml.safe_load(f)
+        assert data["device"] == "cuda"
+
+    def test_set_embedding_model_writes_to_yaml(self, tmp_path):
+        """config set embedding_model BAAI/bge-m3 写入 config.yaml"""
+        from jfox.cli import _config_set_impl
+
+        zk_dir = tmp_path / ".zk"
+        zk_dir.mkdir(parents=True)
+        config_file = zk_dir / "config.yaml"
+
+        with patch("jfox.cli.config") as mock_config:
+            mock_config.zk_dir = zk_dir
+            mock_config.device = "auto"
+            mock_config.embedding_model = "auto"
+            _config_set_impl("embedding_model", "BAAI/bge-m3")
+
+        with open(config_file) as f:
+            data = yaml.safe_load(f)
+        assert data["embedding_model"] == "BAAI/bge-m3"
+
+    def test_set_invalid_key_raises(self):
+        """config set invalid_key 抛出错误"""
+        from jfox.cli import _config_set_impl
+
+        with pytest.raises(ValueError, match="不支持的配置项"):
+            _config_set_impl("invalid_key", "value")
+
+    def test_set_resets_backend_singleton(self, tmp_path):
+        """config set 后重置 backend 单例"""
+        from jfox.cli import _config_set_impl
+
+        zk_dir = tmp_path / ".zk"
+        zk_dir.mkdir(parents=True)
+        config_file = zk_dir / "config.yaml"
+
+        with (
+            patch("jfox.cli.config") as mock_config,
+            patch("jfox.embedding_backend.reset_backend") as mock_reset,
+        ):
+            mock_config.zk_dir = zk_dir
+            mock_config.device = "auto"
+            mock_config.embedding_model = "auto"
+            _config_set_impl("device", "cuda")
+            mock_reset.assert_called_once()
+
+    def test_valid_config_keys(self):
+        """验证所有合法的配置键"""
+        from jfox.cli import _VALID_CONFIG_KEYS
+
+        assert "device" in _VALID_CONFIG_KEYS
+        assert "embedding_model" in _VALID_CONFIG_KEYS
+        assert "batch_size" in _VALID_CONFIG_KEYS
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_config_set_unit.py -v`
+Expected: FAIL — `_config_set_impl` and `_VALID_CONFIG_KEYS` not defined.
+
+- [ ] **Step 3: Implement config set in cli.py**
+
+Add near the top of `cli.py` (after imports, around line 54):
+
+```python
+# config set 允许的配置键及其验证
+_VALID_CONFIG_KEYS = {"device", "embedding_model", "batch_size"}
+```
+
+Add the `_config_set_impl` function (place it before the `status` command, around line 571):
+
+```python
+def _config_set_impl(key: str, value: str):
+    """设置配置项的内部实现"""
+    if key not in _VALID_CONFIG_KEYS:
+        raise ValueError(f"不支持的配置项: {key} (可选: {', '.join(sorted(_VALID_CONFIG_KEYS))})")
+
+    # 读取现有配置（或使用默认值）
+    config_data = {}
+    config_file = config.zk_dir / "config.yaml"
+    if config_file.exists():
+        with open(config_file, "r", encoding="utf-8") as f:
+            config_data = yaml.safe_load(f) or {}
+
+    # 更新配置值
+    config_data[key] = value
+
+    # 写回文件
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(config_file, "w", encoding="utf-8") as f:
+        yaml.dump(config_data, f, allow_unicode=True, sort_keys=False)
+
+    # 重置 backend 单例，下次操作时用新配置
+    from .embedding_backend import reset_backend
+
+    reset_backend()
+
+    console.print(f"[green]✓[/green] {key} = {value}")
+
+    # 如果修改了 embedding_model，检查维度变化
+    if key == "embedding_model":
+        _warn_dimension_change(value)
+
+
+def _warn_dimension_change(new_model: str):
+    """检查新模型维度是否与旧索引匹配"""
+    try:
+        old_dim = None
+        chroma_dir = config.chroma_dir
+        if chroma_dir.exists():
+            import chromadb
+            from chromadb.config import Settings
+
+            client = chromadb.PersistentClient(
+                path=str(chroma_dir),
+                settings=Settings(anonymized_telemetry=False, allow_reset=True),
+            )
+            try:
+                collection = client.get_collection("notes")
+                old_dim = collection.metadata.get("dimension") if collection.metadata else None
+            except Exception:
+                pass
+
+        # 估算新模型维度
+        new_dim = 1024 if ("bge-m3" in new_model or "bge-large" in new_model) else 384
+
+        if old_dim is not None and old_dim != new_dim:
+            console.print(
+                f"[yellow]⚠ 模型已更改为 {new_model} (维度 {old_dim} → {new_dim})[/yellow]"
+            )
+            console.print("  现有向量索引已失效，请运行: [cyan]jfox index rebuild[/cyan]")
+    except Exception:
+        pass  # 检查失败不影响主流程
+```
+
+Add the CLI command (place near other commands, around line 2300):
+
+```python
+@app.command(name="config")
+def config_cmd(
+    action: str = typer.Argument(..., help="操作: set"),
+    key: str = typer.Argument(None, help="配置项名称"),
+    value: str = typer.Argument(None, help="配置值"),
+):
+    """
+    查看/修改知识库配置
+
+    示例:
+
+        jfox config set device cuda          # 使用 GPU
+        jfox config set device auto          # 自动检测
+        jfox config set embedding_model BAAI/bge-m3  # 切换模型
+        jfox config set embedding_model auto          # 自动选择模型
+    """
+    try:
+        if action == "set":
+            if key is None or value is None:
+                console.print("[red]用法: jfox config set <key> <value>[/red]")
+                raise typer.Exit(1)
+            _config_set_impl(key, value)
+        else:
+            console.print(f"[red]未知操作: {action}[/red]")
+            console.print("可用操作: set")
+            raise typer.Exit(1)
+    except ValueError as e:
+        console.print(f"[red]✗[/red] {e}")
+        raise typer.Exit(1)
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]✗[/red] 错误: {e}")
+        raise typer.Exit(1)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_config_set_unit.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add jfox/cli.py tests/test_config_set_unit.py
+git commit -m "feat: add 'jfox config set' command for device/model configuration
+
+- jfox config set device cuda/auto/cpu
+- jfox config set embedding_model <name>/auto
+- Warns on dimension change when switching models
+- Resets backend singleton after config change"
+```
+
+---
+
+### Task 5: CLI `status` 显示实际设备信息
+
+**Files:**
+- Modify: `jfox/cli.py:572-621` (_status_impl function)
+
+- [ ] **Step 1: Update _status_impl to show actual device info**
+
+Replace lines 588-593 (the `"backend"` dict in `_status_impl`):
+
+```python
+        "backend": {
+            "type": backend._resolved_device or "未加载",
+            "model": backend.model_name or "auto (未加载)",
+            "dimension": backend.dimension,
+        },
+```
+
+Replace line 615 (table row for Backend):
+
+```python
+        table.add_row("Backend", backend._resolved_device or "未加载")
+```
+
+Replace line 616 (table row for Model):
+
+```python
+        table.add_row("Model", backend.model_name or "auto (未加载)")
+```
+
+Add after the Model row:
+
+```python
+        table.add_row("Dimension", str(backend.dimension))
+```
+
+- [ ] **Step 2: Verify status output manually**
+
+Run: `uv run jfox status --format json`
+Expected: JSON output with `"type": "cpu"` or `"cuda"` (depending on machine).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add jfox/cli.py
+git commit -m "fix: show actual device info in jfox status instead of hardcoded CPU
+
+- backend.type now shows resolved device (cpu/cuda)
+- Shows model name and dimension dynamically"
+```
+
+---
+
+### Task 6: Daemon 改造 — 读 config + /health 报告设备
+
+**Files:**
+- Modify: `jfox/daemon/server.py:24-37,45-49,76-84`
+- Modify: `jfox/daemon/process.py:208-226` (get_daemon_status)
+
+- [ ] **Step 1: Update daemon server to read config and report device**
+
+In `jfox/daemon/server.py`, replace `HealthResponse` class (lines 45-49):
+
+```python
+class HealthResponse(BaseModel):
+    status: str
+    model: str
+    dimension: int
+    device: str  # 实际使用的设备
+    pid: int
+```
+
+Replace `_load_model` function (lines 24-37):
+
+```python
+@app.on_event("startup")
+def _load_model():
+    """启动时加载模型（标记为 daemon 进程，防止自引用）"""
+    global _backend
+    os.environ["JFOX_DAEMON_PROCESS"] = "1"
+    from ..config import config
+    from ..embedding_backend import EmbeddingBackend
+
+    model_name = config.embedding_model if config.embedding_model != "auto" else None
+    _backend = EmbeddingBackend(device=config.device, model_name=model_name)
+    try:
+        _backend.load()
+        logger.info(
+            f"Daemon: 模型已加载 {_backend.model_name} "
+            f"(device={_backend._resolved_device}, dimension={_backend._resolved_dim})"
+        )
+    except Exception as e:
+        logger.error(f"Daemon: 模型加载失败，进程退出: {e}")
+        os._exit(1)
+```
+
+Update `/health` endpoint (lines 76-84):
+
+```python
+@app.get("/health", response_model=HealthResponse)
+def health():
+    """健康检查"""
+    return HealthResponse(
+        status="ok",
+        model=_backend.model_name,
+        dimension=_backend.dimension,
+        device=_backend._resolved_device or "unknown",
+        pid=os.getpid(),
+    )
+```
+
+- [ ] **Step 2: Update get_daemon_status to pass through device**
+
+In `jfox/daemon/process.py`, update `get_daemon_status()` (lines 219-226):
+
+```python
+    return {
+        "pid": health.get("pid", 0),
+        "host": host,
+        "port": port,
+        "model": health.get("model", "unknown"),
+        "dimension": health.get("dimension", 384),
+        "device": health.get("device", "unknown"),
+        "started_at": data.get("started_at") if data else None,
+    }
+```
+
+- [ ] **Step 3: Update daemon status display in CLI**
+
+In `jfox/cli.py`, in the daemon `status` action table (around line 2548), add after the dimension row:
+
+```python
+                    table.add_row("设备", info.get("device", "unknown"))
+```
+
+And in the daemon `start` action table (around line 2522), add after the dimension row:
+
+```python
+                    table.add_row("设备", info.get("device", "unknown"))
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add jfox/daemon/server.py jfox/daemon/process.py jfox/cli.py
+git commit -m "feat: daemon reads config for device/model and reports device in /health
+
+- daemon/server.py loads model using config.device and config.embedding_model
+- /health endpoint includes device field
+- get_daemon_status() passes through device info
+- CLI daemon status/start shows device"
+```
+
+---
+
+### Task 7: 确保现有快速测试通过
+
+**Files:** No new files — validation only.
+
+- [ ] **Step 1: Run fast unit tests**
+
+Run: `uv run pytest tests/test_config_unit.py tests/test_config_set_unit.py tests/test_embedding_device.py -v`
+Expected: All PASS.
+
+- [ ] **Step 2: Run broader fast tests (no embedding, no slow)**
+
+Run: `uv run pytest tests/ -m "not embedding and not slow" -v --timeout=120`
+Expected: All PASS. If any fail due to the new EmbeddingBackend interface, fix them.
+
+- [ ] **Step 3: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix: address test failures from EmbeddingBackend interface changes"
+```
+
+---
+
+### Task 8: 集成验证
+
+**Files:** No new files — manual verification.
+
+- [ ] **Step 1: Verify CLI help includes new config command**
+
+Run: `uv run jfox --help`
+Expected: `config` command listed.
+
+- [ ] **Step 2: Verify config set works end-to-end**
+
+Run: `uv run jfox config set device cpu && uv run jfox status --format json`
+Expected: device field shows `"cpu"`.
+
+- [ ] **Step 3: Verify auto-detection works**
+
+Run: `uv run jfox config set device auto && uv run jfox status --format json`
+Expected: device field shows `"cuda"` or `"cpu"` depending on machine.
+
+- [ ] **Step 4: Verify daemon status shows device**
+
+Run: `uv run jfox daemon status`
+Expected: Shows device info (or "Daemon 未运行" if not running).
+
+- [ ] **Step 5: Final commit — bump version**
+
+Update version in `jfox/__init__.py` and `pyproject.toml` to `0.4.0` (minor bump for new feature), then run `uv lock`.
+
+```bash
+git add jfox/__init__.py pyproject.toml uv.lock
+git commit -m "chore: bump version to 0.4.0 for GPU embedding support"
+```
+
+---
+
+## Self-Review Checklist
+
+- [x] **Spec coverage:** Each section in the spec maps to a task:
+  - Section 1 (Device detection) → Task 1
+  - Section 2 (EmbeddingBackend) → Task 1
+  - Section 3 (CLI config set) → Tasks 4, 5
+  - Section 4 (Daemon) → Task 6
+  - Section 5 (Config defaults) → Task 2
+- [x] **Placeholder scan:** No TBD/TODO/vague steps. All code is concrete.
+- [x] **Type consistency:** `_resolve_device()`, `_resolve_model_name()`, `_resolved_device`, `_resolved_dim`, `_VALID_CONFIG_KEYS` names are consistent across all tasks.

--- a/docs/superpowers/plans/2026-04-15-make-daemon-deps-required.md
+++ b/docs/superpowers/plans/2026-04-15-make-daemon-deps-required.md
@@ -1,0 +1,358 @@
+# Make Daemon Dependencies Required — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move `fastapi` and `uvicorn` from optional `[daemon]` extras to required dependencies so `jfox daemon start` works out of the box after `uv tool install jfox`.
+
+**Architecture:** Config-only change (no code changes). Move two packages in `pyproject.toml`, then update all documentation that references `[daemon]` as an optional extra.
+
+**Tech Stack:** Python packaging (pyproject.toml), Markdown docs
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|------|--------|---------------|
+| `pyproject.toml` | Modify | Move fastapi/uvicorn to required deps, remove `[daemon]` extra |
+| `uv.lock` | Regenerate | `uv lock` updates lockfile after pyproject.toml change |
+| `README.md` | Modify | Update daemon description (remove "可选依赖") |
+| `CLAUDE.md` | Modify | Update daemon description (remove "可选依赖") |
+| `docs/installation.md` | Modify | Add fastapi/uvicorn to Requirements list |
+| `skills-recommend/claude-code/jfox-common/SKILL.md` | Modify | Remove `[daemon]` optional note |
+| `skills-recommend/claude-code/jfox-search/SKILL.md` | Modify | Remove `[daemon]` optional note |
+| `skills-recommend/claude-code/jfox-ingest/SKILL.md` | Modify | Remove `[daemon]` optional note |
+| `skills-recommend/claude-code/jfox-organize/SKILL.md` | Modify | Remove `[daemon]` optional note |
+| `docs/superpowers/plans/2026-04-14-sync-docs-daemon-show.md` | Modify | Remove `[daemon]` optional notes |
+
+---
+
+### Task 1: Move daemon deps to required in pyproject.toml
+
+**Files:**
+- Modify: `pyproject.toml:26-37,39-54`
+
+- [ ] **Step 1: Edit `pyproject.toml` — add fastapi and uvicorn to dependencies**
+
+Change the `dependencies` list in `pyproject.toml` from:
+
+```toml
+dependencies = [
+    "typer>=0.12.0",
+    "rich>=13.0.0",
+    "sentence-transformers>=3.0",
+    "chromadb>=0.5.0",
+    "networkx>=3.0",
+    "watchdog>=3.0",
+    "pyyaml>=6.0",
+    "pydantic>=2.0",
+    "rank-bm25>=0.2.2",
+    "jinja2>=3.0",
+]
+```
+
+to:
+
+```toml
+dependencies = [
+    "typer>=0.12.0",
+    "rich>=13.0.0",
+    "sentence-transformers>=3.0",
+    "chromadb>=0.5.0",
+    "networkx>=3.0",
+    "watchdog>=3.0",
+    "pyyaml>=6.0",
+    "pydantic>=2.0",
+    "rank-bm25>=0.2.2",
+    "jinja2>=3.0",
+    "fastapi>=0.110.0",
+    "uvicorn[standard]>=0.27.0",
+]
+```
+
+Then delete the entire `[daemon]` section under `[project.optional-dependencies]`:
+
+```toml
+daemon = [
+    "fastapi>=0.110.0",
+    "uvicorn[standard]>=0.27.0",
+]
+```
+
+The `[project.optional-dependencies]` section should end up with only the `dev` entry.
+
+- [ ] **Step 2: Regenerate uv.lock**
+
+Run: `uv lock`
+
+Expected: Lockfile updated with fastapi/uvicorn resolution.
+
+- [ ] **Step 3: Verify installation**
+
+Run: `uv sync --extra dev`
+
+Expected: fastapi and uvicorn installed (visible in output).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "chore: move daemon deps (fastapi, uvicorn) to required dependencies
+
+Closes #150"
+```
+
+---
+
+### Task 2: Update README.md
+
+**Files:**
+- Modify: `README.md:57,70,88`
+
+- [ ] **Step 1: Update Mermaid diagram — remove "(可选)" from daemon label**
+
+In `README.md` line 57, change:
+
+```
+daemon["daemon/<br/>HTTP Server (可选)"]
+```
+
+to:
+
+```
+daemon["daemon/<br/>HTTP Server"]
+```
+
+- [ ] **Step 2: Update module table — daemon description**
+
+In `README.md` line 88, change:
+
+```
+| `daemon/` | Embedding HTTP 守护进程（可选依赖 `[daemon]`），常驻模型避免重复加载 |
+```
+
+to:
+
+```
+| `daemon/` | Embedding HTTP 守护进程，常驻模型避免重复加载 |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: remove optional daemon references from README"
+```
+
+---
+
+### Task 3: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md:70`
+
+- [ ] **Step 1: Update daemon description in module table**
+
+In `CLAUDE.md` line 70, change:
+
+```
+| `daemon/` | Embedding 模型 HTTP 守护进程（可选依赖 `[daemon]`），`jfox daemon start/stop/status` |
+```
+
+to:
+
+```
+| `daemon/` | Embedding 模型 HTTP 守护进程，`jfox daemon start/stop/status` |
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: remove optional daemon references from CLAUDE.md"
+```
+
+---
+
+### Task 4: Update docs/installation.md
+
+**Files:**
+- Modify: `docs/installation.md:44`
+
+- [ ] **Step 1: Add fastapi and uvicorn to Requirements list**
+
+In `docs/installation.md` line 44, change:
+
+```
+- Dependencies: typer, rich, sentence-transformers, chromadb, networkx, watchdog, pyyaml
+```
+
+to:
+
+```
+- Dependencies: typer, rich, sentence-transformers, chromadb, networkx, watchdog, pyyaml, fastapi, uvicorn
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/installation.md
+git commit -m "docs: add fastapi/uvicorn to installation requirements"
+```
+
+---
+
+### Task 5: Update skills-recommend/ SKILL.md files
+
+**Files:**
+- Modify: `skills-recommend/claude-code/jfox-common/SKILL.md:350`
+- Modify: `skills-recommend/claude-code/jfox-search/SKILL.md:108`
+- Modify: `skills-recommend/claude-code/jfox-ingest/SKILL.md:246`
+- Modify: `skills-recommend/claude-code/jfox-organize/SKILL.md:166`
+
+- [ ] **Step 1: Update jfox-common/SKILL.md**
+
+In `skills-recommend/claude-code/jfox-common/SKILL.md` line 350, change:
+
+```
+注意：daemon 是可选依赖 `[daemon]`，未安装时自动 fallback 到本地模型加载。
+```
+
+to:
+
+```
+注意：daemon 依赖（fastapi、uvicorn）已作为必选依赖安装，`jfox daemon start` 可直接使用。
+```
+
+- [ ] **Step 2: Update jfox-search/SKILL.md**
+
+In `skills-recommend/claude-code/jfox-search/SKILL.md` line 108, change:
+
+```
+- **Slow search**: First search loads embedding model (30-60s). Subsequent searches are fast. 可通过 `jfox daemon start`（需安装 `[daemon]` 依赖）启动守护进程避免重复加载。
+```
+
+to:
+
+```
+- **Slow search**: First search loads embedding model (30-60s). Subsequent searches are fast. 可通过 `jfox daemon start` 启动守护进程避免重复加载。
+```
+
+- [ ] **Step 3: Update jfox-ingest/SKILL.md**
+
+In `skills-recommend/claude-code/jfox-ingest/SKILL.md` line 246, change:
+
+```
+# 批量导入加速（可选，需安装 [daemon] 依赖）
+```
+
+to:
+
+```
+# 批量导入加速（可选）
+```
+
+- [ ] **Step 4: Update jfox-organize/SKILL.md**
+
+In `skills-recommend/claude-code/jfox-organize/SKILL.md` line 166, change:
+
+```
+# 批量整理加速（可选，需安装 [daemon] 依赖）
+```
+
+to:
+
+```
+# 批量整理加速（可选）
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills-recommend/
+git commit -m "docs: remove [daemon] optional dependency notes from skills"
+```
+
+---
+
+### Task 6: Update existing plan doc
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-04-14-sync-docs-daemon-show.md:64,169,245`
+
+- [ ] **Step 1: Update all three occurrences**
+
+Line 64 — change:
+
+```
+| `daemon/` | Embedding HTTP 守护进程（可选依赖 `[daemon]`），常驻模型避免重复加载 |
+```
+
+to:
+
+```
+| `daemon/` | Embedding HTTP 守护进程，常驻模型避免重复加载 |
+```
+
+Line 169 — change:
+
+```
+注意：daemon 是可选依赖 `[daemon]`，未安装时自动 fallback 到本地模型加载。
+```
+
+to:
+
+```
+注意：daemon 依赖（fastapi、uvicorn）已作为必选依赖安装，`jfox daemon start` 可直接使用。
+```
+
+Line 245 — change:
+
+```
++ - **Slow search**: First search loads embedding model (30-60s). Subsequent searches are fast. 可通过 `jfox daemon start`（需安装 `[daemon]` 依赖）启动守护进程避免重复加载。
+```
+
+to:
+
+```
++ - **Slow search**: First search loads embedding model (30-60s). Subsequent searches are fast. 可通过 `jfox daemon start` 启动守护进程避免重复加载。
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-04-14-sync-docs-daemon-show.md
+git commit -m "docs: remove [daemon] optional notes from plan doc"
+```
+
+---
+
+### Task 7: Final verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Verify no remaining `[daemon]` optional references**
+
+Run: `grep -rn "\[daemon\]" --include="*.md" --include="*.toml" .`
+
+Expected: Zero matches (or only historical changelog entries that are fine to keep).
+
+- [ ] **Step 2: Verify pyproject.toml correctness**
+
+Run: `uv run python -c "import fastapi; import uvicorn; print('OK')"`
+
+Expected: `OK`
+
+- [ ] **Step 3: Run fast tests to confirm no breakage**
+
+Run: `uv run pytest tests/ -m "not slow and not embedding" -x`
+
+Expected: All tests pass. Hand this command to the user for manual execution if it's too slow.
+
+---
+
+## Self-Review
+
+1. **Spec coverage:** Issue #150 acceptance criteria all covered — pyproject.toml change (Task 1), installation.md (Task 4), all `[daemon]` doc references (Tasks 2-6), verification (Task 7).
+2. **Placeholder scan:** All steps contain exact code/commands. No TBD/TODO placeholders.
+3. **Type consistency:** N/A — this is a config/doc-only change, no types involved.

--- a/docs/superpowers/plans/2026-04-16-fix-windows-daemon-console-window.md
+++ b/docs/superpowers/plans/2026-04-16-fix-windows-daemon-console-window.md
@@ -1,0 +1,206 @@
+# Fix Windows Daemon Console Window Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `jfox daemon start` on Windows so it spawns no visible console window when using Microsoft Store Python.
+
+**Architecture:** Replace `python.exe` with `pythonw.exe` in the subprocess command on Windows. Add a helper function with fallback to `python.exe` if `pythonw.exe` doesn't exist. Keep existing `CREATE_NO_WINDOW` flags as defense-in-depth.
+
+**Tech Stack:** Python 3.10+, subprocess, pathlib
+
+---
+
+### Task 1: Add `_get_pythonw_executable` helper and test
+
+**Files:**
+- Modify: `jfox/daemon/process.py:1-22` (add helper after imports)
+- Create: `tests/unit/test_daemon_process.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_daemon_process.py`:
+
+```python
+"""Daemon 进程管理单元测试"""
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+class TestGetPythonwExecutable:
+    """测试 _get_pythonw_executable 辅助函数"""
+
+    def test_returns_pythonw_on_windows(self):
+        """Windows 上返回 pythonw.exe"""
+        if sys.platform != "win32":
+            pytest.skip("Windows only")
+
+        from jfox.daemon.process import _get_pythonw_executable
+
+        result = _get_pythonw_executable()
+        assert result.endswith("pythonw.exe") or result.endswith("python.exe")
+
+    def test_fallback_when_pythonw_missing(self):
+        """pythonw.exe 不存在时回退到 python.exe"""
+        if sys.platform != "win32":
+            pytest.skip("Windows only")
+
+        from jfox.daemon.process import _get_pythonw_executable
+
+        with patch("jfox.daemon.process.Path") as mock_path_cls:
+            # 模拟 pythonw.exe 不存在
+            mock_path_instance = mock_path_cls.return_value
+            mock_path_instance.exists.return_value = False
+            result = _get_pythonw_executable()
+            assert result == sys.executable
+
+    def test_non_windows_returns_sys_executable(self):
+        """非 Windows 平台返回 sys.executable"""
+        from jfox.daemon.process import _get_pythonw_executable
+
+        with patch("jfox.daemon.process.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            mock_sys.executable = "/usr/bin/python3"
+            result = _get_pythonw_executable()
+            assert result == "/usr/bin/python3"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_daemon_process.py -v -k "test_returns_pythonw_on_windows or test_fallback_when_pythonw_missing or test_non_windows_returns" --no-header`
+Expected: FAIL with `ImportError: cannot import name '_get_pythonw_executable'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `jfox/daemon/process.py` after the imports (after line 17), before `logger = logging.getLogger(__name__)`:
+
+```python
+def _get_pythonw_executable() -> str:
+    """获取 pythonw.exe 路径（Windows 无控制台入口）
+
+    Windows 上优先使用 pythonw.exe 避免 daemon 子进程弹出控制台窗口。
+    如果 pythonw.exe 不存在则回退到 sys.executable。
+    非 Windows 平台直接返回 sys.executable。
+    """
+    if sys.platform != "win32":
+        return sys.executable
+
+    pythonw = sys.executable.replace("python.exe", "pythonw.exe")
+    if pythonw != sys.executable and Path(pythonw).exists():
+        return pythonw
+    return sys.executable
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/test_daemon_process.py -v --no-header`
+Expected: all 3 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add jfox/daemon/process.py tests/unit/test_daemon_process.py
+git commit -m "feat(daemon): add _get_pythonw_executable helper for Windows"
+```
+
+---
+
+### Task 2: Use `_get_pythonw_executable` in `start_daemon`
+
+**Files:**
+- Modify: `jfox/daemon/process.py:111` (change cmd construction)
+- Modify: `tests/unit/test_daemon_process.py` (add test)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_daemon_process.py`:
+
+```python
+class TestStartDaemonWindowsExecutable:
+    """测试 start_daemon 在 Windows 上使用 pythonw.exe"""
+
+    @patch("jfox.daemon.process.subprocess.Popen")
+    @patch("jfox.daemon.process._http_health_check")
+    def test_uses_pythonw_on_windows(self, mock_health, mock_popen):
+        """Windows 上 start_daemon 使用 pythonw.exe 启动子进程"""
+        if sys.platform != "win32":
+            pytest.skip("Windows only")
+
+        from jfox.daemon.process import start_daemon
+
+        # daemon 未运行 → 启动新进程
+        mock_health.side_effect = [None, {"pid": 9999}]
+        mock_popen.return_value.pid = 1234
+
+        start_daemon()
+
+        call_args = mock_popen.call_args
+        cmd = call_args[0][0]
+        assert cmd[0].endswith("pythonw.exe"), f"Expected pythonw.exe, got {cmd[0]}"
+
+    @patch("jfox.daemon.process.subprocess.Popen")
+    @patch("jfox.daemon.process._http_health_check")
+    def test_creationflags_present(self, mock_health, mock_popen):
+        """Windows 上 creationflags 包含 CREATE_NO_WINDOW"""
+        if sys.platform != "win32":
+            pytest.skip("Windows only")
+
+        from jfox.daemon.process import start_daemon
+
+        mock_health.side_effect = [None, {"pid": 9999}]
+        mock_popen.return_value.pid = 1234
+
+        start_daemon()
+
+        kwargs = mock_popen.call_args[1]
+        flags = kwargs.get("creationflags", 0)
+        CREATE_NO_WINDOW = 0x08000000
+        assert flags & CREATE_NO_WINDOW, "CREATE_NO_WINDOW flag not set"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_daemon_process.py -v -k "test_uses_pythonw_on_windows" --no-header`
+Expected: FAIL — `cmd[0]` is `python.exe`, not `pythonw.exe`
+
+- [ ] **Step 3: Update `start_daemon` to use the helper**
+
+In `jfox/daemon/process.py`, replace line 111:
+
+```python
+    # 构建启动命令
+    cmd = [sys.executable, "-m", "jfox.daemon.server", "--host", host, "--port", str(port)]
+```
+
+with:
+
+```python
+    # 构建启动命令（Windows 使用 pythonw.exe 避免控制台窗口）
+    cmd = [_get_pythonw_executable(), "-m", "jfox.daemon.server", "--host", host, "--port", str(port)]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_daemon_process.py -v --no-header`
+Expected: all 5 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add jfox/daemon/process.py tests/unit/test_daemon_process.py
+git commit -m "fix(daemon): use pythonw.exe to prevent console window on Windows
+
+Closes #159"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:** Issue #159 要求用 `pythonw.exe` 替代 `python.exe`，Task 2 实现了这一点。fallback 逻辑在 Task 1 的 helper 中。`creationflags` 保留在 Task 2 中验证。
+
+**2. Placeholder scan:** 无 TBD/TODO。所有步骤都有完整代码和命令。
+
+**3. Type consistency:** `_get_pythonw_executable()` 返回 `str`，与 `sys.executable` 类型一致，直接用于 `cmd` 列表第一个元素。

--- a/docs/superpowers/plans/2026-04-18-daemon-timeout-and-index-rebuild.md
+++ b/docs/superpowers/plans/2026-04-18-daemon-timeout-and-index-rebuild.md
@@ -1,0 +1,744 @@
+# Daemon 启动可见性 + Index Rebuild 修复 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修复 daemon 首次启动超时/无日志可见性 + index rebuild 不重建 ChromaDB collection 结构 + 维度不匹配错误提示不友好
+
+**Architecture:** 三个独立修复点：(1) daemon 子进程日志落盘 + 首次下载预检 + 动态超时；(2) VectorStore 新增 `reset_collection()` 彻底重建 collection；(3) `add_note()` 捕获维度不匹配异常并给出 Actionable 提示。所有修改都在现有模块内完成，不新增文件。
+
+**Tech Stack:** Python 3.10+, ChromaDB, subprocess, pathlib
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `jfox/daemon/process.py` | Modify | 日志落盘、模型缓存预检、动态超时 |
+| `jfox/vector_store.py` | Modify | 新增 `reset_collection()`、`add_note()` 维度不匹配友好提示 |
+| `jfox/indexer.py` | Modify | `index_all()` 调用 `reset_collection()` 替代 `clear()` |
+| `jfox/daemon/__init__.py` | Modify | 导出 `DAEMON_LOG_FILE` 常量 |
+| `tests/unit/test_vector_store_clear.py` | Modify | 新增 `reset_collection()` 测试 |
+| `tests/unit/test_indexer_clear_before_rebuild.py` | Modify | 更新 rebuild 测试使用 `reset_collection()` |
+| `tests/unit/test_daemon_process.py` | Modify | 新增日志落盘、预检、动态超时测试 |
+
+---
+
+### Task 1: VectorStore.reset_collection() — 新增方法 + 测试
+
+**Files:**
+- Modify: `jfox/vector_store.py:186-207`
+- Modify: `tests/unit/test_vector_store_clear.py`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `tests/unit/test_vector_store_clear.py` 末尾追加：
+
+```python
+class TestVectorStoreResetCollection:
+    """VectorStore.reset_collection() 单元测试"""
+
+    def test_reset_collection_recreates_collection(self):
+        """reset_collection() 应删除旧 collection 并创建新的（维度重置）"""
+        from jfox.vector_store import VectorStore
+
+        store = VectorStore()
+        client = chromadb.EphemeralClient()
+        store.client = client
+        store.collection = client.create_collection(
+            name="notes", metadata={"hnsw:space": "cosine"}
+        )
+
+        # 插入 384 维数据
+        store.collection.add(
+            ids=["note_001"],
+            documents=["doc1"],
+            embeddings=[[0.1] * 384],
+            metadatas=[{"title": "t1", "type": "permanent", "filepath": "/a", "tags": ""}],
+        )
+        assert store.collection.count() == 1
+
+        # reset 后 collection 应为空
+        result = store.reset_collection()
+
+        assert result is True
+        assert store.collection.count() == 0
+
+    def test_reset_collection_on_nonexistent_collection(self):
+        """reset_collection() 在 collection 不存在时应正常创建新的"""
+        from jfox.vector_store import VectorStore
+
+        store = VectorStore()
+        client = chromadb.EphemeralClient()
+        store.client = client
+        # 不创建 collection，client 上没有 "notes" collection
+
+        result = store.reset_collection()
+
+        assert result is True
+        assert store.collection is not None
+        assert store.collection.count() == 0
+
+    def test_reset_collection_returns_false_on_init_failure(self):
+        """reset_collection() 在 init 失败时返回 False"""
+        from jfox.vector_store import VectorStore
+
+        store = VectorStore()
+        store.client = MagicMock()
+        store.collection = MagicMock()
+        store.collection.count.return_value = 0
+        store.client.delete_collection.side_effect = Exception("DB error")
+
+        result = store.reset_collection()
+
+        assert result is False
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `uv run pytest tests/unit/test_vector_store_clear.py::TestVectorStoreResetCollection -v`
+Expected: FAIL — `AttributeError: 'VectorStore' object has no attribute 'reset_collection'`
+
+- [ ] **Step 3: 实现 reset_collection()**
+
+在 `jfox/vector_store.py` 的 `clear()` 方法后面（第 207 行之后）追加：
+
+```python
+    def reset_collection(self) -> bool:
+        """
+        彻底删除并重建 collection（用于 index rebuild）
+
+        与 clear() 不同，reset_collection() 会删除整个 collection 结构再重建，
+        确保 embedding dimension 等元信息也被重置。
+        适用于切换模型后需要 rebuild 的场景。
+
+        Returns:
+            是否成功重建
+        """
+        if self.client is None:
+            self.init()
+
+        try:
+            self.client.delete_collection("notes")
+            logger.info("Deleted old collection 'notes'")
+        except Exception:
+            pass  # collection 可能不存在
+
+        try:
+            self.collection = self.client.get_or_create_collection(
+                name="notes", metadata={"hnsw:space": "cosine"}
+            )
+            logger.info("Recreated collection 'notes'")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to recreate collection: {e}")
+            return False
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `uv run pytest tests/unit/test_vector_store_clear.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add jfox/vector_store.py tests/unit/test_vector_store_clear.py
+git commit -m "feat(vector_store): add reset_collection() for full collection rebuild"
+```
+
+---
+
+### Task 2: Indexer.index_all() 使用 reset_collection() 替代 clear()
+
+**Files:**
+- Modify: `jfox/indexer.py:253`
+- Modify: `tests/unit/test_indexer_clear_before_rebuild.py`
+
+- [ ] **Step 1: 更新测试**
+
+在 `tests/unit/test_indexer_clear_before_rebuild.py` 中：
+
+将 `test_index_all_calls_vector_store_clear` 的断言从 `clear` 改为 `reset_collection`：
+
+```python
+    def test_index_all_calls_vector_store_reset_collection(self):
+        """index_all() 应在索引笔记前调用 vector_store.reset_collection()"""
+        from jfox.indexer import Indexer
+
+        mock_config = MagicMock()
+        mock_vector_store = MagicMock()
+
+        # 空笔记目录
+        with tempfile.TemporaryDirectory() as tmpdir:
+            notes_dir = Path(tmpdir) / "notes"
+            notes_dir.mkdir()
+            mock_config.notes_dir = str(notes_dir)
+
+            indexer = Indexer(config=mock_config, vector_store=mock_vector_store)
+            count = indexer.index_all()
+
+            assert count == 0
+            mock_vector_store.reset_collection.assert_called_once()
+```
+
+将 `test_index_all_clear_before_add` 的调用顺序检查从 `clear` 改为 `reset_collection`：
+
+```python
+    def test_index_all_reset_before_add(self):
+        """reset_collection() 必须在 add_or_update_note() 之前调用"""
+        from jfox.indexer import Indexer
+
+        mock_config = MagicMock()
+        mock_vector_store = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            notes_dir = Path(tmpdir) / "notes"
+            notes_dir.mkdir()
+            mock_config.notes_dir = str(notes_dir)
+
+            # 创建假笔记文件
+            note_file = notes_dir / "20260412120000-test.md"
+            note_file.write_text(
+                "---\nid: '20260412120000'\ntitle: Test\ntype: permanent\ntags: []\n---\nContent"
+            )
+
+            with patch("jfox.note.NoteManager") as mock_note_mgr:
+                mock_note = MagicMock()
+                mock_note.id = "20260412120000"
+                mock_note_mgr.load_note.return_value = mock_note
+
+                indexer = Indexer(config=mock_config, vector_store=mock_vector_store)
+                indexer.index_all()
+
+            # 验证调用顺序
+            calls = mock_vector_store.method_calls
+            reset_indices = [i for i, c in enumerate(calls) if c[0] == "reset_collection"]
+            add_indices = [i for i, c in enumerate(calls) if c[0] == "add_or_update_note"]
+
+            if reset_indices and add_indices:
+                assert reset_indices[0] < add_indices[0], (
+                    f"reset_collection() (call #{reset_indices[0]}) must be before "
+                    f"add_or_update_note() (call #{add_indices[0]})"
+                )
+```
+
+同时删除旧的 `test_index_all_calls_vector_store_clear` 和 `test_index_all_clear_before_add` 方法（被上面两个新方法替代）。
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `uv run pytest tests/unit/test_indexer_clear_before_rebuild.py -v`
+Expected: FAIL — `reset_collection` not called (因为 `index_all()` 仍调用 `clear()`)
+
+- [ ] **Step 3: 修改 index_all()**
+
+在 `jfox/indexer.py:253`，将：
+
+```python
+        # 清除旧索引数据，确保干净重建
+        self.vector_store.clear()
+```
+
+改为：
+
+```python
+        # 彻底重建 collection（删除旧结构 + 重建，解决模型切换后维度不匹配）
+        self.vector_store.reset_collection()
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `uv run pytest tests/unit/test_indexer_clear_before_rebuild.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add jfox/indexer.py tests/unit/test_indexer_clear_before_rebuild.py
+git commit -m "fix(indexer): use reset_collection() for full rebuild on model switch"
+```
+
+---
+
+### Task 3: add_note() 维度不匹配友好错误提示
+
+**Files:**
+- Modify: `jfox/vector_store.py:84-86`
+- Modify: `tests/unit/test_vector_store_clear.py`（追加测试）
+
+- [ ] **Step 1: 写失败测试**
+
+在 `tests/unit/test_vector_store_clear.py` 末尾追加：
+
+```python
+class TestVectorStoreDimensionMismatch:
+    """add_note() 维度不匹配时应给出友好提示"""
+
+    def test_add_note_dimension_mismatch_friendly_message(self, capfd):
+        """维度不匹配时错误信息应包含 rebuild 提示"""
+        from jfox.vector_store import VectorStore
+        from jfox.models import Note, NoteType
+        from unittest.mock import MagicMock, patch
+
+        store = VectorStore()
+        client = chromadb.EphemeralClient()
+        store.client = client
+        store.collection = client.create_collection(
+            name="notes", metadata={"hnsw:space": "cosine"}
+        )
+
+        # 创建一个假笔记
+        note = MagicMock(spec=Note)
+        note.id = "20260412120000"
+        note.title = "Test"
+        note.content = "Test content"
+        note.type = NoteType.PERMANENT
+        note.tags = []
+        note.filepath = Path("/tmp/test.md")
+
+        # mock collection.add 抛出维度不匹配异常
+        original_add = store.collection.add
+        store.collection.add = MagicMock(
+            side_effect=Exception(
+                "Collection expecting embedding with dimension of 384, got 1024"
+            )
+        )
+
+        result = store.add_note(note)
+
+        assert result is False
+        # 验证 logger.error 被调用且包含友好提示
+        # （通过 capfd 捕获或直接 mock logger）
+
+
+    def test_add_note_normal_exception_still_returns_false(self):
+        """非维度不匹配的异常仍返回 False"""
+        from jfox.vector_store import VectorStore
+
+        store = VectorStore()
+        store.collection = MagicMock()
+        store.collection.add.side_effect = Exception("Some other error")
+
+        note = MagicMock()
+        note.id = "20260412120000"
+        note.title = "Test"
+        note.content = "Content"
+        note.type = MagicMock(value="permanent")
+        note.tags = []
+        note.filepath = MagicMock()
+
+        with patch("jfox.vector_store.get_backend") as mock_backend:
+            mock_backend.return_value.encode_single.return_value.tolist.return_value = [0.1] * 1024
+            result = store.add_note(note)
+
+        assert result is False
+```
+
+- [ ] **Step 2: 运行测试确认通过/失败**
+
+Run: `uv run pytest tests/unit/test_vector_store_clear.py::TestVectorStoreDimensionMismatch -v`
+Expected: 第二个测试 PASS（已有行为），第一个测试需要验证友好提示
+
+- [ ] **Step 3: 修改 add_note() 错误处理**
+
+将 `jfox/vector_store.py` 中 `add_note()` 的 except 块（第 84-86 行）：
+
+```python
+        except Exception as e:
+            logger.error(f"Failed to add note {note.id}: {e}")
+            return False
+```
+
+改为：
+
+```python
+        except Exception as e:
+            error_msg = str(e)
+            if "dimension" in error_msg.lower() and "expecting" in error_msg.lower():
+                # 维度不匹配：模型已切换，提示用户 rebuild
+                import re
+                dim_match = re.search(r"dimension of (\d+).*got (\d+)", error_msg)
+                if dim_match:
+                    old_dim, new_dim = dim_match.group(1), dim_match.group(2)
+                    logger.error(
+                        f"Embedding 维度不匹配（collection: {old_dim}, 当前模型: {new_dim}）。"
+                        f"可能是模型已切换，请执行 jfox index rebuild 重建索引。原始错误: {error_msg}"
+                    )
+                else:
+                    logger.error(
+                        f"Embedding 维度不匹配，可能是模型已切换。"
+                        f"请执行 jfox index rebuild 重建索引。原始错误: {error_msg}"
+                    )
+            else:
+                logger.error(f"Failed to add note {note.id}: {error_msg}")
+            return False
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `uv run pytest tests/unit/test_vector_store_clear.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add jfox/vector_store.py tests/unit/test_vector_store_clear.py
+git commit -m "fix(vector_store): friendly error message on embedding dimension mismatch"
+```
+
+---
+
+### Task 4: Daemon 日志落盘 — 子进程 stdout/stderr 写入日志文件
+
+**Files:**
+- Modify: `jfox/daemon/process.py:38,148-155`
+- Modify: `jfox/daemon/__init__.py`（导出 DAEMON_LOG_FILE）
+- Modify: `tests/unit/test_daemon_process.py`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `tests/unit/test_daemon_process.py` 末尾追加：
+
+```python
+class TestDaemonLogFile:
+    """测试 daemon 子进程日志落盘"""
+
+    @patch("jfox.daemon.process.subprocess.Popen")
+    @patch("jfox.daemon.process._http_health_check")
+    def test_start_daemon_writes_to_log_file(self, mock_health, mock_popen):
+        """start_daemon 应将子进程 stdout/stderr 重定向到日志文件"""
+        from jfox.daemon.process import start_daemon, DAEMON_LOG_FILE
+
+        mock_health.side_effect = [None, {"pid": 9999}]
+        mock_popen.return_value.pid = 1234
+
+        start_daemon()
+
+        call_kwargs = mock_popen.call_args[1]
+        # stdout 和 stderr 不应是 DEVNULL
+        assert call_kwargs["stdout"] != subprocess.DEVNULL
+        assert call_kwargs["stderr"] != subprocess.DEVNULL
+        # 应该是文件对象，且路径包含 DAEMON_LOG_FILE 的路径
+        stdout_arg = call_kwargs["stdout"]
+        assert hasattr(stdout_arg, "name") or hasattr(stdout_arg, "write")
+
+    @patch("jfox.daemon.process.subprocess.Popen")
+    @patch("jfox.daemon.process._http_health_check")
+    def test_daemon_log_file_path(self, mock_health, mock_popen):
+        """DAEMON_LOG_FILE 应在用户 home 目录下"""
+        from jfox.daemon.process import DAEMON_LOG_FILE
+        from pathlib import Path
+
+        assert str(DAEMON_LOG_FILE).endswith(".jfox_daemon.log")
+        assert DAEMON_LOG_FILE.parent == Path.home()
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `uv run pytest tests/unit/test_daemon_process.py::TestDaemonLogFile -v`
+Expected: FAIL — `ImportError: cannot import name 'DAEMON_LOG_FILE'`
+
+- [ ] **Step 3: 实现日志落盘**
+
+在 `jfox/daemon/process.py` 中：
+
+1. 在文件顶部（第 17 行 `from . import DEFAULT_HOST, DEFAULT_PORT` 之后）添加常量：
+
+```python
+DAEMON_LOG_FILE = Path.home() / ".jfox_daemon.log"
+```
+
+2. 将 `STARTUP_TIMEOUT = 60` 行（第 38 行）改为：
+
+```python
+STARTUP_TIMEOUT = 60  # 常规启动超时（秒）
+FIRST_RUN_TIMEOUT = 300  # 首次下载模型超时（秒）
+```
+
+3. 在 `start_daemon()` 函数中，将 `subprocess.Popen` 调用（第 148-155 行）的 stdout/stderr 从 DEVNULL 改为日志文件。替换：
+
+```python
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            **kwargs,
+        )
+```
+
+为：
+
+```python
+    # 子进程日志落盘（stdout/stderr → 日志文件）
+    log_file = open(DAEMON_LOG_FILE, "a", encoding="utf-8")
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=log_file,
+            stderr=log_file,
+            stdin=subprocess.DEVNULL,
+            **kwargs,
+        )
+```
+
+同时将日志提示也加上，在 `logger.info(f"Daemon 进程已启动 (PID: {proc.pid})")` 后追加：
+
+```python
+        logger.info(f"Daemon 日志文件: {DAEMON_LOG_FILE}")
+```
+
+在函数末尾的 `return False`（启动超时）之前，也需要关闭 `log_file`。为了正确管理文件句柄，需要用 try/finally 包裹。完整的 `start_daemon` 函数替换见下方。
+
+4. 完整的 `start_daemon()` 替换为：
+
+```python
+def start_daemon(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> bool:
+    """
+    启动 daemon 后台进程
+
+    Returns:
+        True 表示启动成功
+    """
+    # 检查是否已在运行
+    health = _http_health_check(host, port)
+    if health is not None:
+        logger.info("Daemon 已在运行")
+        _write_pid_file(
+            {
+                "pid": health.get("pid", 0),
+                "host": host,
+                "port": port,
+                "started_at": time.time(),
+            }
+        )
+        return True
+
+    # 首次启动预检：检查模型缓存是否存在
+    timeout = STARTUP_TIMEOUT
+    cache_info = _check_model_cache()
+    if cache_info["needs_download"]:
+        logger.info(f"首次启动需要下载模型 {cache_info['model_name']}（约 {cache_info['size_hint']}）")
+        timeout = FIRST_RUN_TIMEOUT
+
+    # 构建启动命令（Windows 使用 pythonw.exe 避免控制台窗口）
+    cmd = [
+        _get_pythonw_executable(),
+        "-m",
+        "jfox.daemon.server",
+        "--host",
+        host,
+        "--port",
+        str(port),
+    ]
+
+    kwargs = {}
+    if sys.platform == "win32":
+        # Windows: 后台分离进程，不弹窗
+        CREATE_NEW_PROCESS_GROUP = 0x00000200
+        DETACHED_PROCESS = 0x00000008
+        CREATE_NO_WINDOW = 0x08000000
+        kwargs["creationflags"] = CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS | CREATE_NO_WINDOW
+    else:
+        kwargs["start_new_session"] = True
+
+    # 子进程日志落盘（stdout/stderr → 日志文件）
+    log_file = open(DAEMON_LOG_FILE, "a", encoding="utf-8")
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=log_file,
+            stderr=log_file,
+            stdin=subprocess.DEVNULL,
+            **kwargs,
+        )
+        logger.info(f"Daemon 进程已启动 (PID: {proc.pid})")
+        logger.info(f"Daemon 日志文件: {DAEMON_LOG_FILE}")
+    except Exception as e:
+        log_file.close()
+        logger.error(f"启动 daemon 失败: {e}")
+        return False
+
+    # 等待 daemon 就绪（用 HTTP 健康检查判断，不用 PID）
+    try:
+        for i in range(timeout):
+            time.sleep(1)
+            health = _http_health_check(host, port)
+            if health is not None:
+                # 从 daemon 自身获取真实 PID
+                real_pid = health.get("pid", proc.pid)
+                _write_pid_file(
+                    {
+                        "pid": real_pid,
+                        "host": host,
+                        "port": port,
+                        "started_at": time.time(),
+                    }
+                )
+                logger.info(f"Daemon 已就绪 (PID: {real_pid}, port: {port})")
+                return True
+
+        logger.warning(f"Daemon 启动超时（{timeout}秒），日志见 {DAEMON_LOG_FILE}")
+        return False
+    finally:
+        log_file.close()
+```
+
+5. 在 `start_daemon()` 函数之前（第 106 行之前）添加预检函数：
+
+```python
+def _check_model_cache() -> dict:
+    """
+    检查当前模型是否已缓存
+
+    Returns:
+        dict: {"needs_download": bool, "model_name": str, "size_hint": str}
+    """
+    try:
+        from .config import config as _cfg
+        from .embedding_backend import _GPU_DEFAULT_MODEL, _CPU_DEFAULT_MODEL
+
+        # 确定目标模型名
+        device = _cfg.device
+        model_name = _cfg.embedding_model
+        if model_name == "auto" or not model_name:
+            # 简单检测：如果 torch 可用且有 CUDA，则用 GPU 模型
+            try:
+                import torch
+                if torch.cuda.is_available():
+                    model_name = _GPU_DEFAULT_MODEL
+                else:
+                    model_name = _CPU_DEFAULT_MODEL
+            except Exception:
+                model_name = _CPU_DEFAULT_MODEL
+
+        # 检查 HuggingFace 缓存
+        hf_home = os.environ.get("HF_HOME", str(Path.home() / ".cache" / "huggingface"))
+        hub_cache = os.environ.get("HUGGINGFACE_HUB_CACHE", str(Path(hf_home) / "hub"))
+        model_cache_dir = Path(hub_cache) / f"models--{model_name.replace('/', '--')}"
+
+        size_hint = "2GB" if "bge-m3" in model_name else "90MB"
+
+        if model_cache_dir.exists():
+            # 检查是否有实际权重文件（snapshots 目录不为空）
+            snapshots_dir = model_cache_dir / "snapshots"
+            has_files = (
+                snapshots_dir.exists()
+                and any(snapshots_dir.iterdir())
+            )
+            return {
+                "needs_download": not has_files,
+                "model_name": model_name,
+                "size_hint": size_hint,
+            }
+
+        return {
+            "needs_download": True,
+            "model_name": model_name,
+            "size_hint": size_hint,
+        }
+    except Exception:
+        # 预检失败不应阻止启动
+        return {"needs_download": False, "model_name": "unknown", "size_hint": ""}
+```
+
+- [ ] **Step 4: 更新 __init__.py 导出**
+
+在 `jfox/daemon/__init__.py` 中追加导出：
+
+```python
+from .process import DAEMON_LOG_FILE
+```
+
+并在 `__all__` 列表中追加 `"DAEMON_LOG_FILE"`。
+
+- [ ] **Step 5: 运行测试确认通过**
+
+Run: `uv run pytest tests/unit/test_daemon_process.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add jfox/daemon/process.py jfox/daemon/__init__.py tests/unit/test_daemon_process.py
+git commit -m "fix(daemon): redirect subprocess logs to file, add model cache pre-check and dynamic timeout"
+```
+
+---
+
+### Task 5: CLI daemon start 输出增加日志文件提示
+
+**Files:**
+- Modify: `jfox/cli.py:2614-2634`
+
+- [ ] **Step 1: 修改 CLI 输出**
+
+在 `jfox/cli.py` 的 `daemon start` 分支（第 2615 行附近），将：
+
+```python
+            console.print("[yellow]正在启动 embedding daemon...[/yellow]")
+```
+
+改为：
+
+```python
+            from .daemon.process import DAEMON_LOG_FILE
+            console.print("[yellow]正在启动 embedding daemon...[/yellow]")
+            console.print(f"[dim]日志文件: {DAEMON_LOG_FILE}[/dim]")
+```
+
+在第 2632 行（启动失败时），将：
+
+```python
+                console.print("[red]✗ Daemon 启动失败[/red]")
+```
+
+改为：
+
+```python
+                console.print(f"[red]✗ Daemon 启动失败[/red]")
+                console.print(f"[dim]查看日志: {DAEMON_LOG_FILE}[/dim]")
+```
+
+- [ ] **Step 2: 运行快速测试确认无语法错误**
+
+Run: `uv run python -c "from jfox.cli import app; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add jfox/cli.py
+git commit -m "feat(cli): show daemon log file path in start/failure output"
+```
+
+---
+
+## Self-Review
+
+### 1. Spec Coverage
+
+| Issue 要求 | 任务 |
+|------------|------|
+| 子进程日志落盘 | Task 4（stdout/stderr → DAEMON_LOG_FILE） |
+| 首次启动预检 + 提示 | Task 4（`_check_model_cache()` + 日志提示） |
+| 动态超时 | Task 4（`FIRST_RUN_TIMEOUT = 300`） |
+| reset_collection() | Task 1（新增方法） |
+| index_all 用 reset 替代 clear | Task 2 |
+| 维度不匹配友好提示 | Task 3 |
+| CLI 显示日志路径 | Task 5 |
+
+### 2. Placeholder Scan
+
+No TBD/TODO/fill-in-later found. All steps contain actual code.
+
+### 3. Type Consistency
+
+- `reset_collection()` 返回 `bool`，与 `clear()` 签名一致 ✓
+- `DAEMON_LOG_FILE` 是 `Path` 对象，与 `PID_FILE` 风格一致 ✓
+- `_check_model_cache()` 返回 `dict`，在 `start_daemon()` 内部使用 ✓
+- `log_file` 用 `open()` 打开，传给 `subprocess.Popen` 的 stdout/stderr ✓
+- Task 4 的测试 import `DAEMON_LOG_FILE` 与 `process.py` 中定义一致 ✓

--- a/docs/superpowers/plans/2026-04-22-release-skill.md
+++ b/docs/superpowers/plans/2026-04-22-release-skill.md
@@ -1,0 +1,746 @@
+# Release Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create a `/release` skill that automates jfox's version bump → CHANGELOG → commit → PR → GitHub Release workflow.
+
+**Architecture:** Skill file (`SKILL.md`) provides step-by-step instructions for Claude. A Python helper script (`release_helper.py`) handles deterministic work: semver calculation, file updates, CHANGELOG generation. Claude orchestrates git/GitHub operations and user confirmations.
+
+**Tech Stack:** Python 3.10+, standard library only (re, json, subprocess, pathlib). Uses `uv run` for execution context.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `.claude/skills/release/release_helper.py` | Create | Version calculation, file updates, CHANGELOG generation. Outputs JSON. |
+| `.claude/skills/release/SKILL.md` | Create | Skill instructions for Claude: pre-checks → run script → confirm → git → PR → Release. |
+| `tests/unit/test_release_helper.py` | Create | Unit tests for release_helper.py. |
+
+No existing files are modified.
+
+---
+
+### Task 1: release_helper.py — Version Calculation
+
+**Files:**
+- Create: `.claude/skills/release/release_helper.py`
+- Test: `tests/unit/test_release_helper.py`
+
+- [ ] **Step 1: Write failing tests for version calculation**
+
+Create `tests/unit/test_release_helper.py`:
+
+```python
+"""release_helper.py 单元测试"""
+import json
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# 被测模块路径
+HELPER = str(
+    Path(__file__).resolve().parents[2] / ".claude" / "skills" / "release" / "release_helper.py"
+)
+
+
+def _run_helper(*args, env=None):
+    """运行 release_helper.py 并返回 (stdout, stderr, returncode)"""
+    result = subprocess.run(
+        ["python", HELPER, *args],
+        capture_output=True,
+        text=True,
+        cwd=Path(__file__).resolve().parents[2],
+        env=env or os.environ.copy(),
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+def _parse_json(stdout: str) -> dict:
+    return json.loads(stdout.strip())
+
+
+# ── 版本号计算 ──
+
+
+class TestVersionParsing:
+    """测试从 pyproject.toml 读取当前版本"""
+
+    def test_read_current_version(self):
+        """能正确读取当前项目版本"""
+        stdout, _, rc = _run_helper("patch", "--dry-run")
+        assert rc == 0, f"stderr: {_.strip()}"
+        data = _parse_json(stdout)
+        assert "current_version" in data
+        # 验证是 semver 格式
+        parts = data["current_version"].split(".")
+        assert len(parts) == 3
+        assert all(p.isdigit() for p in parts)
+
+
+class TestVersionBump:
+    """测试 bump 类型版本号计算"""
+
+    def test_patch_bump(self):
+        stdout, _, rc = _run_helper("patch", "--dry-run")
+        assert rc == 0
+        data = _parse_json(stdout)
+        cur = [int(x) for x in data["current_version"].split(".")]
+        new = [int(x) for x in data["new_version"].split(".")]
+        assert new[0] == cur[0]
+        assert new[1] == cur[1]
+        assert new[2] == cur[1] + 1  # patch +1
+
+    def test_minor_bump(self):
+        stdout, _, rc = _run_helper("minor", "--dry-run")
+        assert rc == 0
+        data = _parse_json(stdout)
+        cur = [int(x) for x in data["current_version"].split(".")]
+        new = [int(x) for x in data["new_version"].split(".")]
+        assert new[0] == cur[0]
+        assert new[1] == cur[1] + 1
+        assert new[2] == 0
+
+    def test_major_bump(self):
+        stdout, _, rc = _run_helper("major", "--dry-run")
+        assert rc == 0
+        data = _parse_json(stdout)
+        cur = [int(x) for x in data["current_version"].split(".")]
+        new = [int(x) for x in data["new_version"].split(".")]
+        assert new[0] == cur[0] + 1
+        assert new[1] == 0
+        assert new[2] == 0
+
+    def test_explicit_version(self):
+        stdout, _, rc = _run_helper("99.99.99", "--dry-run")
+        assert rc == 0
+        data = _parse_json(stdout)
+        assert data["new_version"] == "99.99.99"
+
+
+class TestVersionValidation:
+    """测试版本号校验"""
+
+    def test_invalid_bump_type(self):
+        _, stderr, rc = _run_helper("foobar")
+        assert rc != 0
+        # 应该输出错误 JSON
+        data = _parse_json(_)
+        assert "error" in data
+
+    def test_same_version_rejected(self):
+        """指定当前版本应被拒绝"""
+        stdout, _, rc = _run_helper("patch", "--dry-run")
+        data = _parse_json(stdout)
+        current = data["current_version"]
+        _, stderr, rc2 = _run_helper(current)
+        assert rc2 != 0
+        data2 = _parse_json(_)
+        assert "error" in data2
+
+    def test_lower_version_rejected(self):
+        """指定比当前更低的版本应被拒绝"""
+        stdout, _, _ = _run_helper("patch", "--dry-run")
+        data = _parse_json(stdout)
+        cur_parts = [int(x) for x in data["current_version"].split(".")]
+        lower = f"{cur_parts[0]}.{cur_parts[1]}.{max(0, cur_parts[2] - 1)}"
+        _, stderr, rc = _run_helper(lower)
+        assert rc != 0
+        data2 = _parse_json(_)
+        assert "error" in data2
+
+    def test_invalid_semver_rejected(self):
+        """非 semver 格式应被拒绝"""
+        _, stderr, rc = _run_helper("1.2")
+        assert rc != 0
+        data = _parse_json(_)
+        assert "error" in data
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_release_helper.py -v`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement version calculation with `--dry-run` support**
+
+Create `.claude/skills/release/release_helper.py` with the following structure:
+
+```python
+#!/usr/bin/env python3
+"""
+jfox release 辅助脚本
+
+处理版本号计算、文件更新、CHANGELOG 生成。
+输出 JSON 供 Claude 解析。
+
+用法:
+    python release_helper.py patch          # bump patch
+    python release_helper.py minor          # bump minor
+    python release_helper.py major          # bump major
+    python release_helper.py 0.5.0          # 指定版本
+    python release_helper.py ... --dry-run  # 只计算不修改文件
+"""
+import json
+import re
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+# 项目根目录（脚本位于 .claude/skills/release/，向上 3 级）
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+PYPROJECT_TOML = PROJECT_ROOT / "pyproject.toml"
+INIT_PY = PROJECT_ROOT / "jfox" / "__init__.py"
+CHANGELOG_MD = PROJECT_ROOT / "CHANGELOG.md"
+
+
+def output_json(data: dict):
+    """输出 JSON 到 stdout"""
+    print(json.dumps(data, ensure_ascii=False))
+
+
+def output_error(msg: str):
+    """输出错误 JSON 并退出"""
+    output_json({"error": msg})
+    sys.exit(1)
+
+
+def read_current_version() -> str:
+    """从 pyproject.toml 读取当前版本号"""
+    content = PYPROJECT_TOML.read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"(\d+\.\d+\.\d+)"', content, re.MULTILINE)
+    if not match:
+        output_error(f"未在 {PYPROJECT_TOML} 中找到 version 字段")
+    return match.group(1)
+
+
+def parse_bump(arg: str, current: str) -> str:
+    """解析版本参数，返回新版本号"""
+    # 尝试作为 bump 类型
+    if arg in ("patch", "minor", "major"):
+        parts = [int(x) for x in current.split(".")]
+        if arg == "patch":
+            parts[2] += 1
+        elif arg == "minor":
+            parts[1] += 1
+            parts[2] = 0
+        elif arg == "major":
+            parts[0] += 1
+            parts[1] = 0
+            parts[2] = 0
+        return f"{parts[0]}.{parts[1]}.{parts[2]}"
+
+    # 尝试作为 semver
+    if not re.match(r"^\d+\.\d+\.\d+$", arg):
+        output_error(f"无效的版本号或 bump 类型: {arg}（期望 patch/minor/major 或 X.Y.Z）")
+
+    # 确保新版本 > 当前版本
+    new_parts = [int(x) for x in arg.split(".")]
+    cur_parts = [int(x) for x in current.split(".")]
+    if new_parts <= cur_parts:
+        output_error(f"新版本 {arg} 不大于当前版本 {current}")
+
+    return arg
+
+
+def update_files(new_version: str, current_version: str):
+    """更新 pyproject.toml、__init__.py、uv.lock"""
+    # pyproject.toml
+    content = PYPROJECT_TOML.read_text(encoding="utf-8")
+    content = re.sub(
+        r'^version\s*=\s"\d+\.\d+\.\d+"',
+        f'version = "{new_version}"',
+        content,
+        flags=re.MULTILINE,
+    )
+    PYPROJECT_TOML.write_text(content, encoding="utf-8")
+
+    # __init__.py
+    content = INIT_PY.read_text(encoding="utf-8")
+    content = re.sub(
+        r'__version__\s*=\s*"\d+\.\d+\.\d+"',
+        f'__version__ = "{new_version}"',
+        content,
+    )
+    INIT_PY.write_text(content, encoding="utf-8")
+
+    # uv.lock
+    result = subprocess.run(
+        ["uv", "lock"],
+        cwd=str(PROJECT_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        output_error(f"uv lock 失败: {result.stderr}")
+
+
+def get_last_tag() -> str:
+    """获取最新的 git tag"""
+    result = subprocess.run(
+        ["git", "describe", "--tags", "--abbrev=0"],
+        cwd=str(PROJECT_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return ""  # 没有 tag
+    return result.stdout.strip()
+
+
+def parse_commits(last_tag: str) -> list[dict]:
+    """解析 last_tag..HEAD 之间的 commit，返回分类后的条目列表"""
+    if last_tag:
+        range_spec = f"{last_tag}..HEAD"
+    else:
+        range_spec = "HEAD"
+
+    result = subprocess.run(
+        ["git", "log", range_spec, "--oneline", "--format=%s"],
+        cwd=str(PROJECT_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return []
+
+    entries = []
+    seen = set()  # 去重（merge commit 和 squash 可能重复）
+
+    for line in result.stdout.strip().split("\n"):
+        if not line.strip():
+            continue
+
+        # 跳过 bump version 的 commit
+        if "bump version" in line.lower():
+            continue
+
+        # 跳过纯 merge commit
+        if line.startswith("Merge ") and not any(
+            x in line for x in ["feat", "fix", "refactor", "docs", "chore", "perf"]
+        ):
+            continue
+
+        # 解析 conventional commit: type(scope): message (#PR)
+        # 也支持 type: message (#PR) 无 scope 的情况
+        match = re.match(
+            r"^(feat|fix|refactor|docs|chore|perf)(?:\(([^)]+)\))?:\s*(.+?)(?:\s*\(#(\d+)\))?$",
+            line,
+        )
+        if match:
+            entry = {
+                "type": match.group(1),
+                "scope": match.group(2) or "",
+                "message": match.group(3).strip(),
+                "pr": int(match.group(4)) if match.group(4) else None,
+            }
+        else:
+            # 非 conventional commit 格式，作为 change 处理
+            # 尝试提取 PR 号
+            pr_match = re.search(r"\(#(\d+)\)", line)
+            entry = {
+                "type": "other",
+                "scope": "",
+                "message": line.strip(),
+                "pr": int(pr_match.group(1)) if pr_match else None,
+            }
+
+        # 去重 key
+        key = (entry["type"], entry["scope"], entry["message"])
+        if key not in seen:
+            seen.add(key)
+            entries.append(entry)
+
+    return entries
+
+
+def generate_changelog(new_version: str, current_version: str, entries: list[dict]) -> str:
+    """生成 CHANGELOG Markdown 内容"""
+    today = date.today().isoformat()
+    last_tag = get_last_tag()
+
+    # 按 type 分类
+    features = [e for e in entries if e["type"] == "feat"]
+    fixes = [e for e in entries if e["type"] == "fix"]
+    changes = [e for e in entries if e["type"] not in ("feat", "fix")]
+
+    lines = [f"## [{new_version}] - {today}", ""]
+
+    def format_entry(e: dict) -> str:
+        scope = f"**{e['scope']}**: " if e["scope"] else ""
+        pr = f" (#{e['pr']})" if e["pr"] else ""
+        return f"- {scope}{e['message']}{pr}"
+
+    if features:
+        lines.append("### Features")
+        lines.extend(format_entry(e) for e in features)
+        lines.append("")
+
+    if fixes:
+        lines.append("### Fixes")
+        lines.extend(format_entry(e) for e in fixes)
+        lines.append("")
+
+    if changes:
+        lines.append("### Changes")
+        lines.extend(format_entry(e) for e in changes)
+        lines.append("")
+
+    # 底部比较链接
+    tag_prev = last_tag.lstrip("v") if last_tag else current_version
+    lines.append(
+        f"[{new_version}]: https://github.com/zhuxixi/jfox/compare/"
+        f"v{tag_prev}...v{new_version}"
+    )
+
+    return "\n".join(lines)
+
+
+def update_changelog_file(new_changelog: str):
+    """将新条目插入 CHANGELOG.md 头部"""
+    if not CHANGELOG_MD.exists():
+        content = "# Changelog\n\n"
+    else:
+        content = CHANGELOG_MD.read_text(encoding="utf-8")
+
+    # 在第一个 ## 之前插入（跳过文件头注释）
+    # 找到第一个 ## [version] 行
+    insert_pos = content.find("\n## ")
+    if insert_pos == -1:
+        # 没有现有条目，追加到末尾
+        content = content.rstrip("\n") + "\n\n" + new_changelog + "\n"
+    else:
+        content = content[: insert_pos + 1] + new_changelog + "\n\n" + content[insert_pos + 1 :]
+
+    CHANGELOG_MD.write_text(content, encoding="utf-8")
+
+
+def summarize_entries(entries: list[dict]) -> str:
+    """生成条目摘要"""
+    counts = {}
+    for e in entries:
+        t = e["type"]
+        if t == "feat":
+            counts["feature"] = counts.get("feature", 0) + 1
+        elif t == "fix":
+            counts["fix"] = counts.get("fix", 0) + 1
+        else:
+            counts["change"] = counts.get("change", 0) + 1
+
+    parts = []
+    for label in ("feature", "fix", "change"):
+        if label in counts:
+            parts.append(f"{counts[label]} {label}{'s' if counts[label] > 1 else ''}")
+    return ", ".join(parts) if parts else "0 changes"
+
+
+def main():
+    if len(sys.argv) < 2:
+        output_error("用法: release_helper.py <version|patch|minor|major> [--dry-run]")
+
+    version_arg = sys.argv[1]
+    dry_run = "--dry-run" in sys.argv
+
+    # 1. 读取当前版本
+    current_version = read_current_version()
+
+    # 2. 计算新版本
+    new_version = parse_bump(version_arg, current_version)
+
+    # 3. 解析 commits
+    last_tag = get_last_tag()
+    entries = parse_commits(last_tag)
+
+    # 4. 生成 CHANGELOG
+    changelog = generate_changelog(new_version, current_version, entries)
+
+    if dry_run:
+        # 只输出计算结果，不修改文件
+        output_json({
+            "current_version": current_version,
+            "new_version": new_version,
+            "last_tag": last_tag,
+            "changelog_preview": changelog,
+            "changelog_entries": entries,
+            "changelog_summary": summarize_entries(entries),
+            "files_modified": ["pyproject.toml", "jfox/__init__.py", "uv.lock", "CHANGELOG.md"],
+        })
+        return
+
+    # 5. 更新文件
+    update_files(new_version, current_version)
+
+    # 6. 更新 CHANGELOG
+    update_changelog_file(changelog)
+
+    # 7. 输出结果
+    output_json({
+        "current_version": current_version,
+        "new_version": new_version,
+        "last_tag": last_tag,
+        "changelog_preview": changelog,
+        "changelog_entries": entries,
+        "changelog_summary": summarize_entries(entries),
+        "files_modified": ["pyproject.toml", "jfox/__init__.py", "uv.lock", "CHANGELOG.md"],
+    })
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_release_helper.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude/skills/release/release_helper.py tests/unit/test_release_helper.py
+git commit -m "feat(skills): add release helper script with version bump and CHANGELOG generation"
+```
+
+---
+
+### Task 2: SKILL.md — Release Skill 指令文件
+
+**Files:**
+- Create: `.claude/skills/release/SKILL.md`
+
+- [ ] **Step 1: Create SKILL.md**
+
+Create `.claude/skills/release/SKILL.md`:
+
+```markdown
+---
+name: release
+description: Release a new version of jfox. Bumps version, generates CHANGELOG, creates PR and GitHub Release. Triggers on "发版", "release", "bump version", "发布版本".
+---
+
+# Release Skill
+
+将 jfox 发版流程从多步手动操作简化为一条命令。覆盖版本号 bump → CHANGELOG → commit → PR → GitHub Release 全流程。
+
+## 用法
+
+```
+/release 0.5.0          # 指定具体版本号
+/release patch          # bump patch: 0.4.1 → 0.4.2
+/release minor          # bump minor: 0.4.1 → 0.5.0
+/release major          # bump major: 0.4.1 → 1.0.0
+```
+
+## 执行流程
+
+严格按照以下步骤执行。每一步必须完成后再进入下一步。
+
+### Step 1: 前置校验
+
+运行以下检查，任何一项失败则立即停止并告知用户原因：
+
+```bash
+# 1. 当前分支必须是 main
+git branch --show-current
+# 期望输出: main
+
+# 2. 工作区必须干净
+git status --porcelain
+# 期望输出: 空
+
+# 3. 不存在未合并的 bump 分支
+git branch --list 'chore/bump-*'
+# 期望输出: 空
+
+# 4. 没有未合并的 bump PR
+gh pr list --state open --head "chore/bump-*"
+# 期望输出: 空
+```
+
+### Step 2: 运行辅助脚本（预览模式）
+
+用 `--dry-run` 先预览计算结果：
+
+```bash
+uv run python .claude/skills/release/release_helper.py <version> --dry-run
+```
+
+解析 JSON 输出，提取 `current_version`、`new_version`、`changelog_preview`、`changelog_summary`。
+
+### Step 3: 展示变更摘要并等待确认
+
+向用户展示：
+
+```
+📦 Release 预览:
+  当前版本: {current_version}
+  新版本号: {new_version}
+  变更摘要: {changelog_summary}
+
+CHANGELOG 预览:
+{changelog_preview}
+
+将修改的文件:
+  - pyproject.toml
+  - jfox/__init__.py
+  - uv.lock
+  - CHANGELOG.md
+```
+
+**必须等待用户明确确认后才继续。** 如果用户拒绝或要求修改，停止流程。
+
+### Step 4: 运行辅助脚本（正式模式）
+
+```bash
+uv run python .claude/skills/release/release_helper.py <version>
+```
+
+确认脚本退出码为 0。如果非 0，读取错误信息并告知用户，停止流程。
+
+### Step 5: Git 操作
+
+```bash
+# 创建分支
+git checkout -b chore/bump-version-{new_version}
+
+# 暂存文件
+git add pyproject.toml jfox/__init__.py uv.lock CHANGELOG.md
+
+# 提交
+git commit -m "chore: bump version to {new_version}"
+
+# 推送
+git push -u origin chore/bump-version-{new_version}
+```
+
+### Step 6: 创建 PR
+
+使用 CHANGELOG 内容作为 PR body：
+
+```bash
+gh pr create \
+  --title "chore: bump version to {new_version}" \
+  --body "$(cat <<'EOF'
+## Summary
+Bump version from {current_version} to {new_version}
+
+{changelog_preview}
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+记录返回的 PR URL。
+
+### Step 7: 等待合并
+
+告知用户：
+
+```
+PR 已创建: {PR_URL}
+请合并此 PR 后告知我，我将继续创建 GitHub Release。
+```
+
+等待用户确认 PR 已合并。
+
+### Step 8: 切回 main 并拉取最新代码
+
+```bash
+git checkout main
+git pull origin main
+```
+
+### Step 9: 创建 GitHub Release
+
+```bash
+gh release create v{new_version} \
+  --title "v{new_version}" \
+  --notes "$(cat <<'EOF'
+{changelog_preview}
+EOF
+)"
+```
+
+告知用户：
+
+```
+Release v{new_version} 已创建！
+GitHub Actions 将自动发布到 PyPI。
+可在 https://github.com/zhuxixi/jfox/actions 监控发布状态。
+```
+
+## 错误处理
+
+- 脚本返回非零退出码 → 读取 stderr 中的错误 JSON，展示给用户，停止流程
+- git 操作失败 → 展示错误信息，建议用户手动修复
+- PR 创建失败 → 检查是否已有同名 PR，或提示权限问题
+- Release 创建失败 → 检查 tag 是否已存在，或提示权限问题
+
+## 注意事项
+
+- **不使用 `--no-verify`**，保持 pre-commit hook 正常运行
+- **始终在新分支操作**，不直接修改 main
+- **每个确认点都必须等待**，不自动跳过
+```
+
+- [ ] **Step 2: Test the skill invocation**
+
+手动验证 skill 文件格式正确：
+```bash
+# 确认 SKILL.md 有正确的 frontmatter
+head -5 .claude/skills/release/SKILL.md
+```
+
+期望看到：
+```
+---
+name: release
+description: Release a new version...
+---
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/release/SKILL.md
+git commit -m "feat(skills): add release skill with full workflow instructions"
+```
+
+---
+
+### Task 3: End-to-end Verification
+
+- [ ] **Step 1: Verify helper script dry-run works**
+
+```bash
+uv run python .claude/skills/release/release_helper.py patch --dry-run
+```
+
+期望：输出合法 JSON，包含 `current_version`、`new_version`、`changelog_preview` 等字段。
+
+- [ ] **Step 2: Verify helper script error handling**
+
+```bash
+# 无效 bump 类型
+uv run python .claude/skills/release/release_helper.py foobar
+# 期望: 非零退出码 + error JSON
+
+# 无效版本号
+uv run python .claude/skills/release/release_helper.py 1.2
+# 期望: 非零退出码 + error JSON
+```
+
+- [ ] **Step 3: Run all release helper tests**
+
+```bash
+uv run pytest tests/unit/test_release_helper.py -v
+```
+
+期望：所有测试通过。

--- a/docs/superpowers/plans/2026-04-26-fix-daemon-deprecation-warnings.md
+++ b/docs/superpowers/plans/2026-04-26-fix-daemon-deprecation-warnings.md
@@ -1,0 +1,185 @@
+# Fix Daemon Deprecation Warnings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate two deprecation warnings from daemon startup log (`~/.jfox_daemon.log`)
+
+**Architecture:** Three files, four surgical replacements — FastAPI lifespan migration + sentence-transformers API rename + dimension property unification
+
+**Tech Stack:** Python, FastAPI, sentence-transformers
+
+**Spec:** `docs/superpowers/specs/2026-04-26-fix-daemon-deprecation-warnings-design.md`
+
+---
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `jfox/daemon/server.py` | Replace `@app.on_event("startup")` with `lifespan` context manager |
+| `jfox/embedding_backend.py` | Rename `get_sentence_embedding_dimension()` → `get_embedding_dimension()` (2 places) |
+| `jfox/performance.py` | Replace `backend.model.get_sentence_embedding_dimension()` → `backend.dimension` |
+
+No new files created. No test changes needed — these are pure renames/migrations with identical behavior.
+
+---
+
+### Task 1: Migrate FastAPI `on_event` to `lifespan`
+
+**Files:**
+- Modify: `jfox/daemon/server.py`
+
+- [ ] **Step 1: Add import and replace `on_event` with `lifespan`**
+
+Replace the top of `server.py` (lines 8-18) to add `asynccontextmanager` import:
+
+```python
+import argparse
+import logging
+import os
+from contextlib import asynccontextmanager
+from typing import List
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+# 全局 embedding 后端（模型加载后常驻内存）
+_backend = None
+
+
+def _load_model():
+    """启动时加载模型（标记为 daemon 进程，防止自引用）"""
+    global _backend
+    os.environ["JFOX_DAEMON_PROCESS"] = "1"
+    from ..config import config
+    from ..embedding_backend import EmbeddingBackend
+
+    model_name = config.embedding_model if config.embedding_model != "auto" else None
+    _backend = EmbeddingBackend(device=config.device, model_name=model_name)
+    try:
+        _backend.load()
+        logger.info(
+            f"Daemon: 模型已加载 {_backend.model_name} "
+            f"(device={_backend._resolved_device}, dimension={_backend._resolved_dim})"
+        )
+    except Exception as e:
+        logger.error(f"Daemon: 模型加载失败，进程退出: {e}")
+        os._exit(1)
+
+
+@asynccontextmanager
+async def lifespan(app):
+    _load_model()
+    yield
+
+
+app = FastAPI(title="JFox Embedding Daemon", lifespan=lifespan)
+```
+
+This replaces lines 8-18 (imports + global + old `@app.on_event` decorated `_load_model` + old `app = FastAPI(...)`).
+
+- [ ] **Step 2: Verify daemon starts without DeprecationWarning**
+
+Run: `uv run python -c "from jfox.daemon.server import app; print('OK')"`
+
+Expected: `OK` with no `DeprecationWarning` about `on_event`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add jfox/daemon/server.py
+git commit -m "fix(daemon): migrate FastAPI on_event to lifespan pattern
+
+Removes DeprecationWarning from daemon log. Refs #164."
+```
+
+---
+
+### Task 2: Rename `get_sentence_embedding_dimension` in `embedding_backend.py`
+
+**Files:**
+- Modify: `jfox/embedding_backend.py:98`
+- Modify: `jfox/embedding_backend.py:138`
+
+- [ ] **Step 1: Replace two occurrences**
+
+Line 98, in `load()` method:
+```python
+# Before:
+self._resolved_dim = self.model.get_sentence_embedding_dimension()
+# After:
+self._resolved_dim = self.model.get_embedding_dimension()
+```
+
+Line 138, in `dimension` property:
+```python
+# Before:
+return self.model.get_sentence_embedding_dimension()
+# After:
+return self.model.get_embedding_dimension()
+```
+
+- [ ] **Step 2: Verify import works without FutureWarning**
+
+Run: `uv run python -c "from jfox.embedding_backend import EmbeddingBackend; print('OK')"`
+
+Expected: `OK` with no `FutureWarning`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add jfox/embedding_backend.py
+git commit -m "fix(embedding): rename get_sentence_embedding_dimension to get_embedding_dimension
+
+Removes FutureWarning from sentence-transformers. Refs #164."
+```
+
+---
+
+### Task 3: Use `backend.dimension` in `performance.py` fallback
+
+**Files:**
+- Modify: `jfox/performance.py:144`
+
+- [ ] **Step 1: Replace direct model access with dimension property**
+
+Line 144:
+```python
+# Before:
+dim = backend.model.get_sentence_embedding_dimension()
+# After:
+dim = backend.dimension
+```
+
+- [ ] **Step 2: Verify module imports cleanly**
+
+Run: `uv run python -c "from jfox.performance import BatchEmbeddingProcessor; print('OK')"`
+
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add jfox/performance.py
+git commit -m "fix(perf): use backend.dimension instead of direct model access
+
+Unifies dimension access and fixes FutureWarning. Refs #164."
+```
+
+---
+
+### Task 4: Final verification
+
+- [ ] **Step 1: Run fast tests**
+
+Run: `uv run pytest tests/unit/test_daemon_process.py -v`
+
+Expected: All pass.
+
+- [ ] **Step 2: Grep for any remaining deprecated calls**
+
+Run: `grep -rn "get_sentence_embedding_dimension\|on_event.*startup" jfox/ --include="*.py"`
+
+Expected: No matches.

--- a/docs/superpowers/plans/2026-04-27-intranet-model-download.md
+++ b/docs/superpowers/plans/2026-04-27-intranet-model-download.md
@@ -1,0 +1,828 @@
+# 内网模型自动下载 (#172) 实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 实现全自动模型下载降级链，让内网用户也能无感知的首次启动 jfox daemon。
+
+**架构:** 新增 `ModelDownloader` 类，封装 3 步重试链。`daemon start` 启动前自动调用。新增 `jfox model download` CLI 命令。
+
+**Tech Stack:** Python, huggingface_hub, typer, rich, pytest, curl (系统命令)
+
+---
+
+## 文件清单
+
+| 文件 | 类型 | 职责 |
+|------|------|------|
+| `jfox/model_downloader.py` | 新建 | `ModelDownloader` 类，3 步重试链 |
+| `jfox/cli.py` | 修改 | 新增 `model download` 子命令 |
+| `jfox/daemon/process.py` | 修改 | `start_daemon()` 启动前调用下载检查 |
+| `scripts/download-model-intranet.sh` | 新建 | 降级兜底脚本（curl 参考实现） |
+| `tests/unit/test_model_downloader.py` | 新建 | 单元测试 |
+| `tests/integration/test_model_download.py` | 新建 | 集成测试 |
+
+---
+
+### Task 1: ModelDownloader 核心类
+
+**Files:**
+- Create: `jfox/model_downloader.py`
+
+- [ ] **Step 1: 编写模型下载器核心类**
+
+```python
+"""模型下载器 - 支持内网自动降级下载"""
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# 镜像站地址
+_HF_MIRROR = "https://hf-mirror.com"
+
+# 重试超时（秒）
+_TIMEOUT_HF_HUB = 60
+_TIMEOUT_CURL = 120
+
+# 需要下载的文件列表（按重要性排序）
+_REQUIRED_FILES = [
+    "model.safetensors",
+    "config.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "sentence_bert_config.json",
+]
+
+
+class ModelDownloader:
+    """模型下载器，支持全自动降级重试链"""
+
+    def __init__(self, model_name: str):
+        self.model_name = model_name
+        self._hf_hub_cache = self._get_hf_hub_cache()
+        self._model_cache = self._hf_hub_cache / f"models--{model_name.replace('/', '--')}"
+
+    def _get_hf_hub_cache(self) -> Path:
+        """获取 HuggingFace Hub 缓存目录"""
+        try:
+            import huggingface_hub.constants
+
+            return Path(huggingface_hub.constants.HUGGINGFACE_HUB_CACHE)
+        except Exception:
+            hf_home = os.environ.get("HF_HOME", str(Path.home() / ".cache" / "huggingface"))
+            return Path(hf_home) / "hub"
+
+    def ensure_cached(self) -> bool:
+        """
+        确保模型已缓存。按重试链逐层降级。
+        返回 True 表示成功（无论哪一步成功）。
+        """
+        if self._check_cached():
+            logger.info(f"模型已缓存: {self.model_name}")
+            return True
+
+        logger.info(f"缓存未命中: {self.model_name}，开始下载")
+
+        # Step 1: 正常下载
+        logger.info("步骤 1: 使用 huggingface_hub 正常下载...")
+        if self._try_hf_hub_download():
+            logger.info("步骤 1 成功，模型已缓存")
+            return True
+        logger.warning("步骤 1 失败，进入步骤 2")
+
+        # Step 2: 镜像站下载
+        logger.info(f"步骤 2: 切换 HF_ENDPOINT={_HF_MIRROR} 重试...")
+        if self._try_hf_hub_download(endpoint=_HF_MIRROR):
+            logger.info("步骤 2 成功，模型已缓存")
+            return True
+        logger.warning("步骤 2 失败，进入步骤 3")
+
+        # Step 3: curl 子进程下载
+        logger.info("步骤 3: 使用 curl 子进程从镜像站下载...")
+        if self._try_curl_download():
+            logger.info("步骤 3 成功，模型已缓存")
+            return True
+        logger.error("步骤 3 失败，所有自动方式均已尝试")
+
+        return False
+
+    def _check_cached(self) -> bool:
+        """检查模型是否已在 HuggingFace 缓存目录中存在"""
+        if not self._model_cache.exists():
+            return False
+        snapshots_dir = self._model_cache / "snapshots"
+        if not snapshots_dir.exists():
+            return False
+        # 检查至少有一个 snapshot 且包含 model.safetensors
+        for snapshot in snapshots_dir.iterdir():
+            if snapshot.is_dir():
+                if (snapshot / "model.safetensors").exists():
+                    return True
+        return False
+
+    def _try_hf_hub_download(self, endpoint: Optional[str] = None) -> bool:
+        """
+        使用 huggingface_hub 下载模型。
+        endpoint=None 为正常模式；endpoint 为镜像站地址。
+        """
+        env_backup = None
+        try:
+            from huggingface_hub import hf_hub_download
+
+            if endpoint:
+                env_backup = os.environ.get("HF_ENDPOINT")
+                os.environ["HF_ENDPOINT"] = endpoint
+
+            # 下载核心文件（只下载 model.safetensors 即可让 sentence-transformers 识别）
+            hf_hub_download(
+                repo_id=self.model_name,
+                filename="model.safetensors",
+                cache_dir=str(self._hf_hub_cache),
+                local_files_only=False,
+            )
+            # 尝试下载其他必要文件（不失败）
+            for fname in _REQUIRED_FILES[1:]:
+                try:
+                    hf_hub_download(
+                        repo_id=self.model_name,
+                        filename=fname,
+                        cache_dir=str(self._hf_hub_cache),
+                        local_files_only=False,
+                    )
+                except Exception:
+                    pass  # 非核心文件，缺失不影响基本功能
+
+            return True
+        except Exception as e:
+            logger.warning(f"huggingface_hub 下载失败: {e}")
+            return False
+        finally:
+            if env_backup is not None:
+                os.environ["HF_ENDPOINT"] = env_backup
+            elif endpoint and "HF_ENDPOINT" in os.environ:
+                del os.environ["HF_ENDPOINT"]
+
+    def _try_curl_download(self) -> bool:
+        """
+        使用 curl 子进程下载模型文件到 HF 缓存目录。
+        按 HF 缓存目录结构放置，使 sentence-transformers 认为"模型已缓存"。
+        """
+        if not shutil.which("curl"):
+            logger.warning("系统未安装 curl，跳过步骤 3")
+            return False
+
+        # 构建镜像站 URL
+        base_url = f"{_HF_MIRROR}/{self.model_name}/resolve/main"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            downloaded = []
+
+            for fname in _REQUIRED_FILES:
+                url = f"{base_url}/{fname}"
+                dest = tmp_path / fname
+                logger.info(f"下载 {fname}...")
+                try:
+                    result = subprocess.run(
+                        [
+                            "curl", "-L", "-f", "-s", "-S",
+                            "--connect-timeout", "10",
+                            "--max-time", str(_TIMEOUT_CURL),
+                            "-o", str(dest),
+                            url,
+                        ],
+                        capture_output=True,
+                        text=True,
+                        timeout=_TIMEOUT_CURL + 5,
+                    )
+                    if result.returncode == 0 and dest.exists() and dest.stat().st_size > 0:
+                        downloaded.append(fname)
+                    else:
+                        logger.debug(f"{fname} 下载失败或为空，跳过")
+                except Exception as e:
+                    logger.debug(f"{fname} 下载异常: {e}")
+
+            if "model.safetensors" not in downloaded:
+                logger.error("model.safetensors 下载失败，步骤 3 未完成")
+                return False
+
+            # 按 HF 缓存目录结构放置
+            # 格式: hub/models--org--model/snapshots/commit_hash/{files}
+            # 使用伪 commit hash（基于模型名哈希）
+            import hashlib
+
+            commit_hash = hashlib.sha256(self.model_name.encode()).hexdigest()[:12]
+            snapshot_dir = self._model_cache / "snapshots" / commit_hash
+            snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+            for fname in downloaded:
+                src = tmp_path / fname
+                dst = snapshot_dir / fname
+                shutil.copy2(str(src), str(dst))
+
+            # 创建 refs 指向 snapshot
+            refs_dir = self._model_cache / "refs"
+            refs_dir.mkdir(parents=True, exist_ok=True)
+            (refs_dir / "main").write_text(commit_hash, encoding="utf-8")
+
+            return True
+
+    def get_manual_instructions(self) -> str:
+        """获取手动下载说明"""
+        return (
+            f"自动下载失败。请手动下载模型:\n"
+            f"  1. 访问 {_HF_MIRROR}/{self.model_name}\n"
+            f"  2. 下载 model.safetensors 和 config.json\n"
+            f"  3. 放置到 {self._model_cache}/snapshots/\n"
+            f"  或运行: bash scripts/download-model-intranet.sh"
+        )
+```
+
+- [ ] **Step 2: 验证语法**
+
+Run: `python -m py_compile jfox/model_downloader.py`
+Expected: 无输出（通过）
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add jfox/model_downloader.py
+git commit -m "feat(model): add ModelDownloader with 3-step retry chain"
+```
+
+---
+
+### Task 2: CLI 新增 `model download` 命令
+
+**Files:**
+- Modify: `jfox/cli.py`
+- 在 `daemon` 命令附近添加
+
+- [ ] **Step 1: 在 cli.py 中导入并添加 model download 命令**
+
+在 `daemon` 命令之后（约 2663 行后）插入：
+
+```python
+@app.command()
+def model_download(
+    model: Optional[str] = typer.Option(
+        None, "--model", "-m",
+        help="模型名（默认从配置读取，auto 则按设备自动选择）"
+    ),
+    force: bool = typer.Option(
+        False, "--force", "-f",
+        help="强制重新下载（覆盖已有缓存）"
+    ),
+):
+    """
+    手动下载 embedding 模型
+
+    自动尝试 3 种下载方式（huggingface_hub → 镜像站 → curl）。
+    通常不需要手动调用，daemon start 会自动执行。
+
+    示例:
+
+        jfox model download                    # 下载默认模型
+        jfox model download --model bge-m3     # 下载指定模型
+        jfox model download --force            # 强制重新下载
+    """
+    from .model_downloader import ModelDownloader
+    from .embedding_backend import EmbeddingBackend
+
+    # 解析模型名
+    if model is None or model == "auto":
+        backend = EmbeddingBackend()
+        device = backend._resolve_device()
+        model = backend._resolve_model_name(device)
+
+    console.print(f"[yellow]准备下载模型: {model}[/yellow]")
+
+    downloader = ModelDownloader(model)
+
+    if force and downloader._check_cached():
+        console.print("[yellow]强制重新下载，清理旧缓存...[/yellow]")
+        import shutil
+        shutil.rmtree(downloader._model_cache, ignore_errors=True)
+
+    ok = downloader.ensure_cached()
+    if ok:
+        console.print(f"[green]✓ 模型下载完成: {model}[/green]")
+    else:
+        console.print(f"[red]✗ 模型下载失败[/red]")
+        console.print(Panel(downloader.get_manual_instructions(), title="手动下载"))
+        raise typer.Exit(1)
+```
+
+- [ ] **Step 2: 运行快速语法检查**
+
+Run: `python -m py_compile jfox/cli.py`
+Expected: 无输出（通过）
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add jfox/cli.py
+git commit -m "feat(cli): add model download command"
+```
+
+---
+
+### Task 3: daemon start 自动调用下载检查
+
+**Files:**
+- Modify: `jfox/daemon/process.py`
+
+- [ ] **Step 1: 在 start_daemon 中添加下载检查**
+
+修改 `start_daemon` 函数，在"首次启动预检"之后、构建启动命令之前插入下载逻辑：
+
+找到 `jfox/daemon/process.py` 中 `start_daemon` 函数（约 158 行），在 `cache_info = _check_model_cache()` 和 `if cache_info["needs_download"]:` 代码块之后，构建 `cmd` 列表之前插入：
+
+```python
+    # 首次启动预检：检查模型缓存是否存在
+    timeout = STARTUP_TIMEOUT
+    cache_info = _check_model_cache()
+    if cache_info["needs_download"]:
+        logger.info(
+            f"首次启动需要下载模型 {cache_info['model_name']}"
+            f"（约 {cache_info['size_hint']}）"
+        )
+        # 自动下载模型（内网降级重试）
+        try:
+            from ..model_downloader import ModelDownloader
+            downloader = ModelDownloader(cache_info["model_name"])
+            if not downloader.ensure_cached():
+                logger.error("模型自动下载失败")
+                # 不阻断启动，让 daemon 自己去尝试加载（会暴露更详细的错误日志）
+        except Exception as e:
+            logger.warning(f"模型下载检查异常: {e}")
+```
+
+**注意：** 这里选择**不阻断启动**。理由：
+1. 如果下载失败但用户已有其他方式放置了模型，daemon 加载可能仍成功
+2. 让 daemon 自己去加载可以暴露更底层的错误信息
+3. 避免下载逻辑 bug 导致 daemon 完全无法启动
+
+如果希望严格阻断（下载失败就不启动），改为：
+```python
+            if not downloader.ensure_cached():
+                logger.error("模型自动下载失败，daemon 未启动")
+                return False
+```
+
+- [ ] **Step 2: 运行快速语法检查**
+
+Run: `python -m py_compile jfox/daemon/process.py`
+Expected: 无输出（通过）
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add jfox/daemon/process.py
+git commit -m "feat(daemon): auto-download model before start with retry chain"
+```
+
+---
+
+### Task 4: 降级兜底脚本
+
+**Files:**
+- Create: `scripts/download-model-intranet.sh`
+
+- [ ] **Step 1: 创建 bash 脚本**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# JFox 内网模型下载脚本
+# 当 huggingface_hub 无法工作时，使用 curl 手动下载模型
+# =============================================================================
+
+MODEL_NAME="${1:-sentence-transformers/all-MiniLM-L6-v2}"
+HF_MIRROR="https://hf-mirror.com"
+
+# 获取 HF 缓存目录
+HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"
+HUB_CACHE="${HUGGINGFACE_HUB_CACHE:-$HF_HOME/hub}"
+MODEL_CACHE="$HUB_CACHE/models--${MODEL_NAME//\//--}"
+
+info()  { echo -e "\033[0;32m[INFO]\033[0m $*"; }
+warn()  { echo -e "\033[1;33m[WARN]\033[0m $*"; }
+error() { echo -e "\033[0;31m[ERROR]\033[0m $*" >&2; }
+
+# 检查 curl
+if ! command -v curl > /dev/null 2>&1; then
+    error "curl 未安装，请先安装 curl"
+    exit 1
+fi
+
+info "目标模型: $MODEL_NAME"
+info "缓存目录: $MODEL_CACHE"
+
+# 生成伪 commit hash
+COMMIT_HASH=$(echo -n "$MODEL_NAME" | sha256sum | cut -c1-12)
+SNAPSHOT_DIR="$MODEL_CACHE/snapshots/$COMMIT_HASH"
+
+mkdir -p "$SNAPSHOT_DIR"
+
+# 下载文件列表
+FILES=("model.safetensors" "config.json" "tokenizer.json" "tokenizer_config.json")
+
+for fname in "${FILES[@]}"; do
+    URL="$HF_MIRROR/$MODEL_NAME/resolve/main/$fname"
+    DEST="$SNAPSHOT_DIR/$fname"
+
+    if [ -f "$DEST" ] && [ -s "$DEST" ]; then
+        info "$fname 已存在，跳过"
+        continue
+    fi
+
+    info "下载 $fname..."
+    if curl -L -f -s -S --connect-timeout 10 --max-time 120 \
+         -o "$DEST" "$URL"; then
+        info "$fname 下载完成"
+    else
+        warn "$fname 下载失败或不存在，跳过"
+        rm -f "$DEST"
+    fi
+done
+
+# 检查核心文件
+if [ ! -f "$SNAPSHOT_DIR/model.safetensors" ]; then
+    error "model.safetensors 下载失败"
+    exit 1
+fi
+
+# 创建 refs
+mkdir -p "$MODEL_CACHE/refs"
+echo "$COMMIT_HASH" > "$MODEL_CACHE/refs/main"
+
+info "模型下载完成: $MODEL_CACHE"
+info "现在可以运行: jfox daemon start"
+```
+
+- [ ] **Step 2: 添加可执行权限**
+
+Run: `chmod +x scripts/download-model-intranet.sh`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/download-model-intranet.sh
+git commit -m "feat(scripts): add intranet model download fallback script"
+```
+
+---
+
+### Task 5: 单元测试
+
+**Files:**
+- Create: `tests/unit/test_model_downloader.py`
+
+- [ ] **Step 1: 编写单元测试**
+
+```python
+"""ModelDownloader 单元测试"""
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from jfox.model_downloader import ModelDownloader, _HF_MIRROR
+
+
+class TestModelDownloader:
+    """ModelDownloader 单元测试"""
+
+    @pytest.fixture
+    def downloader(self, tmp_path):
+        """创建带临时缓存的 downloader"""
+        with patch(
+            "jfox.model_downloader.ModelDownloader._get_hf_hub_cache",
+            return_value=tmp_path / "hub",
+        ):
+            d = ModelDownloader("sentence-transformers/all-MiniLM-L6-v2")
+            return d
+
+    def test_check_cached_when_not_exists(self, downloader):
+        """缓存不存在时返回 False"""
+        assert downloader._check_cached() is False
+
+    def test_check_cached_when_exists(self, downloader):
+        """缓存存在时返回 True"""
+        # 创建模拟缓存结构
+        snapshot = (
+            downloader._model_cache
+            / "snapshots"
+            / "abc123"
+        )
+        snapshot.mkdir(parents=True)
+        (snapshot / "model.safetensors").write_text("fake")
+        assert downloader._check_cached() is True
+
+    def test_check_cached_missing_model_file(self, downloader):
+        """有 snapshot 但缺少 model.safetensors 时返回 False"""
+        snapshot = downloader._model_cache / "snapshots" / "abc123"
+        snapshot.mkdir(parents=True)
+        (snapshot / "config.json").write_text("fake")
+        assert downloader._check_cached() is False
+
+    def test_ensure_cached_early_return_when_cached(self, downloader):
+        """已缓存时直接返回 True，不走重试链"""
+        snapshot = downloader._model_cache / "snapshots" / "abc123"
+        snapshot.mkdir(parents=True)
+        (snapshot / "model.safetensors").write_text("fake")
+
+        with patch.object(downloader, "_try_hf_hub_download") as mock_hf:
+            result = downloader.ensure_cached()
+            assert result is True
+            mock_hf.assert_not_called()
+
+    def test_ensure_cached_step1_succeeds(self, downloader):
+        """Step 1 成功，后续步骤不执行"""
+        with patch.object(
+            downloader, "_try_hf_hub_download", side_effect=[True, False]
+        ) as mock_hf:
+            with patch.object(downloader, "_try_curl_download") as mock_curl:
+                result = downloader.ensure_cached()
+                assert result is True
+                assert mock_hf.call_count == 1
+                mock_curl.assert_not_called()
+
+    def test_ensure_cached_step1_fails_step2_succeeds(self, downloader):
+        """Step 1 失败，Step 2 成功"""
+        with patch.object(
+            downloader, "_try_hf_hub_download", side_effect=[False, True]
+        ) as mock_hf:
+            with patch.object(downloader, "_try_curl_download") as mock_curl:
+                result = downloader.ensure_cached()
+                assert result is True
+                # 第一次调用 endpoint=None，第二次 endpoint=镜像站
+                assert mock_hf.call_count == 2
+                mock_curl.assert_not_called()
+
+    def test_ensure_cached_step1_2_fail_step3_succeeds(self, downloader):
+        """Step 1/2 失败，Step 3 成功"""
+        with patch.object(
+            downloader, "_try_hf_hub_download", return_value=False
+        ) as mock_hf:
+            with patch.object(
+                downloader, "_try_curl_download", return_value=True
+            ) as mock_curl:
+                result = downloader.ensure_cached()
+                assert result is True
+                assert mock_hf.call_count == 2
+                mock_curl.assert_called_once()
+
+    def test_ensure_cached_all_fail(self, downloader):
+        """全部失败，返回 False"""
+        with patch.object(
+            downloader, "_try_hf_hub_download", return_value=False
+        ):
+            with patch.object(
+                downloader, "_try_curl_download", return_value=False
+            ):
+                result = downloader.ensure_cached()
+                assert result is False
+
+    def test_try_hf_hub_download_sets_env(self, downloader):
+        """验证镜像模式设置了 HF_ENDPOINT 环境变量"""
+        env_before = os.environ.get("HF_ENDPOINT")
+
+        with patch("jfox.model_downloader.hf_hub_download") as mock_download:
+            mock_download.side_effect = Exception("network")
+            downloader._try_hf_hub_download(endpoint=_HF_MIRROR)
+
+        # 调用后环境变量应被恢复
+        assert os.environ.get("HF_ENDPOINT") == env_before
+
+    def test_try_curl_download_no_curl(self, downloader):
+        """curl 不存在时返回 False"""
+        with patch("jfox.model_downloader.shutil.which", return_value=None):
+            result = downloader._try_curl_download()
+            assert result is False
+
+    def test_cleanup_partial(self, downloader):
+        """验证部分下载残留被清理（通过 TemporaryDirectory 自动实现）"""
+        # TemporaryDirectory 在上下文退出时自动清理
+        # 这里验证 _try_curl_download 使用 tempfile
+        with patch("jfox.model_downloader.shutil.which", return_value="curl"):
+            with patch("jfox.model_downloader.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                # 模拟 model.safetensors 下载成功但文件为空（导致失败）
+                downloader._try_curl_download()
+                # 验证临时目录在使用后会被清理
+```
+
+- [ ] **Step 2: 运行单元测试**
+
+Run: `uv run pytest tests/unit/test_model_downloader.py -v`
+Expected: 全部通过
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/test_model_downloader.py
+git commit -m "test(model): add ModelDownloader unit tests"
+```
+
+---
+
+### Task 6: 集成测试
+
+**Files:**
+- Create: `tests/integration/test_model_download.py`
+
+- [ ] **Step 1: 编写集成测试**
+
+```python
+"""模型下载集成测试"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from jfox.model_downloader import ModelDownloader
+
+
+class TestModelDownloadRetryChain:
+    """mock 网络层，验证完整重试链按顺序执行"""
+
+    @pytest.fixture
+    def downloader(self, tmp_path):
+        with patch(
+            "jfox.model_downloader.ModelDownloader._get_hf_hub_cache",
+            return_value=tmp_path / "hub",
+        ):
+            return ModelDownloader("sentence-transformers/all-MiniLM-L6-v2")
+
+    def test_full_chain_step1_succeeds(self, downloader):
+        """Step 1 成功，后续步骤不执行"""
+        with patch.object(
+            downloader, "_try_hf_hub_download", side_effect=[True, False]
+        ) as mock_hf:
+            with patch.object(
+                downloader, "_try_curl_download"
+            ) as mock_curl:
+                result = downloader.ensure_cached()
+                assert result is True
+                assert mock_hf.call_count == 1
+                mock_curl.assert_not_called()
+
+    def test_full_chain_step1_fails_step2_succeeds(self, downloader):
+        """Step 1 失败，Step 2 成功"""
+        with patch.object(
+            downloader, "_try_hf_hub_download", side_effect=[False, True]
+        ) as mock_hf:
+            with patch.object(
+                downloader, "_try_curl_download"
+            ) as mock_curl:
+                result = downloader.ensure_cached()
+                assert result is True
+                # 验证调用了两次：第一次 endpoint=None，第二次 endpoint=镜像站
+                calls = mock_hf.call_args_list
+                assert len(calls) == 2
+                assert calls[0][1].get("endpoint") is None
+                assert calls[1][1].get("endpoint") is not None
+                mock_curl.assert_not_called()
+
+    def test_full_chain_step1_2_fail_step3_succeeds(self, downloader):
+        """Step 1/2 失败，Step 3 成功"""
+        with patch.object(
+            downloader, "_try_hf_hub_download", return_value=False
+        ):
+            with patch.object(
+                downloader, "_try_curl_download", return_value=True
+            ) as mock_curl:
+                result = downloader.ensure_cached()
+                assert result is True
+                mock_curl.assert_called_once()
+
+    def test_full_chain_all_fail(self, downloader):
+        """全部失败，返回 False"""
+        with patch.object(
+            downloader, "_try_hf_hub_download", return_value=False
+        ):
+            with patch.object(
+                downloader, "_try_curl_download", return_value=False
+            ):
+                result = downloader.ensure_cached()
+                assert result is False
+
+    def test_daemon_start_calls_downloader(self):
+        """验证 daemon start 启动前调用下载检查"""
+        from jfox.daemon.process import start_daemon
+
+        with patch("jfox.daemon.process._http_health_check", return_value=None):
+            with patch("jfox.daemon.process._check_model_cache") as mock_cache:
+                mock_cache.return_value = {
+                    "needs_download": True,
+                    "model_name": "test-model",
+                    "size_hint": "90MB",
+                }
+                with patch(
+                    "jfox.daemon.process.ModelDownloader"
+                ) as mock_cls:
+                    mock_downloader = MagicMock()
+                    mock_downloader.ensure_cached.return_value = True
+                    mock_cls.return_value = mock_downloader
+
+                    with patch("jfox.daemon.process.subprocess.Popen"):
+                        with patch(
+                            "jfox.daemon.process._http_health_check",
+                            side_effect=[None, {"pid": 123}],
+                        ):
+                            start_daemon()
+                            mock_cls.assert_called_once_with("test-model")
+                            mock_downloader.ensure_cached.assert_called_once()
+
+    def test_cli_model_download_command(self):
+        """验证 CLI model download 命令正确调用 downloader"""
+        from jfox.cli import app
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+
+        with patch(
+            "jfox.cli.ModelDownloader"
+        ) as mock_cls:
+            mock_downloader = MagicMock()
+            mock_downloader.ensure_cached.return_value = True
+            mock_downloader._check_cached.return_value = False
+            mock_cls.return_value = mock_downloader
+
+            result = runner.invoke(app, ["model", "download"])
+            assert result.exit_code == 0
+            mock_cls.assert_called_once()
+            mock_downloader.ensure_cached.assert_called_once()
+```
+
+- [ ] **Step 2: 运行集成测试**
+
+Run: `uv run pytest tests/integration/test_model_download.py -v`
+Expected: 全部通过
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_model_download.py
+git commit -m "test(model): add model download integration tests"
+```
+
+---
+
+## Self-Review
+
+### 1. Spec Coverage
+
+| Spec 要求 | 对应 Task |
+|---|---|
+| ModelDownloader 3 步重试链 | Task 1 |
+| 日志策略（INFO/WARN/ERROR） | Task 1 |
+| `jfox model download` CLI 命令 | Task 2 |
+| daemon start 自动调用 | Task 3 |
+| curl 子进程下载到 HF 缓存 | Task 1 |
+| 部分下载清理 | Task 1 (TemporaryDirectory) |
+| 超时策略 | Task 1 (_TIMEOUT_HF_HUB, _TIMEOUT_CURL) |
+| 降级兜底脚本 | Task 4 |
+| 单元测试 | Task 5 |
+| 集成测试 | Task 6 |
+
+**无遗漏。**
+
+### 2. Placeholder Scan
+
+- ✅ 无 "TBD" / "TODO"
+- ✅ 无 "implement later"
+- ✅ 无 "Add appropriate error handling"（每步有具体代码）
+- ✅ 无 "Similar to Task N"
+- ✅ 所有代码块包含完整代码
+
+### 3. Type Consistency
+
+- ✅ `ensure_cached()` 返回 `bool`，Task 1/2/3/5/6 一致
+- ✅ `ModelDownloader.__init__(model_name: str)`，所有调用一致
+- ✅ `_try_hf_hub_download(endpoint: Optional[str] = None)`，签名一致
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-27-intranet-model-download.md`.**
+
+Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-15-gpu-embedding-design.md
+++ b/docs/superpowers/specs/2026-04-15-gpu-embedding-design.md
@@ -1,0 +1,190 @@
+# GPU 加速 Embedding 设计
+
+> Issue: #155
+> 日期: 2026-04-15
+
+## 目标
+
+打通 `config.py` 中已有的 `device`/`embedding_model` 配置到 `EmbeddingBackend`，让 GPU（CUDA）自动生效，并支持更大的 embedding 模型。
+
+## 背景
+
+- `config.py` 已定义 `device`, `embedding_model`, `embedding_dimension` 字段，但 `EmbeddingBackend` 从未读取
+- `get_backend()` 硬编码 `EmbeddingBackend()` 不传任何配置
+- `dimension` 硬编码 384，换模型会崩溃
+- 用户硬件：RTX 4000 SFF Ada 20GB + 2x 2080 Ti 22G SLI
+
+## 硬件与模型选择
+
+| 场景 | 模型 | 维度 | VRAM | device |
+|------|------|------|------|--------|
+| GPU 可用（默认） | `BAAI/bge-m3` | 1024 | ~2.3GB | cuda |
+| GPU 不可用（后备） | `sentence-transformers/all-MiniLM-L6-v2` | 384 | ~0.3GB | cpu |
+
+向量数据库保持 ChromaDB 不变 — 个人知识库万级文档无需 GPU 向量检索。
+
+## 设计
+
+### 1. Device 检测与模型选择
+
+**自动检测逻辑**（`config.device = "auto"` 时）：
+
+1. 首次加载 embedding 模型时调用 `torch.cuda.is_available()`
+2. GPU 可用 → `device="cuda"`, 默认模型 `BAAI/bge-m3`
+3. GPU 不可用 → `device="cpu"`, 默认模型 `sentence-transformers/all-MiniLM-L6-v2`
+4. 用户手动指定 `device: "cpu"/"cuda"` 时跳过自动检测
+
+**模型选择优先级**：
+- `config.embedding_model` 设为具体值 → 使用该模型，不论 device
+- `config.embedding_model = "auto"` → 根据 device 自动选默认模型
+
+**日志示例**：
+```
+INFO  检测到 CUDA 可用 (NVIDIA RTX 4000 SFF Ada), 使用 GPU
+INFO  模型已加载: BAAI/bge-m3 (device=cuda, dimension=1024)
+```
+
+```
+INFO  CUDA 不可用, 使用 CPU
+INFO  模型已加载: sentence-transformers/all-MiniLM-L6-v2 (device=cpu, dimension=384)
+```
+
+### 2. EmbeddingBackend 改造
+
+**构造函数**：
+
+```python
+class EmbeddingBackend:
+    def __init__(self, model_name: str | None = None, device: str = "auto"):
+        self.model_name = model_name  # None/"auto" 表示由 device 自动决定
+        self.device = device
+        self.model = None
+        self._resolved_device: str | None = None
+        self._resolved_dim: int | None = None
+```
+
+**`load()` 流程**：
+
+1. 解析 device：`"auto"` → `torch.cuda.is_available()` → `"cuda"` 或 `"cpu"`
+2. 解析 model_name：`None`/`"auto"` 时根据 device 选默认模型
+3. `SentenceTransformer(model_name, device=resolved_device)`
+4. 缓存 `_resolved_device` 和 `_resolved_dim`
+
+**`dimension` 属性**：
+
+```python
+@property
+def dimension(self) -> int:
+    if self._resolved_dim is not None:
+        return self._resolved_dim
+    if self.model is not None:
+        return self.model.get_sentence_embedding_dimension()
+    # 未加载时从 config 读取
+    from .config import config
+    return config.embedding_dimension
+```
+
+**`get_backend()` 改造**：
+
+```python
+def get_backend() -> EmbeddingBackend:
+    global _backend
+    if _backend is None:
+        from .config import config
+        model_name = config.embedding_model
+        if model_name == "auto":
+            model_name = None  # 交给 EmbeddingBackend 根据 device 自动决定
+        _backend = EmbeddingBackend(model_name=model_name, device=config.device)
+    return _backend
+```
+
+### 3. CLI `config set` 命令
+
+```
+jfox config set device cuda
+jfox config set device auto
+jfox config set embedding_model BAAI/bge-m3
+jfox config set embedding_model auto
+```
+
+**行为**：
+
+1. 修改 `config.yaml` 对应字段
+2. 重置全局 backend 单例（`reset_backend()`），下次操作时用新配置重建
+3. 如果修改了 `embedding_model`，检查新维度与旧索引是否匹配：
+   - 维度相同 → 静默完成
+   - 维度不同 → 打印警告：
+
+```
+⚠ 模型已更改为 BAAI/bge-m3 (维度 384 → 1024)
+  现有向量索引已失效，请运行: jfox index rebuild
+```
+
+重建索引使用已有的 `jfox index rebuild` 命令。
+
+**`jfox status` 改造**：
+
+把 `cli.py:590` 硬编码的 `"type": "CPU"` 改为动态读取：
+
+```python
+"backend": {
+    "type": backend._resolved_device or "未加载",
+    "model": backend.model_name,
+    "dimension": backend.dimension,
+}
+```
+
+### 4. Daemon 改造
+
+**`/health` 增强**：
+
+```python
+class HealthResponse(BaseModel):
+    status: str
+    model: str
+    dimension: int
+    device: str      # 新增：实际使用的设备
+    pid: int
+```
+
+**启动时读 config**：
+
+```python
+from ..config import config
+model_name = config.embedding_model if config.embedding_model != "auto" else None
+_backend = EmbeddingBackend(device=config.device, model_name=model_name)
+```
+
+启动日志报告 device：
+```
+INFO  Daemon: 模型已加载 BAAI/bge-m3 (device=cuda, dimension=1024)
+```
+
+**不做 daemon hot-reload**。切换模型时 `jfox daemon stop && jfox daemon start` 即可。
+
+### 5. Config 默认值变更
+
+| 字段 | 旧默认值 | 新默认值 | 原因 |
+|------|---------|---------|------|
+| `embedding_model` | `"sentence-transformers/all-MiniLM-L6-v2"` | `"auto"` | 由 device 自动决定 |
+| `embedding_dimension` | `384` | `0` | 不再硬编码，0 表示动态 |
+| `device` | `"auto"` | `"auto"` | 不变 |
+
+**向后兼容**：旧 config.yaml 写死了 `embedding_model: sentence-transformers/all-MiniLM-L6-v2` 时，升级后继续用该模型，不会自动切换。只有 `"auto"` 才触发自动选择。
+
+## 改动文件清单
+
+| 文件 | 改动 |
+|------|------|
+| `embedding_backend.py` | 构造函数加 `device`，`load()` 传 device，`dimension` 动态化 |
+| `config.py` | 默认值变更，`get_backend()` 读 config |
+| `cli.py` | 新增 `config set` 命令，`status` 显示实际 device |
+| `daemon/server.py` | `/health` 加 device，启动读 config |
+| `tests/conftest.py` | `MockEmbeddingBackend` 适配新接口 |
+
+## 不在范围内
+
+- Daemon hot-reload（`POST /reload`）
+- 向量数据库替换（Milvus/Qdrant）
+- 抽象向量存储接口
+- 多 GPU / SLI 感知（PyTorch 自行处理）

--- a/docs/superpowers/specs/2026-04-21-release-skill-design.md
+++ b/docs/superpowers/specs/2026-04-21-release-skill-design.md
@@ -1,0 +1,175 @@
+# Release Skill 设计
+
+## 目标
+
+创建一个 `/release` skill，将 jfox 的发版流程从手动多步操作简化为一条命令。覆盖从版本号 bump 到 GitHub Release 创建的全流程。
+
+## 背景
+
+### 现状痛点
+
+- 发版需要手动修改 3 个文件：`pyproject.toml`、`jfox/__init__.py`、`uv.lock`
+- 曾因遗漏 `__init__.py` 导致 #88 事故
+- CHANGELOG.md 停在 0.2.0，后续 4 个版本未更新
+- 每次发版需手动创建分支、commit、PR、Release，步骤重复
+
+### 发版流程
+
+GitHub Release (tag) → `publish.yml` workflow → PyPI (OIDC)
+
+## 方案
+
+### 架构：Skill + Python 辅助脚本
+
+- **Skill 文件** (`SKILL.md`): 流程指令，Claude 读取后逐步执行
+- **辅助脚本** (`release_helper.py`): 处理确定性工作（版本计算、文件更新、CHANGELOG 生成），输出 JSON
+
+### 文件结构
+
+```
+.claude/skills/release/
+├── SKILL.md            # Skill 指令文件
+└── release_helper.py   # Python 辅助脚本
+```
+
+## 调用方式
+
+```
+/release 0.5.0          # 指定具体版本号
+/release patch          # bump patch: 0.4.1 → 0.4.2
+/release minor          # bump minor: 0.4.1 → 0.5.0
+/release major          # bump major: 0.4.1 → 1.0.0
+```
+
+## 辅助脚本设计
+
+### 输入
+
+命令行参数：版本号（semver 字符串或 bump 类型关键词）
+
+### 职责
+
+1. **版本号计算**
+   - 从 `pyproject.toml` 读取当前版本
+   - 解析 bump 类型或使用指定版本
+   - 校验 semver 格式
+   - 确保新版本 > 当前版本
+
+2. **三处文件更新**
+   - `pyproject.toml`: 替换 `version = "X.Y.Z"` 行
+   - `jfox/__init__.py`: 替换 `__version__ = "X.Y.Z"` 行
+   - `uv.lock`: 运行 `uv lock` 更新
+
+3. **CHANGELOG 生成**
+   - 获取上一个 git tag（`git describe --tags --abbrev=0`）
+   - 提取 `<last_tag>..HEAD` 之间的 commit log
+   - 按 conventional commit 类型分类：feat → Features, fix → Fixes, 其他 → Changes
+   - 从 commit message 中提取 scope 和 PR 号
+   - 生成 Markdown 条目并插入 CHANGELOG.md 头部
+   - 添加底部比较链接
+
+### 输出
+
+JSON 格式，包含：
+
+```json
+{
+  "current_version": "0.4.1",
+  "new_version": "0.5.0",
+  "changelog_entries": [
+    {"type": "feat", "scope": "search", "message": "add hybrid search mode", "pr": 155},
+    {"type": "fix", "scope": "cli", "message": "fix list command table output", "pr": 165}
+  ],
+  "changelog_summary": "2 features, 3 fixes, 1 change",
+  "files_modified": ["pyproject.toml", "jfox/__init__.py", "uv.lock", "CHANGELOG.md"]
+}
+```
+
+脚本出错时输出 `{"error": "描述"}` 并以非零退出码退出。
+
+## Claude 负责的流程
+
+### 1. 前置校验
+
+- 当前分支是否为 main
+- 工作区是否干净（`git status --porcelain`）
+- 是否存在未合并的 bump 分支（`git branch --list 'chore/bump-*'`）
+- 是否有未合并的 PR（`gh pr list --state open`）
+
+### 2. 调用辅助脚本
+
+```bash
+uv run python .claude/skills/release/release_helper.py <version>
+```
+
+### 3. 展示变更摘要并等待确认
+
+向用户展示：
+- 新版本号
+- CHANGELOG 条目预览
+- 即将修改的文件列表
+
+**必须等待用户确认后才继续。**
+
+### 4. Git 操作
+
+```bash
+git checkout -b chore/bump-version-X.Y.Z
+git add pyproject.toml jfox/__init__.py uv.lock CHANGELOG.md
+git commit -m "chore: bump version to X.Y.Z"
+git push -u origin chore/bump-version-X.Y.Z
+```
+
+### 5. 创建 PR
+
+```bash
+gh pr create \
+  --title "chore: bump version to X.Y.Z" \
+  --body "<CHANGELOG content>"
+```
+
+### 6. 等待合并提示
+
+告知用户 PR 已创建，提示合并。
+
+### 7. 创建 GitHub Release
+
+合并后由用户确认，然后执行：
+
+```bash
+gh release create vX.Y.Z --title "vX.Y.Z" --notes "<CHANGELOG content>"
+```
+
+这会触发 `publish.yml` 自动发布到 PyPI。
+
+## CHANGELOG 格式
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Features
+- **scope**: description (#PR)
+
+### Fixes
+- **scope**: description (#PR)
+
+### Changes
+- **scope**: description (#PR)
+
+[X.Y.Z]: https://github.com/zhuxixi/jfox/compare/vPREV...vX.Y.Z
+```
+
+## 安全设计
+
+- **用户确认点**: 变更摘要后、commit 前、创建 Release 前
+- **不跳过 hook**: 使用正常 git commit 流程，不使用 `--no-verify`
+- **分支保护**: 始终在新分支操作，不直接改 main
+- **幂等性**: 脚本可在已修改的文件上安全重新运行
+- **预检阻断**: 校验失败时立即停止，不执行任何文件修改
+
+## 不做的事
+
+- 不修改 `publish.yml` workflow
+- 不处理 prerelease/beta 版本号
+- 不支持同时 bump 多个版本
+- 不自动监控 PyPI 发布状态

--- a/docs/superpowers/specs/2026-04-26-fix-daemon-deprecation-warnings-design.md
+++ b/docs/superpowers/specs/2026-04-26-fix-daemon-deprecation-warnings-design.md
@@ -1,0 +1,56 @@
+# 修复 Daemon 日志 Deprecation Warnings
+
+> Issue: #164
+> Date: 2026-04-26
+
+## 背景
+
+`jfox daemon start` 后 `~/.jfox_daemon.log` 中有两个 deprecation warning，不影响功能但产生日志噪音。
+
+## 修改清单
+
+### 1. FastAPI `on_event` → `lifespan` 模式
+
+**文件:** `jfox/daemon/server.py`
+
+将 `@app.on_event("startup")` 替换为 FastAPI 官方推荐的 `lifespan` context manager：
+
+```python
+from contextlib import asynccontextmanager
+
+@asynccontextmanager
+async def lifespan(app):
+    _load_model()
+    yield
+
+app = FastAPI(title="JFox Embedding Daemon", lifespan=lifespan)
+```
+
+`_load_model()` 函数体不变，仅去掉 `@app.on_event("startup")` 装饰器。
+
+### 2. `get_sentence_embedding_dimension()` → `get_embedding_dimension()`
+
+**文件:** `jfox/embedding_backend.py`
+
+两处直接替换：
+
+- 行 98 (`load` 方法内): `self.model.get_sentence_embedding_dimension()` → `self.model.get_embedding_dimension()`
+- 行 138 (`dimension` property 内): 同上
+
+### 3. `performance.py` fallback 路径改用 `backend.dimension`
+
+**文件:** `jfox/performance.py`
+
+行 144 改用 dimension property，不直接访问模型内部方法：
+
+```python
+dim = backend.dimension  # 替代 backend.model.get_sentence_embedding_dimension()
+```
+
+这样更统一，且与 daemon 模式兼容（daemon 模式下 `backend.model` 为 None）。
+
+## 影响范围
+
+- 纯 API 重命名/模式迁移，行为不变
+- 无需改动测试（warning 不影响断言）
+- 兼容当前 sentence-transformers 版本（新方法已可用）

--- a/docs/superpowers/specs/2026-04-27-intranet-model-download-design.md
+++ b/docs/superpowers/specs/2026-04-27-intranet-model-download-design.md
@@ -1,0 +1,284 @@
+# 内网模型自动下载设计 (#172)
+
+## 问题描述
+
+在公司内网（有代理/防火墙限制）环境中，`huggingface_hub` 无法连接 HuggingFace 官方服务器，导致 `jfox daemon start` 首次启动时模型下载失败，卡在加载阶段。
+
+具体表现：
+- `sentence-transformers` 从 `huggingface.co` 下载超时或 SSL 握手失败
+- 即使设置 `HF_HUB_OFFLINE=1` 或 `HF_ENDPOINT=https://hf-mirror.com`，某些内网代理环境仍无法工作
+
+## 目标
+
+1. **全自动降级**：daemon 启动前自动检测模型缓存，未命中时按重试链逐层降级下载
+2. **透明日志**：每步操作都有清晰的 INFO/WARN/ERROR 日志
+3. **独立命令**：新增 `jfox model download` 子命令，也可手动调用
+4. **无感知**：前 3 步全自动，用户无感知；只有全部失败时才提示手动操作
+
+## 架构设计
+
+### 重试链
+
+```
+Step 1: huggingface_hub 正常下载（全自动）
+  → 失败 →
+Step 2: 切换 HF_ENDPOINT=hf-mirror.com 重试（全自动）
+  → 失败 →
+Step 3: 代码自动执行 curl 子进程下载到 HF 缓存目录（全自动）
+  → 失败 →
+报错，提示用户运行独立脚本（需用户操作）
+```
+
+任何一步成功立即终止重试链，启动 daemon。
+
+### 新增模块
+
+```
+jfox/model_downloader.py         # ModelDownloader 类
+scripts/download-model-intranet.sh  # 降级兜底脚本
+```
+
+### 修改模块
+
+```
+jfox/daemon/process.py           # start_daemon() 启动前调用下载检查
+jfox/cli.py                      # 新增 model download 子命令
+```
+
+## 详细设计
+
+### ModelDownloader 类
+
+```python
+class ModelDownloader:
+    def __init__(self, model_name: str):
+        self.model_name = model_name
+        self.cache_dir = Path(huggingface_hub.constants.HUGGINGFACE_HUB_CACHE)
+        self.model_cache = self.cache_dir / f"models--{model_name.replace('/', '--')}"
+
+    def ensure_cached(self) -> bool:
+        """
+        确保模型已缓存。按重试链逐层降级。
+        返回 True 表示成功（无论哪一步成功）。
+        返回 False 表示全部失败。
+        """
+
+    def _check_cached(self) -> bool:
+        """检查模型是否已在 HuggingFace 缓存目录中存在"""
+
+    def _try_hf_hub_download(self, endpoint: Optional[str] = None) -> bool:
+        """
+        Step 1/2: 使用 huggingface_hub 下载。
+        endpoint=None 为正常模式；endpoint="https://hf-mirror.com" 为镜像模式。
+        """
+
+    def _try_curl_download(self) -> bool:
+        """
+        Step 3: 代码自动执行 curl 子进程下载到 HF 缓存目录。
+        按 HF 缓存目录结构放置文件，使 sentence-transformers 认为"模型已缓存"。
+        """
+        # 下载文件列表：
+        # - model.safetensors
+        # - config.json
+        # - tokenizer.json
+        # - tokenizer_config.json
+        # - sentence_bert_config.json（如存在）
+
+    def _cleanup_partial(self):
+        """清理部分下载残留，防止损坏缓存"""
+```
+
+### 日志策略
+
+| 场景 | 日志级别 | 示例 |
+|------|---------|------|
+| 每步开始 | INFO | `[INFO] 步骤 1: 使用 huggingface_hub 正常下载...` |
+| 每步成功 | INFO | `[INFO] 步骤 1 成功，模型已缓存` |
+| 每步失败 | WARN | `[WARN] 步骤 1 失败: HTTPSConnectionPool timeout` |
+| 全部失败 | ERROR | `[ERROR] 模型下载失败，所有自动方式均已尝试` |
+| 最终提示 | INFO | `建议手动下载: jfox model download --manual` |
+
+完整日志示例：
+
+```
+[INFO] 检查模型缓存: sentence-transformers/all-MiniLM-L6-v2
+[INFO] 缓存未命中，开始下载
+[INFO] 步骤 1: 使用 huggingface_hub 正常下载...
+[WARN] 步骤 1 失败: HTTPSConnectionPool timeout
+[INFO] 步骤 2: 切换 HF_ENDPOINT=hf-mirror.com 重试...
+[WARN] 步骤 2 失败: SSL handshake failed
+[INFO] 步骤 3: 使用 curl 子进程从镜像站下载...
+[INFO] 下载 model.safetensors (87MB)...
+[INFO] 下载 config.json...
+[INFO] 步骤 3 成功，模型已缓存
+[INFO] 启动 daemon...
+```
+
+### CLI 集成
+
+**新增命令：`jfox model download`**
+
+```bash
+jfox model download [--model MODEL] [--force]
+
+选项:
+  --model   指定模型名（默认从配置读取，auto 则按 device 自动选择）
+  --force   强制重新下载（覆盖已有缓存）
+  --manual  显示手动下载脚本说明（全部自动方式失败后的兜底）
+```
+
+**daemon start 自动调用：**
+
+在 `process.py` 的 `start_daemon()` 中，启动子进程前插入：
+
+```python
+def start_daemon(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> bool:
+    # 1. 确定目标模型名
+    model_name = resolve_model_name()  # 复用现有逻辑
+
+    # 2. 确保模型已缓存
+    downloader = ModelDownloader(model_name)
+    if not downloader.ensure_cached():
+        # 前 3 步全自动都失败了
+        logger.error("模型下载失败，所有自动方式均已尝试")
+        console.print("[red]模型下载失败[/red]")
+        console.print("建议: jfox model download --manual")
+        return False
+
+    # 3. 继续原有 daemon 启动逻辑
+    ...
+```
+
+**注意：** 如果 daemon 已在运行，跳过下载检查（因为已有模型在内存中）。
+
+### 超时策略
+
+| 步骤 | 超时 |
+|------|------|
+| Step 1 (hf_hub 正常) | 60 秒 |
+| Step 2 (hf_hub 镜像) | 60 秒 |
+| Step 3 (curl 下载) | 120 秒（模型文件较大） |
+
+### 部分下载清理
+
+任何步骤开始后，如果下载中断（超时、进程被杀、异常退出），`_cleanup_partial()` 自动清理不完整的文件：
+- 删除 `.part` 临时文件
+- 删除不完整的 snapshot 目录
+- 确保下次加载时不会读到损坏的缓存
+
+## 错误处理
+
+```
+daemon start
+  │
+  ▼
+检查模型缓存（_check_cached）
+  │ 已缓存？ → 跳过下载，直接启动 daemon
+  │ 未缓存？ → 进入重试链
+  ▼
+Step 1: huggingface_hub 正常下载（60s 超时）
+  │ 成功 → 记录 [INFO]，启动 daemon
+  │ 失败 → 记录 [WARN]，进入 Step 2
+  ▼
+Step 2: 设置 HF_ENDPOINT，huggingface_hub 重试（60s 超时）
+  │ 成功 → 记录 [INFO]，启动 daemon
+  │ 失败 → 记录 [WARN]，进入 Step 3
+  ▼
+Step 3: curl 子进程下载到 HF 缓存目录（120s 超时）
+  │ 成功 → 记录 [INFO]，启动 daemon
+  │ 失败 → 记录 [ERROR]，提示手动方案
+  ▼
+全部失败 → CLI 报错，daemon 不启动
+```
+
+## 测试方案
+
+### 单元测试：`tests/unit/test_model_downloader.py`
+
+```python
+class TestModelDownloader:
+    """ModelDownloader 单元测试"""
+
+    def test_check_cached_when_exists(self):
+        """缓存已存在时返回 True"""
+
+    def test_check_cached_when_not_exists(self):
+        """缓存不存在时返回 False"""
+
+    def test_try_hf_hub_download_success(self):
+        """mock hf_hub_download 成功"""
+
+    def test_try_hf_hub_download_failure(self):
+        """mock hf_hub_download 抛出异常"""
+
+    def test_try_mirror_download_sets_env(self):
+        """验证设置了 HF_ENDPOINT 环境变量"""
+
+    def test_try_curl_download_executes_subprocess(self):
+        """mock subprocess.run，验证 curl 命令参数"""
+
+    def test_ensure_cached_early_return_when_cached(self):
+        """已缓存时直接返回，不走重试链"""
+
+    def test_ensure_cached_retry_chain_order(self):
+        """验证重试链按 1→2→3 顺序执行"""
+
+    def test_cleanup_partial_removes_temp_files(self):
+        """验证部分下载残留被清理"""
+```
+
+### 集成测试：`tests/integration/test_model_download.py`
+
+```python
+class TestModelDownloadRetryChain:
+    """mock 网络层，验证完整重试链按顺序执行"""
+
+    def test_full_chain_step1_succeeds(self):
+        """Step 1 成功，后续步骤不执行"""
+
+    def test_full_chain_step1_fails_step2_succeeds(self):
+        """Step 1 失败，Step 2 成功"""
+
+    def test_full_chain_step1_2_fail_step3_succeeds(self):
+        """Step 1/2 失败，Step 3 成功"""
+
+    def test_full_chain_all_fail(self):
+        """全部失败，返回 False"""
+
+    def test_daemon_start_calls_downloader(self):
+        """验证 daemon start 启动前调用下载检查"""
+
+    def test_cli_model_download_command(self):
+        """验证 CLI model download 命令正确调用 downloader"""
+```
+
+## 新增/修改文件清单
+
+| 文件 | 类型 | 说明 |
+|------|------|------|
+| `jfox/model_downloader.py` | 新增 | ModelDownloader 类 |
+| `scripts/download-model-intranet.sh` | 新增 | 降级兜底脚本（curl 方案参考实现） |
+| `jfox/cli.py` | 修改 | 新增 `model download` 子命令 |
+| `jfox/daemon/process.py` | 修改 | `start_daemon()` 启动前调用下载检查 |
+| `tests/unit/test_model_downloader.py` | 新增 | 单元测试 |
+| `tests/integration/test_model_download.py` | 新增 | 集成测试 |
+
+## 依赖
+
+- **无新增 Python 依赖**
+- `curl`：系统命令（Step 3 使用）
+- `huggingface_hub`：已存在（Step 1/2 使用）
+
+## 风险
+
+| 风险 | 缓解 |
+|------|------|
+| curl 不可用 | Step 3 前检查 `shutil.which("curl")`，不存在则跳过 |
+| curl 下载中途被杀 | 部分下载清理 + 断点续传（curl `-C -`） |
+| HF 缓存目录结构变更 | 使用 `huggingface_hub.constants` 获取路径，不硬编码 |
+| 并发下载冲突 | PID 文件锁或临时目录隔离 |
+
+## 关联
+
+- #172 — 原始问题（公司内网模型下载失败）
+- #117 — daemon 模式已解决重复加载，但首次下载仍需联网


### PR DESCRIPTION
## Summary
- Add 15 superpowers plan documents under `docs/superpowers/plans/`
- Add 4 superpowers spec documents under `docs/superpowers/specs/`
- Update `.gitignore` to ignore Claude Code runtime files and temporary analysis files

## Changes
- `.gitignore`: Add `.claude/scheduled_tasks.json`, `.claude/scheduled_tasks.lock`, `.claude/worktrees/`, `analysis_report.md`, `kimi-export-*.md`, `review_body*.md`
- `docs/superpowers/plans/`: Historical implementation plans for various features
- `docs/superpowers/specs/`: Design specification documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)