### PR TITLE
fix: strip frontmatter from --content-file input to prevent duplication

### DIFF
--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -1149,12 +1149,15 @@ def delete(
 
 def _strip_frontmatter(raw: str) -> str:
     """如果内容包含 YAML frontmatter，则剥离 frontmatter 和标题行，只返回正文"""
+    # 去除 UTF-8 BOM
+    if raw.startswith("﻿"):
+        raw = raw[1:]
     match = re.match(r"^---\n.*?\n---\n+(.*)", raw, re.DOTALL)
     if not match:
         return raw
     body = match.group(1).strip()
-    # 去除开头的 markdown 标题行（如 "# Title"）
-    body = re.sub(r"^#\s+.*\n*", "", body).strip()
+    # 去除 jfox 生成的标题行（# 后跟空格和非空内容，空行结尾）
+    body = re.sub(r"^#[ \t]+\S.*\n*", "", body).strip()
     return body
 
 

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 import sys
 import warnings
 from datetime import datetime
@@ -1146,8 +1147,22 @@ def delete(
         raise typer.Exit(1)
 
 
+def _strip_frontmatter(raw: str) -> str:
+    """如果内容包含 YAML frontmatter，则剥离 frontmatter 和标题行，只返回正文"""
+    match = re.match(r"^---\n.*?\n---\n+(.*)", raw, re.DOTALL)
+    if not match:
+        return raw
+    body = match.group(1).strip()
+    # 去除开头的 markdown 标题行（如 "# Title"）
+    body = re.sub(r"^#\s+.*\n*", "", body).strip()
+    return body
+
+
 def _read_content_file(content_file: str) -> str:
-    """从文件或 stdin 读取内容（--content-file 共用逻辑）"""
+    """从文件或 stdin 读取内容（--content-file 共用逻辑）
+
+    如果文件包含 YAML frontmatter（如 jfox 笔记文件），自动剥离只保留正文。
+    """
     if content_file == "-":
         import sys
 
@@ -1159,11 +1174,13 @@ def _read_content_file(content_file: str) -> str:
     if not p.is_file():
         raise ValueError(f"路径不是文件: {content_file}")
     try:
-        return p.read_text(encoding="utf-8")
+        raw = p.read_text(encoding="utf-8")
     except PermissionError:
         raise ValueError(f"无权限读取文件: {content_file}")
     except UnicodeDecodeError:
         raise ValueError(f"文件编码错误（需要 UTF-8）: {content_file}")
+
+    return _strip_frontmatter(raw)
 
 
 def _edit_impl(

--- a/tests/test_content_file.py
+++ b/tests/test_content_file.py
@@ -1,7 +1,6 @@
 """测试 _read_content_file 对含 frontmatter 文件的处理"""
 
 import tempfile
-from pathlib import Path
 
 from jfox.cli import _read_content_file
 

--- a/tests/test_content_file.py
+++ b/tests/test_content_file.py
@@ -1,0 +1,64 @@
+"""测试 _read_content_file 对含 frontmatter 文件的处理"""
+
+import tempfile
+from pathlib import Path
+
+from jfox.cli import _read_content_file
+
+
+class TestReadContentFile:
+    """_read_content_file 的单元测试"""
+
+    def test_plain_content_unchanged(self):
+        """纯文本内容应原样返回"""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", delete=False, encoding="utf-8"
+        ) as f:
+            f.write("Hello world")
+            f.flush()
+            result = _read_content_file(f.name)
+        assert result == "Hello world"
+
+    def test_content_with_frontmatter_stripped(self):
+        """含 frontmatter 的文件应只返回正文"""
+        raw = "---\nid: '123'\ntitle: test\n---\n\n# test\n\nBody text\n"
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", delete=False, encoding="utf-8"
+        ) as f:
+            f.write(raw)
+            f.flush()
+            result = _read_content_file(f.name)
+        assert "---" not in result
+        assert "Body text" in result
+
+    def test_content_with_frontmatter_no_title(self):
+        """含 frontmatter 但无标题行的文件"""
+        raw = "---\nid: '123'\ntitle: test\n---\n\nJust body text\n"
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", delete=False, encoding="utf-8"
+        ) as f:
+            f.write(raw)
+            f.flush()
+            result = _read_content_file(f.name)
+        assert "---" not in result
+        assert "Just body text" in result
+
+    def test_stdin_passthrough(self):
+        """stdin 模式（'-'）不应做处理"""
+        import io
+        import sys
+
+        old_stdin = sys.stdin
+        try:
+            sys.stdin = io.StringIO("---\nid: x\n---\nbody")
+            result = _read_content_file("-")
+        finally:
+            sys.stdin = old_stdin
+        assert "---" in result
+
+    def test_file_not_found(self):
+        """不存在的文件应抛异常"""
+        import pytest
+
+        with pytest.raises(ValueError, match="文件不存在"):
+            _read_content_file("/nonexistent/file.md")

--- a/tests/unit/test_content_file.py
+++ b/tests/unit/test_content_file.py
@@ -1,6 +1,9 @@
 """测试 _read_content_file 对含 frontmatter 文件的处理"""
 
+import io
 import tempfile
+
+import pytest
 
 from jfox.cli import _read_content_file
 
@@ -44,7 +47,6 @@ class TestReadContentFile:
 
     def test_stdin_passthrough(self):
         """stdin 模式（'-'）不应做处理"""
-        import io
         import sys
 
         old_stdin = sys.stdin
@@ -57,7 +59,18 @@ class TestReadContentFile:
 
     def test_file_not_found(self):
         """不存在的文件应抛异常"""
-        import pytest
-
         with pytest.raises(ValueError, match="文件不存在"):
             _read_content_file("/nonexistent/file.md")
+
+    def test_bom_file_stripped(self):
+        """含 UTF-8 BOM 的 frontmatter 文件应正确剥离"""
+        raw = "---\nid: '123'\ntitle: test\n---\n\nBody with BOM\n"
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".md", delete=False
+        ) as f:
+            f.write(raw.encode("utf-8-sig"))
+            f.flush()
+            result = _read_content_file(f.name)
+        assert "---" not in result
+        assert "Body with BOM" in result
+

--- a/tests/unit/test_content_file.py
+++ b/tests/unit/test_content_file.py
@@ -65,12 +65,9 @@ class TestReadContentFile:
     def test_bom_file_stripped(self):
         """含 UTF-8 BOM 的 frontmatter 文件应正确剥离"""
         raw = "---\nid: '123'\ntitle: test\n---\n\nBody with BOM\n"
-        with tempfile.NamedTemporaryFile(
-            mode="wb", suffix=".md", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".md", delete=False) as f:
             f.write(raw.encode("utf-8-sig"))
             f.flush()
             result = _read_content_file(f.name)
         assert "---" not in result
         assert "Body with BOM" in result
-


### PR DESCRIPTION
## Summary
- `_read_content_file` now strips YAML frontmatter and title headers from file content before returning, preventing duplicate frontmatter when a jfox note file is passed to `edit --content-file` or `add --content-file`
- Stdin mode (`-`) remains exempt — raw content passes through unchanged
- 5 new unit tests covering plain content, frontmatter+title, frontmatter only, stdin, and file-not-found

Closes #198

## Test plan
- [x] `uv run pytest tests/test_content_file.py -v` — 5/5 passed
- [x] Red-green regression verified (tests fail without fix, pass with fix)
- [x] `uv run ruff check jfox/cli.py` — clean
- [x] `uv run black --check jfox/cli.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)