### PR TITLE
fix(note): downgrade parse failure log to warning in load_note

### DIFF
--- a/jfox/note.py
+++ b/jfox/note.py
@@ -3,6 +3,8 @@
 import logging
 from datetime import datetime
 from pathlib import Path
+
+import yaml
 from typing import Any, Dict, List, Optional
 
 from .config import ZKConfig, config
@@ -101,6 +103,9 @@ def load_note(filepath: Path) -> Optional[Note]:
 
         return Note.from_markdown(content, filepath)
 
+    except (ValueError, yaml.YAMLError) as e:
+        logger.warning(f"Failed to load note from {filepath}: {e}")
+        return None
     except Exception as e:
         logger.error(f"Failed to load note from {filepath}: {e}")
         return None
@@ -726,6 +731,9 @@ def load_note_static(filepath: Path) -> Optional[Note]:
 
         return Note.from_markdown(content, filepath)
 
+    except (ValueError, yaml.YAMLError) as e:
+        logger.warning(f"Failed to load note from {filepath}: {e}")
+        return None
     except Exception as e:
         logger.error(f"Failed to load note from {filepath}: {e}")
         return None

--- a/jfox/note.py
+++ b/jfox/note.py
@@ -3,9 +3,9 @@
 import logging
 from datetime import datetime
 from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 import yaml
-from typing import Any, Dict, List, Optional
 
 from .config import ZKConfig, config
 from .models import Note, NoteType

--- a/jfox/note.py
+++ b/jfox/note.py
@@ -103,6 +103,9 @@ def load_note(filepath: Path) -> Optional[Note]:
 
         return Note.from_markdown(content, filepath)
 
+    except UnicodeDecodeError as e:
+        logger.error(f"Failed to load note from {filepath}: {e}")
+        return None
     except (ValueError, yaml.YAMLError) as e:
         logger.warning(f"Failed to load note from {filepath}: {e}")
         return None
@@ -731,6 +734,9 @@ def load_note_static(filepath: Path) -> Optional[Note]:
 
         return Note.from_markdown(content, filepath)
 
+    except UnicodeDecodeError as e:
+        logger.error(f"Failed to load note from {filepath}: {e}")
+        return None
     except (ValueError, yaml.YAMLError) as e:
         logger.warning(f"Failed to load note from {filepath}: {e}")
         return None


### PR DESCRIPTION
## Summary
- Split the broad `except Exception` catch in `load_note()` and `load_note_static()` into two: `(ValueError, yaml.YAMLError)` for recoverable parse failures logged as `WARNING`, and a generic `Exception` fallback for real IO/permission errors kept as `ERROR`
- Fixes #186: `jfox show` 等命令遇到空文件时不再打印误导性的 ERROR 日志

## Test plan
- [ ] 知识库中放入空 `.md` 文件，运行 `jfox show <id>`，确认日志级别为 WARNING 而非 ERROR
- [ ] 确认正常笔记操作不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)