### PR TITLE
feat: add Claude Code plugin packaging (#209)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "jfox-skills",
+  "id": "jfox-skills",
+  "owner": { "name": "zhuxixi" },
+  "metadata": {
+    "description": "JFox Zettelkasten 知识管理工具的 Claude Code 集成",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "jfox",
+      "source": "./",
+      "description": "JFox 知识管理 CLI 的 Claude Code 集成——搜索、导入、整理、会话总结",
+      "version": "0.1.0",
+      "author": { "name": "zhuxixi" },
+      "keywords": ["zettelkasten", "knowledge-management"],
+      "category": "workflow"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "jfox",
+  "description": "JFox 知识管理 CLI 的 Claude Code 集成——搜索、导入、整理、会话总结",
+  "version": "0.1.0",
+  "author": { "name": "zhuxixi" },
+  "license": "MIT",
+  "keywords": ["zettelkasten", "knowledge-management", "cli"],
+  "skills": [
+    "./skills-recommend/claude-code/jfox-common",
+    "./skills-recommend/claude-code/jfox-ingest",
+    "./skills-recommend/claude-code/jfox-organize",
+    "./skills-recommend/claude-code/jfox-search",
+    "./skills-recommend/claude-code/jfox-session-summary"
+  ],
+  "commands": [
+    "./commands/jfox-common",
+    "./commands/jfox-ingest",
+    "./commands/jfox-organize",
+    "./commands/jfox-search",
+    "./commands/jfox-session-summary"
+  ]
+}

--- a/commands/jfox-common.md
+++ b/commands/jfox-common.md
@@ -1,0 +1,6 @@
+---
+name: jfox-common
+description: 管理知识库（创建、切换、健康检查）和笔记 CRUD
+---
+
+请调用 jfox-common skill 来完成用户的请求。传递用户提供的参数。

--- a/commands/jfox-ingest.md
+++ b/commands/jfox-ingest.md
@@ -1,0 +1,6 @@
+---
+name: jfox-ingest
+description: 从 Git 仓库导入数据（git log、PR、Issues）为 fleeting 笔记
+---
+
+请调用 jfox-ingest skill 来完成用户的请求。传递用户提供的参数。

--- a/commands/jfox-organize.md
+++ b/commands/jfox-organize.md
@@ -1,0 +1,6 @@
+---
+name: jfox-organize
+description: 整理知识库、提炼 fleeting 笔记为 permanent、生成 wiki links
+---
+
+请调用 jfox-organize skill 来完成用户的请求。传递用户提供的参数。

--- a/commands/jfox-search.md
+++ b/commands/jfox-search.md
@@ -1,0 +1,6 @@
+---
+name: jfox-search
+description: 搜索笔记、图谱查询、链接推荐
+---
+
+请调用 jfox-search skill 来完成用户的请求。传递用户提供的参数。

--- a/commands/jfox-session-summary.md
+++ b/commands/jfox-session-summary.md
@@ -1,0 +1,6 @@
+---
+name: jfox-session-summary
+description: 保存会话总结到知识库作为 fleeting 笔记
+---
+
+请调用 jfox-session-summary skill 来完成用户的请求。传递用户提供的参数。


### PR DESCRIPTION
## Summary

- Add `.claude-plugin/` manifest (`plugin.json` + `marketplace.json`) enabling marketplace installation
- Add 5 slash commands (`/jfox-common`, `/jfox-ingest`, `/jfox-organize`, `/jfox-search`, `/jfox-session-summary`)
- No existing files modified — `skills-recommend/` directory unchanged

## Installation (after merge)

```bash
/plugin marketplace add https://github.com/zhuxixi/jfox
/plugin marketplace install jfox
```

## Test plan

- [ ] Add jfox repo as marketplace source
- [ ] Install jfox plugin from marketplace
- [ ] Test `/jfox-search` command triggers skill correctly
- [ ] Test `/jfox-common` health check works
- [ ] Verify skills auto-trigger by description keywords

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)