### PR TITLE
refactor(plugin): rename kb skill to manage and dedup CRUD docs

### DIFF
--- a/docs/claude-code-plugin-guide.md
+++ b/docs/claude-code-plugin-guide.md
@@ -786,7 +786,7 @@ jfox/                                  # 仓库根目录
 │       ├── .claude-plugin/
 │       │   └── plugin.json            # 插件清单（仅元数据，无 skills 声明 → auto-discovery）
 │       └── skills/                    # 自动发现的 skills
-│           ├── kb/SKILL.md
+│           ├── manage/SKILL.md
 │           ├── ingest/SKILL.md
 │           ├── organize/SKILL.md
 │           ├── search/SKILL.md
@@ -804,5 +804,5 @@ jfox/                                  # 仓库根目录
 - Python 包版本：`0.8.0`
 - Skills 通过 auto-discovery（无 skills 字段）
 - Commands 已删除（曾是 skill shim 反模式）
-- Skill 命名移除 `jfox-` 前缀：`/jfox:search` / `/jfox:kb` / `/jfox:ingest` / `/jfox:organize` / `/jfox:session-summary`
+- Skill 命名移除 `jfox-` 前缀：`/jfox:search` / `/jfox:manage` / `/jfox:ingest` / `/jfox:organize` / `/jfox:session-summary`（`kb` → `manage` rename for clarity）
 - Plugin source 拆出至 `packages/cc-plugin/`，与 `skills-recommend/kimi-cli/` 解耦

--- a/packages/cc-plugin/skills/ingest/SKILL.md
+++ b/packages/cc-plugin/skills/ingest/SKILL.md
@@ -17,7 +17,7 @@ description: Use when user wants to import data from a local git repository into
    ```bash
    jfox kb list --format json
    ```
-   如果没有知识库，提示用户先调用 kb 技能（`/jfox:kb`）创建。
+   如果没有知识库，提示用户先调用 manage 技能（`/jfox:manage`）创建。
 
 2. `git` 命令可用。
 
@@ -192,12 +192,7 @@ jfox bulk-import temp-file.json --type fleeting --kb name
 
 ## 手动输入支持
 
-如果用户直接粘贴文本（未提供仓库路径），将文本整理为单条 fleeting 笔记并导入：
-```bash
-jfox add "<content>" --title "<title>" --type fleeting --tag <tags> [--kb <name>]
-```
-
-> **约定**：`jfox add` 支持 `--format json` 输出 JSON，也可使用快捷方式 `--json`（两者等价）。
+如果用户直接粘贴文本（未提供仓库路径），将文本整理为单条 fleeting 笔记并导入。导入仍遵循下文「笔记格式规范」中的 `source:*` 标签约定；`jfox add` 完整语法与 `--kb` / `--json` / `--content-file` 共享约定详见 `/jfox:manage` §4。
 
 ## 笔记格式规范
 
@@ -237,20 +232,16 @@ jfox search "repo-name" --format json
 # 导入 GitHub 数据
 jfox bulk-import file.json --type fleeting --kb name
 
