### PR TITLE
feat(kb): support JFOX_KB environment variable for default KB

### DIFF
--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -424,13 +424,9 @@ def add(
         if not content:
             raise ValueError("请提供笔记内容（位置参数或 --content-file）")
 
-        # 如果指定了知识库，临时切换
-        if kb:
-            from .config import use_kb
+        from .config import use_kb
 
-            with use_kb(kb):
-                _add_note_impl(content, title, note_type, tags, source, output_format, template)
-        else:
+        with use_kb(kb):
             _add_note_impl(content, title, note_type, tags, source, output_format, template)
 
     except typer.Exit:
@@ -561,13 +557,9 @@ def search(
         if json_output:
             output_format = "json"
 
-        # 如果指定了知识库，临时切换
-        if kb:
-            from .config import use_kb
+        from .config import use_kb
 
-            with use_kb(kb):
-                _search_impl(query, top, note_type, tags, search_mode, output_format)
-        else:
+        with use_kb(kb):
             _search_impl(query, top, note_type, tags, search_mode, output_format)
 
     except Exception as e:
@@ -746,13 +738,9 @@ def status(
 ):
     """查看知识库状态"""
     try:
-        # 如果指定了知识库，临时切换
-        if kb:
-            from .config import use_kb
+        from .config import use_kb
 
-            with use_kb(kb):
-                _status_impl(output_format, json_output)
-        else:
+        with use_kb(kb):
             _status_impl(output_format, json_output)
 
     except Exception as e:
@@ -847,13 +835,9 @@ def list(
         if json_output:
             output_format = "json"
 
-        # 如果指定了知识库，临时切换
-        if kb:
-            from .config import use_kb
+        from .config import use_kb
 
-            with use_kb(kb):
-                _list_impl(note_type, tags, limit, output_format)
-        else:
+        with use_kb(kb):
             _list_impl(note_type, tags, limit, output_format)
 
     except Exception as e:
@@ -897,12 +881,9 @@ def show(
     支持通过笔记 ID 或标题定位。
     """
     try:
-        if kb:
-            from .config import use_kb
+        from .config import use_kb
 
-            with use_kb(kb):
-                _show_impl(note_ref)
-        else:
+        with use_kb(kb):
             _show_impl(note_ref)
 
     except Exception as e:
@@ -1046,13 +1027,9 @@ def refs(
         if json_output:
             output_format = "json"
 
-        # 如果指定了知识库，临时切换
-        if kb:
-            from .config import use_kb
+        from .config import use_kb
 
-            with use_kb(kb):
-                _refs_impl(note_id, search, output_format, json_output)
-        else:
+        with use_kb(kb):
             _refs_impl(note_id, search, output_format, json_output)
 
     except Exception as e:
@@ -1125,13 +1102,9 @@ def delete(
         if json_output:
             output_format = "json"
 
-        # 如果指定了知识库，临时切换
-        if kb:
-            from .config import use_kb
+        from .config import use_kb
 
-            with use_kb(kb):
-                _delete_impl(note_id, force, output_format)
-        else:
+        with use_kb(kb):
             _delete_impl(note_id, force, output_format)
 
     except typer.Exit:
@@ -1331,14 +1304,9 @@ def edit(
         if json_output:
             output_format = "json"
 
-        if kb:
-            from .config import use_kb
+        from .config import use_kb
 
-            with use_kb(kb):
-                _edit_impl(
-                    note_id, content, content_file, title, tags, note_type, source, output_format
-                )
-        else:
+        with use_kb(kb):
             _edit_impl(
                 note_id, content, content_file, title, tags, note_type, source, output_format
             )
@@ -1443,13 +1411,9 @@ def query(
 ):
     """语义搜索 + 知识图谱联合查询"""
     try:
-        # 如果指定了知识库，临时切换
-        if kb:
-            from .config import use_kb
+        from .config import use_kb
 
-            with use_kb(kb):
-                _query_impl(query_str, top, graph_depth, json_output)
-        else:
+        with use_kb(kb):
             _query_impl(query_str, top, graph_depth, json_output)
 
     except Exception as e:
@@ -1579,13 +1543,9 @@ def graph(
         if json_output:
             output_format = "json"
 
-        # 如果指定了知识库，临时切换
-        if kb:
-            from .config import use_kb
+        from .config import use_kb
 
-            with use_kb(kb):
-                _graph_impl(note_id, depth, stats, orphans, output_format, json_output)
-        else:
+        with use_kb(kb):
             _graph_impl(note_id, depth, stats, orphans, output_format, json_output)
 
     except Exception as e:
@@ -1654,13 +1614,9 @@ def daily(
         if json_output:
             output_format = "json"
 
-        # 如果指定了知识库，临时切换
-        if kb:
-            from .config import use_kb
+        from .config import use_kb
 
-            with use_kb(kb):
-                _daily_impl(date, output_format, json_output)
-        else:
+        with use_kb(kb):
             _daily_impl(date, output_format, json_output)
 
     except Exception as e:
@@ -1766,13 +1722,9 @@ def suggest_links(
         output_format = "json"
 
     try:
-        # 如果指定了知识库，临时切换
-        if kb:
-            from .config import use_kb
+        from .config import use_kb
 
-            with use_kb(kb):
-                _suggest_links_impl(content, top_k, threshold, output_format, json_output)
-        else:
+        with use_kb(kb):
             _suggest_links_impl(content, top_k, threshold, output_format, json_output)
 
     except Exception as e:
@@ -1799,13 +1751,9 @@ def inbox(
         if json_output:
             output_format = "json"
 
-        # 如果指定了知识库，临时切换
-        if kb:
-            from .config import use_kb
+        from .config import use_kb
 
-            with use_kb(kb):
-                _inbox_impl(limit, output_format, json_output)
-        else:
+        with use_kb(kb):
             _inbox_impl(limit, output_format, json_output)
 
     except Exception as e:
@@ -1985,13 +1933,9 @@ def index(
         if json_output:
             output_format = "json"
 
-        # 如果指定了知识库，临时切换
-        if kb:
-            from .config import use_kb
+        from .config import use_kb
 
-            with use_kb(kb):
-                _index_impl(action, output_format)
-        else:
+        with use_kb(kb):
             _index_impl(action, output_format)
 
     except typer.Exit:
@@ -2453,15 +2397,9 @@ def ingest_log(
         if json_output:
             output_format = "json"
 
-        # 如果指定了知识库，临时切换
-        if kb:
-            from .config import use_kb
+        from .config import use_kb
 
-            with use_kb(kb):
-                _ingest_log_impl(
-                    repo_path, limit, note_type, batch_size, output_format, json_output
-                )
-        else:
+        with use_kb(kb):
             _ingest_log_impl(repo_path, limit, note_type, batch_size, output_format, json_output)
 
     except ValueError as e:
@@ -2512,20 +2450,10 @@ def bulk_import(
 
         console.print(f"[yellow]Importing {len(notes_data)} notes...[/yellow]")
 
+        from .config import use_kb
         from .performance import bulk_import_notes
 
-        # 如果指定了知识库，临时切换
-        if kb:
-            from .config import use_kb
-
-            with use_kb(kb):
-                result = bulk_import_notes(
-                    notes_data=notes_data,
-                    note_type=note_type,
-                    batch_size=batch_size,
-                    show_progress=not json_output,
-                )
-        else:
+        with use_kb(kb):
             result = bulk_import_notes(
                 notes_data=notes_data,
                 note_type=note_type,

--- a/jfox/config.py
+++ b/jfox/config.py
@@ -9,7 +9,7 @@ from typing import Optional
 import yaml
 from rich.console import Console
 
-_console = Console()
+_console = Console(stderr=True)
 
 
 def get_default_kb_path() -> Path:
@@ -165,7 +165,7 @@ def use_kb(kb_name: Optional[str] = None):
     resolved_from_env = False
 
     if not kb_name:
-        env_kb = os.environ.get("JFOX_KB")
+        env_kb = os.environ.get("JFOX_KB", "").strip()
         if env_kb:
             kb_name = env_kb
             resolved_from_env = True

--- a/jfox/config.py
+++ b/jfox/config.py
@@ -152,6 +152,10 @@ def use_kb(kb_name: Optional[str] = None):
             # 在这个上下文中，操作都在 work 知识库上
             note = create_note(...)
 
+    优先级: --kb > JFOX_KB > 全局配置 default
+    当 kb_name 为 None 时，会先检查 JFOX_KB 环境变量，
+    若未设置则使用全局配置中的默认知识库。
+
     Args:
         kb_name: 知识库名称，None 表示使用当前默认知识库
 

--- a/jfox/config.py
+++ b/jfox/config.py
@@ -1,11 +1,15 @@
 """配置管理"""
 
+import os
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
 import yaml
+from rich.console import Console
+
+_console = Console()
 
 
 def get_default_kb_path() -> Path:
@@ -154,9 +158,16 @@ def use_kb(kb_name: Optional[str] = None):
     Raises:
         ValueError: 知识库不存在
     """
+    resolved_from_env = False
+
     if not kb_name:
-        yield
-        return
+        env_kb = os.environ.get("JFOX_KB")
+        if env_kb:
+            kb_name = env_kb
+            resolved_from_env = True
+        else:
+            yield
+            return
 
     from .kb_manager import get_kb_manager
 
@@ -181,6 +192,12 @@ def use_kb(kb_name: Optional[str] = None):
 
         # 重置索引和搜索引擎（使用新的知识库路径）
         _reset_singletons()
+
+        if resolved_from_env:
+            _console.print(
+                f"Using knowledge base '{kb_name}' (from JFOX_KB environment variable)",
+                style="dim",
+            )
 
         yield
     finally:

--- a/jfox/template_cli.py
+++ b/jfox/template_cli.py
@@ -42,11 +42,7 @@ def list_templates(
         if json_output:
             output_format = "json"
 
-        if kb:
-            with use_kb(kb):
-                manager = get_template_manager()
-                templates = manager.list_templates()
-        else:
+        with use_kb(kb):
             manager = get_template_manager()
             templates = manager.list_templates()
 
@@ -120,11 +116,7 @@ def show_template(
     try:
         from .config import use_kb
 
-        if kb:
-            with use_kb(kb):
-                manager = get_template_manager()
-                template = manager.get_template(name)
-        else:
+        with use_kb(kb):
             manager = get_template_manager()
             template = manager.get_template(name)
 
@@ -183,10 +175,7 @@ def create_template(
     try:
         from .config import use_kb
 
-        if kb:
-            with use_kb(kb):
-                manager = get_template_manager()
-        else:
+        with use_kb(kb):
             manager = get_template_manager()
 
         # Check if template exists
@@ -246,11 +235,7 @@ def edit_template(
     try:
         from .config import use_kb
 
-        if kb:
-            with use_kb(kb):
-                manager = get_template_manager()
-                template = manager.get_template(name)
-        else:
+        with use_kb(kb):
             manager = get_template_manager()
             template = manager.get_template(name)
 
@@ -294,10 +279,7 @@ def remove_template(
     try:
         from .config import use_kb
 
-        if kb:
-            with use_kb(kb):
-                manager = get_template_manager()
-        else:
+        with use_kb(kb):
             manager = get_template_manager()
 
         template = manager.get_template(name)

--- a/tests/unit/test_use_kb_env_var.py
+++ b/tests/unit/test_use_kb_env_var.py
@@ -21,48 +21,52 @@ class TestUseKbEnvVar:
     def test_env_var_used_when_kb_arg_none(self):
         """当 kb_name 为 None 且 JFOX_KB 设置时，应切换到该知识库"""
         with patch.dict(os.environ, {"JFOX_KB": "work"}):
-            with patch("jfox.kb_manager.get_kb_manager") as mock_get_manager:
-                mock_manager = Mock()
-                mock_manager.config_manager.kb_exists.return_value = True
-                mock_manager.config_manager.get_kb_path.return_value = (
-                    config.base_dir.parent / "work"
-                )
-                mock_get_manager.return_value = mock_manager
+            with patch("jfox.config._reset_singletons"):
+                with patch("jfox.kb_manager.get_kb_manager") as mock_get_manager:
+                    mock_manager = Mock()
+                    mock_manager.config_manager.kb_exists.return_value = True
+                    mock_manager.config_manager.get_kb_path.return_value = (
+                        config.base_dir.parent / "work"
+                    )
+                    mock_get_manager.return_value = mock_manager
 
-                with use_kb(None) as _:
-                    # 验证确实切换了知识库
-                    mock_manager.config_manager.get_kb_path.assert_called_once_with("work")
+                    with use_kb(None) as _:
+                        # 验证确实切换了知识库
+                        mock_manager.config_manager.get_kb_path.assert_called_once_with("work")
 
     def test_cli_arg_overrides_env_var(self):
         """当同时传入 kb_name 和设置 JFOX_KB 时，应优先使用传入的 kb_name"""
         with patch.dict(os.environ, {"JFOX_KB": "work"}):
-            with patch("jfox.kb_manager.get_kb_manager") as mock_get_manager:
-                mock_manager = Mock()
-                mock_manager.config_manager.kb_exists.return_value = True
-                mock_manager.config_manager.get_kb_path.return_value = (
-                    config.base_dir.parent / "personal"
-                )
-                mock_get_manager.return_value = mock_manager
+            with patch("jfox.config._reset_singletons"):
+                with patch("jfox.kb_manager.get_kb_manager") as mock_get_manager:
+                    mock_manager = Mock()
+                    mock_manager.config_manager.kb_exists.return_value = True
+                    mock_manager.config_manager.get_kb_path.return_value = (
+                        config.base_dir.parent / "personal"
+                    )
+                    mock_get_manager.return_value = mock_manager
 
-                with use_kb("personal") as _:
-                    # 验证使用的是传入的 "personal"，而不是环境变量的 "work"
-                    mock_manager.config_manager.get_kb_path.assert_called_once_with("personal")
+                    with use_kb("personal") as _:
+                        # 验证使用的是传入的 "personal"，而不是环境变量的 "work"
+                        mock_manager.config_manager.get_kb_path.assert_called_once_with("personal")
 
     def test_invalid_jfox_kb_raises_valueerror(self):
         """当 JFOX_KB 指向不存在的知识库时，应抛出 ValueError"""
         with patch.dict(os.environ, {"JFOX_KB": "nonexistent"}):
-            with patch("jfox.kb_manager.get_kb_manager") as mock_get_manager:
-                mock_manager = Mock()
-                mock_manager.config_manager.kb_exists.return_value = False
-                mock_get_manager.return_value = mock_manager
+            with patch("jfox.config._reset_singletons"):
+                with patch("jfox.kb_manager.get_kb_manager") as mock_get_manager:
+                    mock_manager = Mock()
+                    mock_manager.config_manager.kb_exists.return_value = False
+                    mock_get_manager.return_value = mock_manager
 
-                with pytest.raises(ValueError, match="Knowledge base 'nonexistent' not found"):
-                    with use_kb(None):
-                        pass
+                    with pytest.raises(ValueError, match="Knowledge base 'nonexistent' not found"):
+                        with use_kb(None):
+                            pass
 
     def test_no_env_var_falls_back_to_global_default(self):
         """当没有设置 JFOX_KB 且 kb_name 为 None 时，应直接使用当前默认知识库"""
-        with patch.dict(os.environ, {}, clear=True):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("JFOX_KB", None)
             with patch("jfox.kb_manager.get_kb_manager") as mock_get_manager:
                 # 不应调用 get_kb_manager，因为没有需要切换的知识库
                 original_base_dir = config.base_dir
@@ -72,3 +76,19 @@ class TestUseKbEnvVar:
                     mock_get_manager.assert_not_called()
                     # 验证配置没有被修改
                     assert config.base_dir == original_base_dir
+
+    def test_jfox_kb_with_whitespace_is_stripped(self):
+        """JFOX_KB 值包含首尾空格时应被去除"""
+        with patch.dict(os.environ, {"JFOX_KB": "  work  "}):
+            with patch("jfox.config._reset_singletons"):
+                with patch("jfox.kb_manager.get_kb_manager") as mock_get_manager:
+                    mock_manager = Mock()
+                    mock_manager.config_manager.kb_exists.return_value = True
+                    mock_manager.config_manager.get_kb_path.return_value = (
+                        config.base_dir.parent / "work"
+                    )
+                    mock_get_manager.return_value = mock_manager
+
+                    with use_kb(None) as _:
+                        # 验证去除了空格后使用的是 "work"
+                        mock_manager.config_manager.get_kb_path.assert_called_once_with("work")

--- a/tests/unit/test_use_kb_env_var.py
+++ b/tests/unit/test_use_kb_env_var.py
@@ -1,0 +1,74 @@
+"""
+测试类型: 单元测试
+目标模块: jfox.config.use_kb
+预估耗时: < 1秒
+依赖要求: 无外部依赖，使用 mock
+"""
+
+import os
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+from unittest.mock import Mock, patch
+
+from jfox.config import config, use_kb
+
+
+class TestUseKbEnvVar:
+    """测试 use_kb() 对 JFOX_KB 环境变量的支持"""
+
+    def test_env_var_used_when_kb_arg_none(self):
+        """当 kb_name 为 None 且 JFOX_KB 设置时，应切换到该知识库"""
+        with patch.dict(os.environ, {"JFOX_KB": "work"}):
+            with patch("jfox.kb_manager.get_kb_manager") as mock_get_manager:
+                mock_manager = Mock()
+                mock_manager.config_manager.kb_exists.return_value = True
+                mock_manager.config_manager.get_kb_path.return_value = (
+                    config.base_dir.parent / "work"
+                )
+                mock_get_manager.return_value = mock_manager
+
+                with use_kb(None) as _:
+                    # 验证确实切换了知识库
+                    mock_manager.config_manager.get_kb_path.assert_called_once_with("work")
+
+    def test_cli_arg_overrides_env_var(self):
+        """当同时传入 kb_name 和设置 JFOX_KB 时，应优先使用传入的 kb_name"""
+        with patch.dict(os.environ, {"JFOX_KB": "work"}):
+            with patch("jfox.kb_manager.get_kb_manager") as mock_get_manager:
+                mock_manager = Mock()
+                mock_manager.config_manager.kb_exists.return_value = True
+                mock_manager.config_manager.get_kb_path.return_value = (
+                    config.base_dir.parent / "personal"
+                )
+                mock_get_manager.return_value = mock_manager
+
+                with use_kb("personal") as _:
+                    # 验证使用的是传入的 "personal"，而不是环境变量的 "work"
+                    mock_manager.config_manager.get_kb_path.assert_called_once_with("personal")
+
+    def test_invalid_jfox_kb_raises_valueerror(self):
+        """当 JFOX_KB 指向不存在的知识库时，应抛出 ValueError"""
+        with patch.dict(os.environ, {"JFOX_KB": "nonexistent"}):
+            with patch("jfox.kb_manager.get_kb_manager") as mock_get_manager:
+                mock_manager = Mock()
+                mock_manager.config_manager.kb_exists.return_value = False
+                mock_get_manager.return_value = mock_manager
+
+                with pytest.raises(ValueError, match="Knowledge base 'nonexistent' not found"):
+                    with use_kb(None):
+                        pass
+
+    def test_no_env_var_falls_back_to_global_default(self):
+        """当没有设置 JFOX_KB 且 kb_name 为 None 时，应直接使用当前默认知识库"""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("jfox.kb_manager.get_kb_manager") as mock_get_manager:
+                # 不应调用 get_kb_manager，因为没有需要切换的知识库
+                original_base_dir = config.base_dir
+
+                with use_kb(None) as _:
+                    # 验证没有尝试获取 kb_manager
+                    mock_get_manager.assert_not_called()
+                    # 验证配置没有被修改
+                    assert config.base_dir == original_base_dir


### PR DESCRIPTION
## Summary

- `use_kb()` now checks `JFOX_KB` environment variable when `kb_name` is `None`
- Priority: `--kb` > `JFOX_KB` > global config default
- Prints a dim hint when the env var is active
- Closes #183

## Test Plan

- [x] `test_env_var_used_when_kb_arg_none` — JFOX_KB is respected when no `--kb` is passed
- [x] `test_cli_arg_overrides_env_var` — `--kb` takes precedence over JFOX_KB
- [x] `test_invalid_jfox_kb_raises_valueerror` — invalid KB name raises ValueError
- [x] `test_no_env_var_falls_back_to_global_default` — falls back to global config when JFOX_KB is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)