### PR TITLE
fix(plugin): correct commands paths in plugin.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,14 +4,14 @@
   "owner": { "name": "zhuxixi" },
   "metadata": {
     "description": "JFox Zettelkasten 知识管理工具的 Claude Code 集成",
-    "version": "0.1.0"
+    "version": "0.1.1"
   },
   "plugins": [
     {
       "name": "jfox",
       "source": "./",
       "description": "JFox 知识管理 CLI 的 Claude Code 集成——搜索、导入、整理、会话总结",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": { "name": "zhuxixi" },
       "keywords": ["zettelkasten", "knowledge-management"],
       "category": "workflow"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jfox",
   "description": "JFox 知识管理 CLI 的 Claude Code 集成——搜索、导入、整理、会话总结",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": { "name": "zhuxixi" },
   "license": "MIT",
   "keywords": ["zettelkasten", "knowledge-management", "cli"],
@@ -13,10 +13,10 @@
     "./skills-recommend/claude-code/jfox-session-summary"
   ],
   "commands": [
-    "./commands/jfox-common",
-    "./commands/jfox-ingest",
-    "./commands/jfox-organize",
-    "./commands/jfox-search",
-    "./commands/jfox-session-summary"
+    "../commands/jfox-common",
+    "../commands/jfox-ingest",
+    "../commands/jfox-organize",
+    "../commands/jfox-search",
+    "../commands/jfox-session-summary"
   ]
 }


### PR DESCRIPTION
## Summary
Fix 5 plugin load errors caused by incorrect relative paths for commands in plugin.json.

Commands paths changed from `./commands/...` to `../commands/...` since plugin.json is in `.claude-plugin/` subdirectory but commands are at repo root.

Bump plugin version from 0.1.0 to 0.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)