-# 手动添加单条笔记
-jfox add "content" --title "title" --type fleeting --kb name
-
-# 查看导入结果
-jfox show <note_id> --format json --kb name
-
 # 批量导入加速（可选）
 jfox daemon start                                # 启动 embedding 守护进程
 jfox daemon stop                                 # 完成后停止
 ```
 
+> 单条笔记命令（`jfox add` / `edit` / `delete` / `show` 等）的完整语法详见 `/jfox:manage` §4，共享约定见 §4.1。
+
 ## 错误处理
 
 - **"Not a git repository"**: `jfox ingest-log` 会报错，提示用户提供正确的仓库路径
 - **`gh: not found`** 或 `gh auth status` 失败: 跳过 GitHub PR/Issues 导入，仅用 `jfox ingest-log` 导入 git log
-- **"Knowledge base not found"**: 提示用户先调用 kb 技能（`/jfox:kb`）创建知识库
+- **"Knowledge base not found"**: 提示用户先调用 manage 技能（`/jfox:manage`）创建知识库
 - **Bulk import 部分失败**: 报告成功/失败数量，失败记录不重试

--- a/packages/cc-plugin/skills/manage/SKILL.md
+++ b/packages/cc-plugin/skills/manage/SKILL.md
@@ -1,13 +1,20 @@
 ---
-name: kb
-description: Use when user wants to create, manage, or check the health of a Zettelkasten knowledge base. Triggers on "创建知识库", "初始化", "知识库管理", "检查知识库", "知识库健康", "知识库体检", "health check", "create knowledge base", "init", "kb management", "知识库诊断".
+name: manage
+description: |
+  Use when user wants to create, manage, or check the health of a Zettelkasten knowledge
+  base, look up the canonical reference for any jfox note command (add/edit/delete/
+  list/show/refs/daily), or start/stop the embedding daemon. Triggers on "创建知识库",
+  "初始化", "知识库管理", "切换知识库", "重命名知识库", "删除知识库", "检查知识库",
+  "知识库健康", "知识库体检", "知识库诊断", "守护进程", "启动 daemon", "停止 daemon",
+  "kb status", "create knowledge base", "init", "kb management", "health check",
+  "knowledge base decay", "jfox 命令参考", "jfox CRUD", "embedding daemon".
 ---
 
-# JFox 知识库管理与健康检查
+# JFox 知识库管理、命令参考与健康检查
 
-管理知识库的完整生命周期：创建、切换、查看状态，以及定期健康检查与衰减信号检测。将知识库管理（低频操作）与健康管理合并为一个技能。
+管理知识库的完整生命周期；作为 jfox 笔记命令（add/edit/delete/list/show/refs/daily）的权威参考；提供定期健康检查与衰减信号检测。
 
-## 前置条件
+## 1. 前置条件
 
 确认 jfox 已安装：
 ```bash
@@ -15,7 +22,7 @@ jfox --version
 ```
 未安装时：`uv tool install jfox-cli`
 
-## 知识库路径约定
+## 2. 知识库路径约定
 
 所有知识库存储在 `~/.zettelkasten/` 下：
 
@@ -27,17 +34,17 @@ jfox --version
 
 自定义路径须在 `~/.zettelkasten/` 下（CLI 强制限制）。
 
-## 知识库管理
+## 3. 知识库生命周期
 
-### 检查现有知识库
+### 3.1 检查现有知识库
 
 ```bash
-jfox kb list --format json
+jfox kb list --json
 ```
 
 如果已有知识库，告知用户并询问是使用现有知识库还是创建新知识库。
 
-### 创建知识库
+### 3.2 创建知识库
 
 **默认知识库（首次使用）：**
 ```bash
@@ -61,27 +68,48 @@ jfox init --name personal --desc "个人知识库"
 jfox init --name <name> --path ~/.zettelkasten/<custom-path>
 ```
 
-### 创建后验证
+### 3.3 创建后验证
 
 ```bash
-jfox kb current --format json
-jfox status --format json
+jfox kb current --json
+jfox status --json
 ```
 
 确认知识库已注册、目录结构已创建、状态显示 0 条笔记。
 
-### 管理命令
+### 3.4 切换与重命名
 
 ```bash
 jfox kb switch <name>               # 切换知识库
