### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to jfox-cli will be documented in this file.
 
+## [0.7.1] - 2026-05-05
+
+### Fixes
+- dynamically detect model weight file format
+
+[0.7.1]: https://github.com/zhuxixi/jfox/compare/v0.7.0...v0.7.1
+
 ## [0.7.0] - 2026-05-05
 
 ### Features

--- a/jfox/__init__.py
+++ b/jfox/__init__.py
@@ -1,5 +1,5 @@
 """JFox - Zettelkasten 知识管理工具"""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 __author__ = "User"
 __email__ = "user@example.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jfox-cli"
-version = "0.7.0"
+version = "0.7.1"
 description = "JFox - Zettelkasten 知识管理 CLI 工具"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -867,7 +867,7 @@ wheels = [
 
 [[package]]
 name = "jfox-cli"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary
Bump version from 0.7.0 to 0.7.1

## [0.7.1] - 2026-05-05

### Fixes
- dynamically detect model weight file format

[0.7.1]: https://github.com/zhuxixi/jfox/compare/v0.7.0...v0.7.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)