### PR TITLE
fix: atomic file writes to prevent 0-byte note corruption (#201)

### DIFF
--- a/jfox/note.py
+++ b/jfox/note.py
@@ -1,6 +1,8 @@
 """笔记 CRUD 操作"""
 
 import logging
+import os
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -57,6 +59,22 @@ def create_note(
     )
 
     return note
+
+
+def _atomic_write(filepath: Path, content: str) -> None:
+    """原子写入：先写临时文件再 rename，防止崩溃产生空文件"""
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=filepath.parent, suffix=".tmp")
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp_path, filepath)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def save_note(note: Note, add_to_index: bool = True) -> bool:

--- a/jfox/note.py
+++ b/jfox/note.py
@@ -62,7 +62,7 @@ def create_note(
 
 
 def _atomic_write(filepath: Path, content: str) -> None:
-    """原子写入：先写临时文件再 rename，防止崩溃产生空文件"""
+    """原子写入：先写临时文件再原子替换，防止崩溃产生空文件"""
     filepath.parent.mkdir(parents=True, exist_ok=True)
     tmp_fd, tmp_path = tempfile.mkstemp(dir=filepath.parent, suffix=".tmp")
     try:
@@ -80,12 +80,7 @@ def _atomic_write(filepath: Path, content: str) -> None:
 def save_note(note: Note, add_to_index: bool = True) -> bool:
     """保存笔记到文件"""
     try:
-        # 确保目录存在
-        note.filepath.parent.mkdir(parents=True, exist_ok=True)
-
-        # 写入文件
-        with open(note.filepath, "w", encoding="utf-8") as f:
-            f.write(note.to_markdown())
+        _atomic_write(note.filepath, note.to_markdown())
 
         logger.info(f"Saved note to {note.filepath}")
 
@@ -283,9 +278,7 @@ def update_note(note_obj: Note, add_to_index: bool = True) -> bool:
         note_obj.updated = datetime.now()
 
         # 写入新文件（filepath 属性根据当前字段生成）
-        note_obj.filepath.parent.mkdir(parents=True, exist_ok=True)
-        with open(note_obj.filepath, "w", encoding="utf-8") as f:
-            f.write(note_obj.to_markdown())
+        _atomic_write(note_obj.filepath, note_obj.to_markdown())
 
         # 如果文件路径变了（标题修改导致重命名），删除旧文件
         if old_filepath != note_obj.filepath and old_filepath.exists():

--- a/jfox/note.py
+++ b/jfox/note.py
@@ -64,16 +64,31 @@ def create_note(
 def _atomic_write(filepath: Path, content: str) -> None:
     """原子写入：先写临时文件再原子替换，防止崩溃产生空文件"""
     filepath.parent.mkdir(parents=True, exist_ok=True)
-    tmp_fd, tmp_path = tempfile.mkstemp(dir=filepath.parent, suffix=".tmp")
+    tmp_fd = -1
+    tmp_path = ""
     try:
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=filepath.parent, suffix=".tmp")
         with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            tmp_fd = -1  # fd 已移交 fdopen 管理
             f.write(content)
+        # 保留目标文件权限（如已存在）
+        if filepath.exists():
+            try:
+                os.chmod(tmp_path, filepath.stat().st_mode)
+            except OSError:
+                pass
         os.replace(tmp_path, filepath)
     except BaseException:
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
+        if tmp_fd >= 0:
+            try:
+                os.close(tmp_fd)
+            except OSError:
+                pass
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
         raise
 
 

--- a/jfox/performance.py
+++ b/jfox/performance.py
@@ -9,6 +9,8 @@ import time
 from functools import wraps
 from typing import Any, Callable, List, Optional
 
+from .note import _atomic_write
+
 logger = logging.getLogger(__name__)
 
 
@@ -237,9 +239,7 @@ def bulk_import_notes(
             # 批量保存（不索引）
             for note in notes:
                 try:
-                    note.filepath.parent.mkdir(parents=True, exist_ok=True)
-                    with open(note.filepath, "w", encoding="utf-8") as f:
-                        f.write(note.to_markdown())
+                    _atomic_write(note.filepath, note.to_markdown())
                     imported += 1
                 except Exception as e:
                     logger.warning(f"Failed to save note: {e}")

--- a/tests/unit/test_atomic_write.py
+++ b/tests/unit/test_atomic_write.py
@@ -7,8 +7,7 @@
 
 import os
 import tempfile
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/unit/test_atomic_write.py
+++ b/tests/unit/test_atomic_write.py
@@ -8,13 +8,21 @@
 import os
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
-from jfox.note import _atomic_write
+from jfox.config import ZKConfig
+from jfox.models import NoteType
+from jfox.note import (
+    _atomic_write,
+    create_note,
+    find_note_file,
+    save_note,
+    update_note,
+)
 
 
 class TestAtomicWrite:
@@ -74,3 +82,85 @@ class TestAtomicWrite:
 
         # 目标文件不受影响
         assert filepath.read_text(encoding="utf-8") == "original"
+
+
+class TestUpdateNoteAtomic:
+    """测试 update_note 使用原子写入"""
+
+    def _make_config(self, tmp_path):
+        cfg = ZKConfig(base_dir=tmp_path)
+        cfg.ensure_dirs()
+        return cfg
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_update_note_no_zero_byte_on_failure(
+        self, mock_global_config, mock_note_config, tmp_path
+    ):
+        """update_note 写入失败时不留 0 字节文件"""
+        cfg = self._make_config(tmp_path)
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        n = create_note("original", title="Test", note_type=NoteType.PERMANENT)
+        save_note(n, add_to_index=False)
+
+        # 修改内容
+        n.content = "modified"
+
+        # 模拟 _atomic_write 失败
+        with patch("jfox.note._atomic_write", side_effect=RuntimeError("boom")):
+            result = update_note(n, add_to_index=False)
+
+        assert result is False
+        # 磁盘上原文件不变
+        old_file = find_note_file(cfg, n.id)
+        assert old_file is not None
+        assert "original" in old_file.read_text(encoding="utf-8")
+
+
+class TestSaveNoteAtomic:
+    """测试 save_note 使用原子写入"""
+
+    def _make_config(self, tmp_path):
+        cfg = ZKConfig(base_dir=tmp_path)
+        cfg.ensure_dirs()
+        return cfg
+
+    @patch("jfox.note.config")
+    def test_save_note_uses_atomic_write(self, mock_config, tmp_path):
+        """save_note 应通过 _atomic_write 写入"""
+        cfg = self._make_config(tmp_path)
+        mock_config.notes_dir = cfg.notes_dir
+
+        n = create_note("test content", title="Test", note_type=NoteType.FLEETING)
+
+        with patch("jfox.note._atomic_write", wraps=_atomic_write) as mock_aw:
+            save_note(n, add_to_index=False)
+            mock_aw.assert_called_once()
+
+        # 验证文件内容正确
+        assert n.filepath.exists()
+        content = n.filepath.read_text(encoding="utf-8")
+        assert "test content" in content
+
+    @patch("jfox.note.config")
+    def test_save_note_no_zero_byte_on_failure(self, mock_config, tmp_path):
+        """save_note 写入失败时不留 0 字节文件"""
+        cfg = self._make_config(tmp_path)
+        mock_config.notes_dir = cfg.notes_dir
+
+        n = create_note("content", title="Test", note_type=NoteType.FLEETING)
+        n.set_filepath(cfg.notes_dir / "fleeting" / "test.md")
+
+        # 先创建一个有内容的文件
+        n.filepath.parent.mkdir(parents=True, exist_ok=True)
+        n.filepath.write_text("original content", encoding="utf-8")
+
+        # 模拟 _atomic_write 失败
+        with patch("jfox.note._atomic_write", side_effect=RuntimeError("boom")):
+            result = save_note(n, add_to_index=False)
+
+        assert result is False
+        # 原文件不受影响（不会被截断为 0 字节）
+        assert n.filepath.read_text(encoding="utf-8") == "original content"

--- a/tests/unit/test_atomic_write.py
+++ b/tests/unit/test_atomic_write.py
@@ -1,0 +1,76 @@
+"""
+测试类型: 单元测试
+目标模块: jfox.note (_atomic_write 函数)
+预估耗时: < 1秒
+依赖要求: 无外部依赖
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+from jfox.note import _atomic_write
+
+
+class TestAtomicWrite:
+    """测试 _atomic_write 原子写入"""
+
+    def test_normal_write(self, tmp_path):
+        """正常写入：文件内容正确"""
+        filepath = tmp_path / "test.md"
+        _atomic_write(filepath, "hello world")
+        assert filepath.read_text(encoding="utf-8") == "hello world"
+
+    def test_creates_parent_dir(self, tmp_path):
+        """目标目录不存在时自动创建"""
+        filepath = tmp_path / "sub" / "dir" / "test.md"
+        _atomic_write(filepath, "content")
+        assert filepath.read_text(encoding="utf-8") == "content"
+
+    def test_overwrites_existing(self, tmp_path):
+        """覆盖已有文件时内容正确"""
+        filepath = tmp_path / "test.md"
+        filepath.write_text("old content", encoding="utf-8")
+        _atomic_write(filepath, "new content")
+        assert filepath.read_text(encoding="utf-8") == "new content"
+
+    def test_no_tmp_file_on_write_failure(self, tmp_path):
+        """写入失败时不留临时文件，原文件不受影响"""
+        filepath = tmp_path / "test.md"
+        filepath.write_text("original", encoding="utf-8")
+
+        # 模拟写入过程中异常
+        with patch("os.replace", side_effect=OSError("disk full")):
+            with pytest.raises(OSError, match="disk full"):
+                _atomic_write(filepath, "new content")
+
+        # 原文件不受影响
+        assert filepath.read_text(encoding="utf-8") == "original"
+        # 无 .tmp 残留
+        tmp_files = list(tmp_path.glob("*.tmp"))
+        assert len(tmp_files) == 0
+
+    def test_no_empty_file_on_crash(self, tmp_path):
+        """崩溃后不会产生 0 字节目标文件"""
+        filepath = tmp_path / "test.md"
+        filepath.write_text("original", encoding="utf-8")
+
+        original_mkstemp = tempfile.mkstemp
+
+        def failing_mkstemp(**kwargs):
+            fd, path = original_mkstemp(**kwargs)
+            os.write(fd, b"partial")
+            os.close(fd)
+            raise KeyboardInterrupt
+
+        with patch("tempfile.mkstemp", side_effect=failing_mkstemp):
+            with pytest.raises(KeyboardInterrupt):
+                _atomic_write(filepath, "new content")
+
+        # 目标文件不受影响
+        assert filepath.read_text(encoding="utf-8") == "original"


### PR DESCRIPTION
## Summary

- Add `_atomic_write()` using write-to-temp + `os.replace()` pattern to prevent 0-byte files on process crash
- Refactor `save_note()`, `update_note()`, and `performance.py` batch import to use atomic writes
- Add 8 unit tests covering normal writes, crash safety, and temp file cleanup

Closes #201

## Root Cause

`open(path, "w")` immediately truncates the file to 0 bytes before writing content. If the process crashes between truncate and write (agent timeout, Ctrl+C, OOM), a 0-byte file is left behind.

## Fix

Write to a temp file first, then atomically rename via `os.replace()`. On any exception (including `KeyboardInterrupt`), the temp file is cleaned up and the original file remains untouched.

## Test plan

- [x] `tests/unit/test_atomic_write.py` — 8 tests pass
- [x] Normal write produces correct content
- [x] Crash during write leaves original file intact (no 0-byte file)
- [x] Temp files cleaned up on failure
- [x] `save_note` and `update_note` delegate to `_atomic_write`
- [x] ruff + black pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)