-jfox kb info <name> --format json   # 查看详情
-jfox kb current --format json       # 当前知识库
+jfox kb info <name> --json          # 查看详情
+jfox kb current --json              # 当前知识库
 jfox kb rename <old> <new>          # 重命名
 ```
 
-## 笔记 CRUD
+### 3.5 删除知识库
 
-### 添加笔记
+```bash
+jfox kb remove <name>               # 仅注销，保留笔记文件
+jfox kb remove <name> --force       # 删除知识库（含笔记文件，不可恢复）
+```
+
+### 3.6 查看状态
+
+```bash
+jfox status --json                  # 当前知识库状态
+```
+
+## 4. Canonical 笔记 CRUD 参考
+
+> **本节是 jfox 笔记命令的权威参考；ingest、organize、session-summary 技能直接引用此处，仅在文档中记录自身工作流相关的差异（如标签命名、特殊参数）。**
+
+### 4.1 共享约定
+
+- 所有命令均支持 `--kb <name>` 指定目标知识库，省略时使用当前默认知识库
+- 大部分命令支持 `--format json` 输出 JSON，也可使用快捷方式 `--json`（两者等价）。下文示例统一使用 `--json`。**例外**：`jfox show` 仅输出原始 Markdown，无 JSON 模式
+- 长内容或含特殊字符时，使用 `--content-file <path>` 从文件读取；`--content-file -` 表示从 stdin 读取，可避免 shell 转义问题
+
+### 4.2 添加笔记
 
 ```bash
 # 快速添加（内容直接作为参数）
@@ -104,8 +132,9 @@ jfox add --template meeting --title "周会记录"
 - `fleeting`（默认）— 快速捕获，稍后提炼
 - `literature` — 阅读笔记
 - `permanent` — 已提炼的知识
+- `session` — AI Agent 会话记录（用法及 `--topic` 必填参数详见 `/jfox:session-summary`）
 
-### 编辑笔记
+### 4.3 编辑笔记
 
 ```bash
 # 编辑内容和标题
@@ -123,49 +152,35 @@ jfox edit <note_id> --kb work --content "新内容"
 
 编辑会保留原始笔记 ID 和创建时间。
 
-### 删除笔记
+### 4.4 删除笔记
 
 ```bash
 jfox delete <note_id>               # 需确认
 jfox delete <note_id> --force       # 跳过确认
 ```
 
-### 查看笔记
+### 4.5 查看笔记
 
 ```bash
-jfox list --format json --limit 50              # 列出笔记
-jfox list --type permanent --format json         # 按类型筛选
-jfox daily --json                                # 今天的笔记
-jfox daily --date 2026-04-01 --json              # 指定日期
-jfox refs --search "<标题>" --format json        # 查看反向链接
+jfox show <id_or_title>                         # 查看笔记完整内容（输出 Markdown，不支持 --json）
+jfox list --json --limit 50                     # 列出笔记
+jfox list --type permanent --json               # 按类型筛选
+jfox daily --json                               # 今天的笔记
+jfox daily --date 2026-04-01 --json             # 指定日期
+jfox refs --search "<标题>" --json              # 查看反向链接
 ```
 
-### 删除知识库
-
-```bash
-jfox kb remove <name>               # 仅注销，保留笔记文件
-jfox kb remove <name> --force       # 删除知识库（含笔记文件，不可恢复）
-```
-
-### 查看状态
-
-```bash
-jfox status --format json           # 当前知识库状态
-```
-
-所有命令均支持 `--kb <name>` 指定目标知识库，省略时使用当前默认知识库。
-
-## 健康检查
+## 5. 健康检查
 
 通过组合多个 jfox 命令采集指标，综合评估知识库健康状况。没有单独的 "health" 命令，需要从多个数据源收集并综合分析。
 
 > 如果用户指定了目标知识库名称，在以下所有命令中追加 `--kb <name>` 参数。未指定时省略，使用当前默认知识库。
 
-### 6 项指标采集
+### 5.1 6 项指标采集
 
 ```bash
 # 1. 知识库总体状态
-jfox status --format json [--kb <name>]
+jfox status --json [--kb <name>]
 
 # 2. 图谱指标（--stats 和 --orphans 互斥，分开运行）
 jfox graph --stats --json [--kb <name>]
@@ -177,13 +192,13 @@ jfox graph --orphans --json [--kb <name>]
 jfox index verify [--kb <name>]
 
 # 5. 笔记清单（用于类型分布和日期分析）
-jfox list --format json --limit 500 [--kb <name>]
+jfox list --json --limit 500 [--kb <name>]
 
