### PR TITLE
chore(plugin): bump version to 0.2.0 after kb→manage skill rename

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "JFox Zettelkasten 知识管理工具的 Claude Code 集成",
-    "version": "0.1.2"
+    "version": "0.2.0"
   },
   "plugins": [
     {
       "name": "jfox",
       "source": "./packages/cc-plugin",
-      "description": "JFox 知识管理 CLI 的 Claude Code 集成——搜索、导入、整理、会话总结",
-      "version": "0.1.2",
+      "description": "JFox 知识管理 CLI 的 Claude Code 集成——搜索、写入工作流（导入/整理/会话总结）与知识库管理",
+      "version": "0.2.0",
       "author": { "name": "zhuxixi" },
       "keywords": ["zettelkasten", "knowledge-management"],
       "category": "workflow"

--- a/packages/cc-plugin/.claude-plugin/plugin.json
+++ b/packages/cc-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jfox",
-  "description": "JFox 知识管理 CLI 的 Claude Code 集成——搜索、导入、整理、会话总结",
-  "version": "0.1.2",
+  "description": "JFox 知识管理 CLI 的 Claude Code 集成——搜索、写入工作流（导入/整理/会话总结）与知识库管理",
+  "version": "0.2.0",
   "author": { "name": "zhuxixi" },
   "homepage": "https://github.com/zhuxixi/jfox",
   "repository": "https://github.com/zhuxixi/jfox",


### PR DESCRIPTION
## Summary
- Bump `plugin.json` and `marketplace.json` version `0.1.2` → `0.2.0`
- Tighten plugin descriptions to reflect #218's restructuring

🤖 Generated with [Claude Code](https://claude.com/claude-code)