### PR TITLE
fix(daemon): 修复 daemon stop 无法停止 daemon (#180)

### DIFF
--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -2659,8 +2659,11 @@ def daemon(
                 console.print("[dim]Daemon 未运行[/dim]")
                 return
             console.print("[yellow]正在停止 daemon...[/yellow]")
-            stop_daemon()
-            console.print("[green]✓ Daemon 已停止[/green]")
+            if stop_daemon():
+                console.print("[green]✓ Daemon 已停止[/green]")
+            else:
+                console.print("[red]✗ Daemon 停止失败，请手动终止进程[/red]")
+                raise typer.Exit(1)
 
         elif action == "status":
             info = get_daemon_status()

--- a/jfox/daemon/process.py
+++ b/jfox/daemon/process.py
@@ -296,21 +296,24 @@ def stop_daemon() -> bool:
 
     # 1. 优先通过 HTTP /shutdown 让 daemon 自行退出
     logger.info("正在通过 /shutdown 请求 daemon 停止...")
-    _http_shutdown(host, port)
+    shutdown_ok = _http_shutdown(host, port)
 
-    # 等待 daemon 自行退出（最多 3 秒）
-    for _ in range(6):
-        if _http_health_check(host, port) is None:
-            _remove_pid_file()
-            logger.info("Daemon 已通过 /shutdown 停止")
-            return True
-        time.sleep(0.5)
+    if shutdown_ok:
+        # 等待 daemon 自行退出（最多 3 秒）
+        for _ in range(6):
+            if _http_health_check(host, port) is None:
+                _remove_pid_file()
+                logger.info("Daemon 已通过 /shutdown 停止")
+                return True
+            time.sleep(0.5)
 
-    # 2. /shutdown 失败，从 /health 获取真实 PID 后尝试 taskkill/kill
+    # 2. /shutdown 失败或超时，从 /health 获取真实 PID 后尝试 taskkill/kill
     if pid == 0:
         health = _http_health_check(host, port)
         if health:
             pid = health.get("pid", 0)
+            if not isinstance(pid, int):
+                pid = 0
 
     if pid > 0:
         try:

--- a/jfox/daemon/process.py
+++ b/jfox/daemon/process.py
@@ -93,9 +93,7 @@ def _http_shutdown(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> bool:
     try:
         import urllib.request
 
-        req = urllib.request.Request(
-            f"http://{host}:{port}/shutdown", method="POST", data=b""
-        )
+        req = urllib.request.Request(f"http://{host}:{port}/shutdown", method="POST", data=b"")
         resp = urllib.request.urlopen(req, timeout=3)
         result = json.loads(resp.read().decode("utf-8"))
         return result.get("status") == "shutting_down"

--- a/jfox/daemon/process.py
+++ b/jfox/daemon/process.py
@@ -94,8 +94,8 @@ def _http_shutdown(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> bool:
         import urllib.request
 
         req = urllib.request.Request(f"http://{host}:{port}/shutdown", method="POST", data=b"")
-        resp = urllib.request.urlopen(req, timeout=3)
-        result = json.loads(resp.read().decode("utf-8"))
+        with urllib.request.urlopen(req, timeout=3) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
         return result.get("status") == "shutting_down"
     except (OSError, ValueError):
         return False

--- a/jfox/daemon/process.py
+++ b/jfox/daemon/process.py
@@ -88,6 +88,21 @@ def _http_health_check(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> Op
         return None
 
 
+def _http_shutdown(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> bool:
+    """请求 daemon 通过 /shutdown endpoint 自行停止"""
+    try:
+        import urllib.request
+
+        req = urllib.request.Request(
+            f"http://{host}:{port}/shutdown", method="POST", data=b""
+        )
+        resp = urllib.request.urlopen(req, timeout=3)
+        result = json.loads(resp.read().decode("utf-8"))
+        return result.get("status") == "shutting_down"
+    except (OSError, ValueError):
+        return False
+
+
 def is_daemon_running() -> bool:
     """检查 daemon 是否在运行（以 HTTP 健康检查为准）"""
     # 先尝试 PID 文件记录的地址
@@ -276,11 +291,29 @@ def stop_daemon() -> bool:
         port = data.get("port", DEFAULT_PORT)
 
     # 先检查是否真的在跑
-    if _http_health_check(host, port) is None:
+    health = _http_health_check(host, port)
+    if health is None:
         _remove_pid_file()
         return True
 
-    # 尝试停止
+    # 1. 优先通过 HTTP /shutdown 让 daemon 自行退出
+    logger.info("正在通过 /shutdown 请求 daemon 停止...")
+    _http_shutdown(host, port)
+
+    # 等待 daemon 自行退出（最多 3 秒）
+    for _ in range(6):
+        if _http_health_check(host, port) is None:
+            _remove_pid_file()
+            logger.info("Daemon 已通过 /shutdown 停止")
+            return True
+        time.sleep(0.5)
+
+    # 2. /shutdown 失败，从 /health 获取真实 PID 后尝试 taskkill/kill
+    if pid == 0:
+        health = _http_health_check(host, port)
+        if health:
+            pid = health.get("pid", 0)
+
     if pid > 0:
         try:
             if sys.platform == "win32":
@@ -294,7 +327,7 @@ def stop_daemon() -> bool:
         except (OSError, subprocess.SubprocessError) as e:
             logger.warning(f"停止 daemon 失败: {e}")
 
-    # 等待进程退出
+    # 等待进程退出（最多 5 秒）
     for _ in range(10):
         if _http_health_check(host, port) is None:
             _remove_pid_file()
@@ -302,9 +335,8 @@ def stop_daemon() -> bool:
             return True
         time.sleep(0.5)
 
-    # 超时未退出
+    # 超时未退出 — 不删 PID 文件，保留追踪信息
     logger.warning(f"Daemon 停止超时 (PID: {pid})")
-    _remove_pid_file()
     return False
 
 

--- a/jfox/daemon/server.py
+++ b/jfox/daemon/server.py
@@ -79,6 +79,10 @@ class EncodeSingleRequest(BaseModel):
     text: str
 
 
+class ShutdownResponse(BaseModel):
+    status: str
+
+
 class EncodeSingleResponse(BaseModel):
     embedding: List[float]
     dimension: int
@@ -101,13 +105,12 @@ def health():
     )
 
 
-@app.post("/shutdown")
+@app.post("/shutdown", response_model=ShutdownResponse)
 def shutdown():
     """请求 daemon 自行停止"""
-    global _server
     if _server:
         _server.should_exit = True
-    return {"status": "shutting_down"}
+    return ShutdownResponse(status="shutting_down")
 
 
 @app.post("/encode", response_model=EncodeResponse)

--- a/jfox/daemon/server.py
+++ b/jfox/daemon/server.py
@@ -19,6 +19,9 @@ logger = logging.getLogger(__name__)
 # 全局 embedding 后端（模型加载后常驻内存）
 _backend = None
 
+# uvicorn Server 实例（用于 graceful shutdown）
+_server = None
+
 
 def _load_model():
     """启动时加载模型（标记为 daemon 进程，防止自引用）"""
@@ -98,6 +101,15 @@ def health():
     )
 
 
+@app.post("/shutdown")
+def shutdown():
+    """请求 daemon 自行停止"""
+    global _server
+    if _server:
+        _server.should_exit = True
+    return {"status": "shutting_down"}
+
+
 @app.post("/encode", response_model=EncodeResponse)
 def encode(req: EncodeRequest):
     """批量文本编码"""
@@ -133,7 +145,10 @@ def main():
 
     import uvicorn
 
-    uvicorn.run(app, host=args.host, port=args.port, log_level="warning")
+    global _server
+    config = uvicorn.Config(app, host=args.host, port=args.port, log_level="warning")
+    _server = uvicorn.Server(config)
+    _server.run()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- 添加 `POST /shutdown` endpoint，daemon 可通过 uvicorn `should_exit` 自行优雅退出
- 重写 `stop_daemon()` 为 HTTP-first 流程：先 `/shutdown` → 再 taskkill/kill fallback
- 修复 PID 为 0 时从 `/health` 获取真实 PID（Bug 1）
- 修复超时时不再删除 PID 文件（Bug 3）
- 修复 CLI 检查 `stop_daemon()` 返回值，失败时报错而非打印成功（Bug 2）

Closes #180

## Test plan

- [ ] `jfox daemon start` → `jfox daemon stop` → `jfox daemon status` 显示未运行
- [ ] `jfox daemon start` → 删 `~/.jfox_daemon.pid` → `jfox daemon stop` 仍能成功
- [ ] `jfox daemon stop`（未运行时）显示 "Daemon 未运行"

🤖 Generated with [Claude Code](https://claude.com/claude-code)