-# 6. 未处理收件箱
+# 6. 未处理收件箱（fleeting + session 笔记）
 jfox inbox --json --limit 100 [--kb <name>]
 ```
 
-### 健康指标表
+### 5.2 健康指标表
 
 从采集数据中计算以下指标：
 
@@ -191,12 +206,12 @@ jfox inbox --json --limit 100 [--kb <name>]
 |------|---------|------|------|------|
 | **孤立比例** | `isolated_nodes / total_nodes` | < 20% | 20-40% | > 40% |
 | **平均连接度** | `avg_degree` (图谱统计) | > 2.0 | 1.0-2.0 | < 1.0 |
-| **收件箱积压** | fleeting 笔记数量 | < 10 | 10-30 | > 30 |
+| **收件箱积压** | `jfox inbox` 返回的 fleeting + session 笔记数 | < 10 | 10-30 | > 30 |
 | **索引完整性** | `jfox index verify` 结果 | 全部通过 | -- | 任何异常 |
 | **连通率** | `(total_nodes - isolated_nodes) / total_nodes` | > 0.8 | 0.6-0.8 | < 0.6 |
 | **类型平衡** | fleeting 占 total 比例 | fleeting < 30% | 30-50% | > 50% |
 
-### 衰减信号检测
+### 5.3 衰减信号检测
 
 分析指标，检测以下 5 种衰减模式：
 
@@ -225,7 +240,7 @@ jfox inbox --json --limit 100 [--kb <name>]
 - **原因**：过度依赖少数"枢纽"笔记
 - **修复**：创建中间笔记以分散连接
 
-### 评分系统
+### 5.4 评分系统
 
 计算总体评分（0-100）：
 
@@ -247,7 +262,7 @@ Score = 100
 | 40-59 | D | 较差 -- 明显衰减 |
 | 0-39 | F | 危险 -- 需要立即处理 |
 
-### 报告格式
+### 5.5 报告格式
 
 按以下格式呈现健康报告：
 
@@ -280,31 +295,39 @@ Score = 100
 - ⚠️ 警告 / 需关注
 - ❌ 危险 / 异常
 
-### 运行时机建议
+### 5.6 运行时机建议
 
 - **每周一次**：作为定期知识管理流程的快速健康检查
 - **批量导入后**：验证索引和连接是否健康
 - **整理前**：识别需要优先关注的区域
 - **感觉知识库停滞时**：检测具体的衰减模式以对症下药
 
-## 命令参考
+## 6. Daemon
 
-以下仅列出知识库管理、笔记 CRUD 和健康检查相关命令。所有命令支持 `--kb <name>` 指定知识库，省略时使用当前默认知识库。
+```bash
+jfox daemon start                               # 启动 embedding 守护进程
+jfox daemon stop                                # 停止守护进程
+jfox daemon status                              # 查看 PID、端口、模型信息
+```
 
-**约定**：所有命令均支持 `--format json` 输出 JSON，也可使用快捷方式 `--json`（两者等价）。下文示例统一使用 `--json`。
+注意：daemon 依赖（fastapi、uvicorn）已作为必选依赖安装，`jfox daemon start` 可直接使用。批量整理 / 导入前启动 daemon 可加速 embedding 计算。
 
-### 知识库管理
+## 7. 命令参考速查
+
+> 完整语法详见 §3–§6；本节按主题分组提供速查。
+
+### 知识库生命周期
 
 ```bash
 jfox init --name <name> --desc "<desc>"     # 创建知识库
-jfox kb list --format json                  # 列出所有知识库
+jfox kb list --json                         # 列出所有知识库
 jfox kb switch <name>                       # 切换知识库
-jfox kb info <name> --format json           # 查看知识库详情
-jfox kb current --format json               # 当前知识库
+jfox kb info <name> --json                  # 查看知识库详情
+jfox kb current --json                      # 当前知识库
 jfox kb rename <old> <new>                  # 重命名
 jfox kb remove <name>                       # 注销（保留文件）
 jfox kb remove <name> --force               # 删除（含文件，不可恢复）
