### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to jfox-cli will be documented in this file.
 
+## [0.5.0] - 2026-04-29
+
+### Features
+- 支持通过标签召回笔记 (#170) (#177)
+- **cli**: show tags column in list table output
+- **note**: add tags parameter to list_notes() and search_notes()
+- **vector_store**: add tags parameter to search() for ChromaDB filtering
+
+### Fixes
+- **test**: resolve CI test-full failures (#175)
+
+### Changes
+- add superpowers plans and specs docs, update .gitignore (#178)
+- add tag filtering implementation plan for #170
+- add tag filtering design spec for #170
+
+[0.5.0]: https://github.com/zhuxixi/jfox/compare/v0.4.3...v0.5.0
+
 ## [0.4.3] - 2026-04-28
 
 ### Features

--- a/jfox/__init__.py
+++ b/jfox/__init__.py
@@ -1,5 +1,5 @@
 """JFox - Zettelkasten 知识管理工具"""
 
-__version__ = "0.4.3"
+__version__ = "0.5.0"
 __author__ = "User"
 __email__ = "user@example.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jfox-cli"
-version = "0.4.3"
+version = "0.5.0"
 description = "JFox - Zettelkasten 知识管理 CLI 工具"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -867,7 +867,7 @@ wheels = [
 
 [[package]]
 name = "jfox-cli"
-version = "0.4.3"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary
Bump version from 0.4.3 to 0.5.0

## [0.5.0] - 2026-04-29

### Features
- 支持通过标签召回笔记 (#170) (#177)
- **cli**: show tags column in list table output
- **note**: add tags parameter to list_notes() and search_notes()
- **vector_store**: add tags parameter to search() for ChromaDB filtering

### Fixes
- **test**: resolve CI test-full failures (#175)

### Changes
- add superpowers plans and specs docs, update .gitignore (#178)
- add tag filtering implementation plan for #170
- add tag filtering design spec for #170

[0.5.0]: https://github.com/zhuxixi/jfox/compare/v0.4.3...v0.5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)