### PR TITLE
fix(plugin): remove commands field, let Claude Code auto-discover

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,14 +4,14 @@
   "owner": { "name": "zhuxixi" },
   "metadata": {
     "description": "JFox Zettelkasten 知识管理工具的 Claude Code 集成",
-    "version": "0.1.1"
+    "version": "0.1.2"
   },
   "plugins": [
     {
       "name": "jfox",
       "source": "./",
       "description": "JFox 知识管理 CLI 的 Claude Code 集成——搜索、导入、整理、会话总结",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "author": { "name": "zhuxixi" },
       "keywords": ["zettelkasten", "knowledge-management"],
       "category": "workflow"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jfox",
   "description": "JFox 知识管理 CLI 的 Claude Code 集成——搜索、导入、整理、会话总结",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": { "name": "zhuxixi" },
   "license": "MIT",
   "keywords": ["zettelkasten", "knowledge-management", "cli"],
@@ -11,12 +11,5 @@
     "./skills-recommend/claude-code/jfox-organize",
     "./skills-recommend/claude-code/jfox-search",
     "./skills-recommend/claude-code/jfox-session-summary"
-  ],
-  "commands": [
-    "../commands/jfox-common",
-    "../commands/jfox-ingest",
-    "../commands/jfox-organize",
-    "../commands/jfox-search",
-    "../commands/jfox-session-summary"
   ]
 }


### PR DESCRIPTION
## Summary
Remove explicit `commands` field from plugin.json. Claude Code auto-discovers `commands/` directory at repo root, similar to how official plugins work. The `../commands/` relative path was rejected by the plugin validator.

Plugin version bumped to 0.1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)