-jfox status --format json                   # 知识库状态
+jfox status --json                          # 知识库状态
 ```
 
 ### 笔记 CRUD
@@ -315,18 +338,11 @@ jfox add --content-file <path> --title "<title>"                   # 从文件�
 jfox edit <id> --content "<new>" --title "<title>"                 # 编辑笔记
 jfox edit <id> --content-file <path>                               # 从文件编辑
 jfox delete <id> --force                                           # 删除笔记
-jfox show <id_or_title> --format json                             # 查看笔记完整内容
-jfox list --format json --limit <N>                                # 列出笔记
+jfox show <id_or_title>                                            # 查看笔记完整内容（无 --json）
+jfox list --json --limit <N>                                       # 列出笔记
 jfox daily --json                                                  # 今天的笔记
 jfox daily --date YYYY-MM-DD --json                                # 指定日期
-jfox refs --search "<title>" --format json                         # 反向链接
-```
-
-### 数据导入
-
-```bash
-jfox ingest-log <repo-path> --limit <N> --type fleeting --kb <name>  # Git 仓库导入
-jfox bulk-import <file.json> --type fleeting --kb <name>             # 批量导入
+jfox refs --search "<title>" --json                                # 反向链接
 ```
 
 ### 健康检查
@@ -342,21 +358,20 @@ jfox inbox --json --limit <N>                # 未处理笔记
 ### Daemon
 
 ```bash
-jfox daemon start                               # 启动 embedding 守护进程
-jfox daemon stop                                # 停止守护进程
-jfox daemon status                              # 查看 PID、端口、模型信息
+jfox daemon start                            # 启动 embedding 守护进程
+jfox daemon stop                             # 停止守护进程
+jfox daemon status                           # 查看状态
 ```
 
-注意：daemon 依赖（fastapi、uvicorn）已作为必选依赖安装，`jfox daemon start` 可直接使用。
+> 搜索（search）、导入（ingest）、整理（organize）、会话总结（session-summary）等高频操作命令见对应技能文档。
 
-> 搜索、导入、整理等高频操作命令见对应技能文档（search、ingest、organize）。
-
-## 错误处理
+## 8. 错误处理
 
 | 场景 | 处理方式 |
 |------|---------|
 | "Knowledge base already exists" | 使用 `jfox kb switch <name>` 切换到已有知识库，或使用不同名称创建 |
+| "Knowledge base not found" | 调用本技能（`/jfox:manage`）创建知识库 |
 | "Path is outside managed directory" | 所有知识库必须在 `~/.zettelkasten/` 下 |
 | `jfox: command not found` | 安装：`uv tool install jfox-cli` |
 | 索引过时或 `jfox index verify` 异常 | 运行 `jfox index rebuild` 重建搜索索引 |
-| `ingest-log` 报 "Not a git repository" | 提供正确的 Git 仓库路径 |
+| `ingest-log` 报 "Not a git repository" | 提供正确的 Git 仓库路径（详见 `/jfox:ingest`） |

--- a/packages/cc-plugin/skills/organize/SKILL.md
+++ b/packages/cc-plugin/skills/organize/SKILL.md
@@ -15,13 +15,15 @@ JFox 的核心提炼技能。将原始 fleeting 笔记转化为结构良好、�
 
 知识库中已有笔记。如果知识库为空，建议先调用 ingest 技能（`/jfox:ingest`）导入内容。
 
+> 本技能复用 `/jfox:manage` §4.1 的共享约定（`--kb` / `--json` / `--content-file`），下文示例统一使用 `--json` 简写。
+
 ## Step 1: Inbox 分析
 
 ```bash
 jfox inbox --json --limit 50
 ```
 
-列出所有 fleeting（未处理）笔记。对结果进行分组分析：
+列出所有 fleeting / session 未处理笔记（`jfox inbox` 涵盖两种类型）。对结果进行分组分析：
 
 1. **按 `source:*` 标签分组**：例如所有 `source:git-log` 的笔记归为一组
 2. **组内识别可合并子组**：主题相近、相关的 commits/issues 归入同一子组
