### PR TITLE
feat(note): list_notes 扫描结束时汇总无效文件提示 (#188)

### DIFF
--- a/jfox/note.py
+++ b/jfox/note.py
@@ -166,6 +166,7 @@ def list_notes(
     """
     use_config = cfg or config
     notes = []
+    skipped = 0
 
     types_to_list = [note_type] if note_type else list(NoteType)
 
@@ -178,6 +179,8 @@ def list_notes(
             note = load_note(filepath)
             if note:
                 notes.append(note)
+            else:
+                skipped += 1
 
             # 无标签过滤时可提前截断，避免全量遍历
             if limit and not tags and len(notes) >= limit:
@@ -193,6 +196,9 @@ def list_notes(
     # 截断到 limit
     if limit:
         notes = notes[:limit]
+
+    if skipped > 0:
+        logger.warning(f"{skipped} 个文件无法加载，已跳过。运行 jfox check 清理。")
 
     return notes
 

--- a/tests/unit/test_list_notes_skip.py
+++ b/tests/unit/test_list_notes_skip.py
@@ -1,0 +1,86 @@
+"""
+测试类型: 单元测试
+目标模块: jfox.note (list_notes 跳过文件汇总)
+预估耗时: < 1秒
+依赖要求: 无外部依赖
+"""
+
+import logging
+from datetime import datetime
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+from jfox.note import list_notes
+
+
+class TestListNotesSkipSummary:
+    """list_notes 跳过无效文件时的 warning 汇总"""
+
+    @pytest.fixture
+    def kb_with_corrupt_file(self, temp_kb):
+        """创建包含一个损坏文件的知识库"""
+        from jfox.config import ZKConfig
+        from jfox.models import Note, NoteType
+
+        cfg = ZKConfig(base_dir=temp_kb)
+        cfg.ensure_dirs()
+
+        # 一个正常笔记
+        note = Note(
+            id="20260503001",
+            title="正常笔记",
+            content="内容",
+            type=NoteType.PERMANENT,
+            tags=[],
+            created=datetime(2026, 5, 3, 0, 1),
+            updated=datetime(2026, 5, 3, 0, 1),
+        )
+        note_dir = cfg.notes_dir / note.type.value
+        note_dir.mkdir(parents=True, exist_ok=True)
+        (note_dir / f"{note.id}.md").write_text(note.to_markdown(), encoding="utf-8")
+
+        # 一个空文件（损坏）
+        (note_dir / "empty.md").write_text("", encoding="utf-8")
+
+        return cfg
+
+    def test_no_warning_when_all_valid(self, temp_kb, caplog):
+        """所有文件有效时不输出 warning"""
+        from jfox.config import ZKConfig
+        from jfox.models import Note, NoteType
+
+        cfg = ZKConfig(base_dir=temp_kb)
+        cfg.ensure_dirs()
+
+        note = Note(
+            id="20260503001",
+            title="正常笔记",
+            content="内容",
+            type=NoteType.PERMANENT,
+            tags=[],
+            created=datetime(2026, 5, 3, 0, 1),
+            updated=datetime(2026, 5, 3, 0, 1),
+        )
+        note_dir = cfg.notes_dir / note.type.value
+        note_dir.mkdir(parents=True, exist_ok=True)
+        (note_dir / f"{note.id}.md").write_text(note.to_markdown(), encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING, logger="jfox.note"):
+            results = list_notes(cfg=cfg)
+
+        assert len(results) == 1
+        skip_warnings = [r for r in caplog.records if "无法加载" in r.message]
+        assert len(skip_warnings) == 0
+
+    def test_warning_when_corrupt_file_skipped(self, kb_with_corrupt_file, caplog):
+        """有损坏文件时输出汇总 warning"""
+        with caplog.at_level(logging.WARNING, logger="jfox.note"):
+            results = list_notes(cfg=kb_with_corrupt_file)
+
+        assert len(results) == 1
+        skip_warnings = [r for r in caplog.records if "无法加载" in r.message]
+        assert len(skip_warnings) == 1
+        assert "1 个文件无法加载" in skip_warnings[0].message
+        assert "jfox check" in skip_warnings[0].message


### PR DESCRIPTION
## Summary

- `list_notes()` 遍历文件时计数 `load_note()` 返回 `None` 的次数，扫描结束后输出一条 warning 汇总
- 用户现在能看到知识库中存在损坏/空文件，并得到 `jfox check` 清理提示
- 新增 2 个单元测试覆盖有/无损坏文件两种场景

Fixes #188

## Test plan

- [x] `uv run pytest tests/unit/test_list_notes_skip.py -v` — 2 tests pass
- [x] `uv run pytest tests/unit/test_tag_filter.py -v` — 7 tests pass (no regression)
- [x] `uv run ruff check` / `uv run black --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)