### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to jfox-cli will be documented in this file.
 
+## [0.8.0] - 2026-05-10
+
+### Features
+- add Claude Code plugin packaging for jfox skills (#209) (#210)
+- 新增 session 笔记类型，专存 AI Agent 会话记录 (#202)
+
+### Changes
+- sync AGENTS.md with CLAUDE.md and current codebase (#208)
+
+[0.8.0]: https://github.com/zhuxixi/jfox/compare/v0.7.2...v0.8.0
+
 ## [0.7.2] - 2026-05-07
 
 ### Fixes

--- a/jfox/__init__.py
+++ b/jfox/__init__.py
@@ -1,5 +1,5 @@
 """JFox - Zettelkasten 知识管理工具"""
 
-__version__ = "0.7.2"
+__version__ = "0.8.0"
 __author__ = "User"
 __email__ = "user@example.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jfox-cli"
-version = "0.7.2"
+version = "0.8.0"
 description = "JFox - Zettelkasten 知识管理 CLI 工具"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -867,7 +867,7 @@ wheels = [
 
 [[package]]
 name = "jfox-cli"
-version = "0.7.2"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary
Bump version from 0.7.2 to 0.8.0

## [0.8.0] - 2026-05-10

### Features
- add Claude Code plugin packaging for jfox skills (#210)
- 新增 session 笔记类型，专存 AI Agent 会话记录 (#202)

### Changes
- sync AGENTS.md with CLAUDE.md and current codebase (#208)

[0.8.0]: https://github.com/zhuxixi/jfox/compare/v0.7.2...v0.8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)