@@ -62,8 +64,6 @@ jfox inbox --json --limit 50
    jfox delete <原始-id> --force
    ```
 
-> **约定**：所有命令均支持 `--format json` 输出 JSON，也可使用快捷方式 `--json`（两者等价）。下文示例统一使用 `--json`。
-
 ### 提炼策略表
 
 | 来源 | 策略 | permanent 示例 |
@@ -96,8 +96,6 @@ jfox graph --orphans --json
    jfox edit <孤立笔记_id> --content-file updated.md
    ```
 
-> **约定**：`jfox edit` 支持 `--format json`，也可使用快捷方式 `--json`（两者等价）。
-
 ### 确认改善
 
 ```bash
@@ -115,65 +113,30 @@ jfox graph --stats --json
 
 ## 直接创建笔记
 
-在整理过程中，用户可能想直接创建或编辑一条笔记：
+在整理过程中，用户可能想直接创建或编辑一条笔记。命令完整语法详见 `/jfox:manage` §4。本技能的工作流约束：
 
-**创建笔记**：
-```bash
-jfox add "<内容>" --title "<标题>" --type <fleeting|permanent> --tag <tags> [--kb <name>]
-
-# 从文件读取内容（适合长文本，避免 shell 转义问题）
-jfox add --content-file notes/draft.md --title "<标题>" --type permanent --tag <tags> [--kb <name>]
-
-# 从 stdin 读取
-echo "内容" | jfox add --content-file - --title "<标题>" --type fleeting
-```
-
-对于 permanent 笔记，先运行 `jfox suggest-links` 查找 `[[wiki links]]` 再插入。
-
-**编辑已有笔记**：
-```bash
-# 编辑内容和标题
-jfox edit <note_id> --content "新内容" --title "新标题" --tag <tag>
-
-# 在指定知识库中编辑
-jfox edit <note_id> --kb <kb-name> --content "新内容"
-```
-
-**笔记类型选择参考**：
-
-| 类型 | 使用场景 | 示例 |
-|------|---------|------|
-| `fleeting` | 快速想法、临时记录，稍后提炼 | "突然想到一个 API 设计思路" |
-| `permanent` | 成熟的知识、长期有效的洞察 | "总结出一条设计原则" |
-
-默认类型：`fleeting`（快速记录，后续用本技能提炼）。
+- **对 permanent 笔记**：先运行 `jfox suggest-links "<内容摘要>" --json` 取匹配度 ≥ 0.6 的结果作为 `[[wiki links]]` 候选，再以含链接的内容调用 `jfox add --type permanent`
+- **对 fleeting 笔记**：直接 `jfox add`（默认即 fleeting），链接留到后续提炼阶段
+- **默认类型**：`fleeting`（快速记录，后续用本技能提炼）；只有当内容已是成熟知识时才用 `permanent`
 
 ## 命令参考
 
-```bash
-jfox inbox --json --limit <N>                # 查看收件箱临时笔记
-jfox add "<content>" --type permanent --title "<title>" --tag <tags>  # 添加精炼笔记
-jfox edit <id> --content "新内容"              # 编辑已有笔记（保留 ID 和时间戳）
-jfox delete <id> --force                      # 删除原始笔记
-jfox suggest-links "<content>" --format json  # 推荐链接
-jfox graph --orphans --json                   # 查找孤立笔记
-jfox graph --stats --json                     # 图谱统计指标
-jfox list --format json --limit <N>           # 列出笔记
-jfox daily --json                             # 查看今天的笔记
-jfox daily --date 2026-04-01 --json           # 查看指定日期的笔记
-jfox show <id_or_title> --format json           # 查看笔记完整内容（整理前预览）
+整理工作流专属命令：
 
-# 批量整理加速（可选）
-jfox daemon start                                # 启动 embedding 守护进程
-jfox daemon stop                                 # 完成后停止
+```bash
+jfox inbox --json --limit <N>                 # 查看收件箱（fleeting + session 笔记）
+jfox suggest-links "<content>" --json         # 推荐 [[wiki links]] 候选（按相似度排序）
+jfox graph --orphans --json                   # 查找孤立笔记
+jfox graph --stats --json                     # 图谱统计指标（avg_degree、isolated_nodes 等）
 ```
