### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/jfox/__init__.py
+++ b/jfox/__init__.py
@@ -1,5 +1,5 @@
 """JFox - Zettelkasten 知识管理工具"""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 __author__ = "User"
 __email__ = "user@example.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jfox-cli"
-version = "0.5.0"
+version = "0.6.0"
 description = "JFox - Zettelkasten 知识管理 CLI 工具"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -867,7 +867,7 @@ wheels = [
 
 [[package]]
 name = "jfox-cli"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Bump version from 0.5.0 to 0.6.0.

## Changes

- `pyproject.toml`: version 0.5.0 → 0.6.0
- `jfox/__init__.py`: __version__ 0.5.0 → 0.6.0
- `uv.lock`: jfox-cli 0.5.0 → 0.6.0

## What's New Since 0.5.0

- feat: support `JFOX_KB` environment variable for default knowledge base (#183)
- fix: daemon stop now correctly stops the daemon process (#180)
- fix: daemon dependency changed to required + Windows console popup fix (#181)

🤖 Generated with [Claude Code](https://claude.com/claude-code)