+
+> `jfox add` / `edit` / `delete` / `list` / `show` / `daily` 等通用命令以及 daemon 用法详见 `/jfox:manage` §4 与 §6–§7。
 
 ## 错误处理
 
 - **收件箱为空** → 告知用户 "收件箱为空，无需整理"，可跳到 Step 3 图谱优化
 - **`jfox suggest-links` 返回低匹配度**（score < 0.6）→ 跳过链接推荐，不强制添加
 - **`jfox delete` 目标 ID 不存在** → 报告错误，跳过继续处理其他笔记
-- **`jfox add` / `jfox edit` / `jfox delete`** 支持 `--format json`，也可使用快捷方式 `--json`
 
 ## 使用建议
 

--- a/packages/cc-plugin/skills/session-summary/SKILL.md
+++ b/packages/cc-plugin/skills/session-summary/SKILL.md
@@ -13,6 +13,8 @@ description: |
 - 知识库已初始化（`jfox init`）
 - 确认目标知识库（通过 `--kb` 或当前默认）
 
+> 本技能复用 `/jfox:manage` §4.1 的共享约定（`--kb` / `--json` / `--content-file`）。`jfox add` 通用参数语法详见 `/jfox:manage` §4.2；下文记录的是 session 类型专属约束。
+
 ## 工作流程
 
 ### Step 1: 生成会话总结
@@ -110,13 +112,12 @@ jfox add "<summary>" --title "Session: <topic>" --type <type> --topic <short-top
 
 # 从文件添加（长内容或含特殊字符）
 jfox add --content-file <path> --title "Session: <topic>" --type <type> --topic <short-topic> --tag session --kb <name>
-
-# 验证写入
-jfox show <note_id> --format json
 ```
+
+> 写入后的验证（`jfox show` / `jfox refs` 等）详见 `/jfox:manage` §4.5。
 
 ## 错误处理
 
-- **"Knowledge base not found"**: 提示用户先调用 kb 技能（`/jfox:kb`）创建知识库
+- **"Knowledge base not found"**: 提示用户先调用 manage 技能（`/jfox:manage`）创建知识库
 - **内容过长导致 shell 解析失败**: 切换到 `--content-file` 方式
 - **特殊字符转义问题**: 使用单引号包裹内容，或写入临时文件


### PR DESCRIPTION
## Summary
- Renamed `skills/kb/` → `skills/manage/` so the skill name is self-explanatory (kb was the only opaque acronym among search/ingest/organize/session-summary), and promoted it to the canonical reference for jfox note commands
- Trimmed CRUD command duplication out of `ingest`, `organize`, `session-summary` and replaced with cross-refs to `/jfox:manage §4` — workflow-specific content (ingest's `source:*` tag scheme, organize's `suggest-links` ≥0.6 refine logic, session-summary's `--topic` requirement) preserved verbatim
- Pre-commit CR caught two real bugs that are also fixed here: `jfox show` does not support `--json` (was wrongly documented in §4.5/§7); `jfox inbox` returns Fleeting + Session notes per CLI help (manage §5 health metric and organize §1 wording corrected)

## Test plan
- [ ] Trigger battery: each phrase fires the right skill — "创建知识库" / "知识库健康" / "jfox 命令参考" / "启动 daemon" → `manage`; "导入仓库" → `ingest`; "整理知识库" → `organize`; "保存会话" → `session-summary`; "搜索" → `search`
- [ ] End-to-end on scratch KB: import a small repo (verify `source:*` tagging survives), organize the inbox (verify `[[wiki links]]` via `suggest-links`), capture a session (verify `--topic` + `--tag session` enforcement), check kb health
- [ ] Static checks: `grep /jfox:kb` returns nothing across repo; `jfox show --json` no longer appears as a recommended command

🤖 Generated with [Claude Code](https://claude.com/claude-code)