### PR TITLE
fix: Last Used 始终显示 Never，日常操作未更新 last_used

### DIFF
--- a/jfox/config.py
+++ b/jfox/config.py
@@ -1,5 +1,6 @@
 """配置管理"""
 
+import logging
 import os
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -9,6 +10,7 @@ from typing import Optional
 import yaml
 from rich.console import Console
 
+logger = logging.getLogger(__name__)
 _console = Console(stderr=True)
 
 
@@ -176,7 +178,8 @@ def use_kb(kb_name: Optional[str] = None):
 
             manager = get_kb_manager()
             default_name = manager.config_manager.get_default_kb_name()
-            manager.config_manager.update_last_used(default_name)
+            if not manager.config_manager.update_last_used(default_name):
+                logger.warning(f"Failed to update last_used for default KB '{default_name}'")
 
             yield
             return

--- a/jfox/config.py
+++ b/jfox/config.py
@@ -172,6 +172,12 @@ def use_kb(kb_name: Optional[str] = None):
             kb_name = env_kb
             resolved_from_env = True
         else:
+            from .kb_manager import get_kb_manager
+
+            manager = get_kb_manager()
+            default_name = manager.config_manager.get_default_kb_name()
+            manager.config_manager.update_last_used(default_name)
+
             yield
             return
 

--- a/jfox/config.py
+++ b/jfox/config.py
@@ -202,6 +202,9 @@ def use_kb(kb_name: Optional[str] = None):
         config.zk_dir = kb_path / ".zk"
         config.chroma_dir = config.zk_dir / "chroma_db"
 
+        # 更新最后使用时间
+        manager.config_manager.update_last_used(kb_name)
+
         # 重置索引和搜索引擎（使用新的知识库路径）
         _reset_singletons()
 

--- a/jfox/config.py
+++ b/jfox/config.py
@@ -206,7 +206,8 @@ def use_kb(kb_name: Optional[str] = None):
         config.chroma_dir = config.zk_dir / "chroma_db"
 
         # 更新最后使用时间
-        manager.config_manager.update_last_used(kb_name)
+        if not manager.config_manager.update_last_used(kb_name):
+            logger.warning(f"Failed to update last_used for KB '{kb_name}'")
 
         # 重置索引和搜索引擎（使用新的知识库路径）
         _reset_singletons()

--- a/jfox/global_config.py
+++ b/jfox/global_config.py
@@ -321,7 +321,8 @@ class GlobalConfigManager:
             if existing:
                 try:
                     last_time = datetime.fromisoformat(existing)
-                    if (datetime.now() - last_time).total_seconds() < 300:
+                    elapsed = (datetime.now() - last_time).total_seconds()
+                    if 0 <= elapsed < 300:
                         return True
                 except (ValueError, TypeError) as e:
                     logger.debug(f"Invalid last_used format for '{name}': {e}")

--- a/jfox/global_config.py
+++ b/jfox/global_config.py
@@ -313,10 +313,18 @@ class GlobalConfigManager:
         return self._save()
 
     def update_last_used(self, name: str) -> bool:
-        """更新知识库最后使用时间"""
+        """更新知识库最后使用时间（5分钟内不重复写入）"""
         config = self._load()
 
         if name in config.knowledge_bases:
+            existing = config.knowledge_bases[name].last_used
+            if existing:
+                try:
+                    last_time = datetime.fromisoformat(existing)
+                    if (datetime.now() - last_time).total_seconds() < 300:
+                        return True
+                except (ValueError, TypeError):
+                    pass
             config.knowledge_bases[name].last_used = datetime.now().isoformat()
             self._config = config
             return self._save()

--- a/jfox/global_config.py
+++ b/jfox/global_config.py
@@ -323,8 +323,8 @@ class GlobalConfigManager:
                     last_time = datetime.fromisoformat(existing)
                     if (datetime.now() - last_time).total_seconds() < 300:
                         return True
-                except (ValueError, TypeError):
-                    pass
+                except (ValueError, TypeError) as e:
+                    logger.debug(f"Invalid last_used format for '{name}': {e}")
             config.knowledge_bases[name].last_used = datetime.now().isoformat()
             self._config = config
             return self._save()

--- a/jfox/global_config.py
+++ b/jfox/global_config.py
@@ -327,7 +327,7 @@ class GlobalConfigManager:
                     if 0 <= elapsed < 300:
                         return True
                 except (ValueError, TypeError) as e:
-                    logger.debug(f"Invalid last_used format for '{name}': {e}")
+                    logger.warning(f"Invalid last_used format for '{name}': {e}")
             config.knowledge_bases[name].last_used = datetime.now().isoformat()
             self._config = config
             return self._save()

--- a/jfox/global_config.py
+++ b/jfox/global_config.py
@@ -321,6 +321,8 @@ class GlobalConfigManager:
             if existing:
                 try:
                     last_time = datetime.fromisoformat(existing)
+                    if last_time.tzinfo is not None:
+                        last_time = last_time.replace(tzinfo=None)
                     elapsed = (datetime.now() - last_time).total_seconds()
                     if 0 <= elapsed < 300:
                         return True

--- a/tests/unit/test_global_config.py
+++ b/tests/unit/test_global_config.py
@@ -468,7 +468,9 @@ class TestGlobalConfigManager:
     def test_update_last_used_throttle_skips_recent(self, manager):
         """5分钟内不重复写入"""
         recent_time = datetime.now().isoformat()
-        entry = KnowledgeBaseEntry(name="my_kb", path="/path", created="2024-01-01T00:00:00", last_used=recent_time)
+        entry = KnowledgeBaseEntry(
+            name="my_kb", path="/path", created="2024-01-01T00:00:00", last_used=recent_time
+        )
         manager._config = GlobalConfig(knowledge_bases={"my_kb": entry})
 
         with patch.object(manager, "_save", return_value=True) as mock_save:
@@ -480,7 +482,9 @@ class TestGlobalConfigManager:
     def test_update_last_used_throttle_allows_stale(self, manager):
         """超过5分钟则正常写入"""
         stale_time = "2020-01-01T00:00:00"
-        entry = KnowledgeBaseEntry(name="my_kb", path="/path", created="2024-01-01T00:00:00", last_used=stale_time)
+        entry = KnowledgeBaseEntry(
+            name="my_kb", path="/path", created="2024-01-01T00:00:00", last_used=stale_time
+        )
         manager._config = GlobalConfig(knowledge_bases={"my_kb": entry})
 
         with patch.object(manager, "_save", return_value=True):
@@ -491,7 +495,9 @@ class TestGlobalConfigManager:
 
     def test_update_last_used_no_throttle_when_null(self, manager):
         """last_used 为 None 时直接写入"""
-        entry = KnowledgeBaseEntry(name="my_kb", path="/path", created="2024-01-01T00:00:00", last_used=None)
+        entry = KnowledgeBaseEntry(
+            name="my_kb", path="/path", created="2024-01-01T00:00:00", last_used=None
+        )
         manager._config = GlobalConfig(knowledge_bases={"my_kb": entry})
 
         with patch.object(manager, "_save", return_value=True):

--- a/tests/unit/test_global_config.py
+++ b/tests/unit/test_global_config.py
@@ -9,6 +9,7 @@ import pytest
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
 import json
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -463,6 +464,41 @@ class TestGlobalConfigManager:
         result = manager.update_last_used("nonexistent")
 
         assert result is False
+
+    def test_update_last_used_throttle_skips_recent(self, manager):
+        """5分钟内不重复写入"""
+        recent_time = datetime.now().isoformat()
+        entry = KnowledgeBaseEntry(name="my_kb", path="/path", created="2024-01-01T00:00:00", last_used=recent_time)
+        manager._config = GlobalConfig(knowledge_bases={"my_kb": entry})
+
+        with patch.object(manager, "_save", return_value=True) as mock_save:
+            result = manager.update_last_used("my_kb")
+
+        assert result is True
+        mock_save.assert_not_called()  # 跳过写入
+
+    def test_update_last_used_throttle_allows_stale(self, manager):
+        """超过5分钟则正常写入"""
+        stale_time = "2020-01-01T00:00:00"
+        entry = KnowledgeBaseEntry(name="my_kb", path="/path", created="2024-01-01T00:00:00", last_used=stale_time)
+        manager._config = GlobalConfig(knowledge_bases={"my_kb": entry})
+
+        with patch.object(manager, "_save", return_value=True):
+            result = manager.update_last_used("my_kb")
+
+        assert result is True
+        assert entry.last_used != stale_time
+
+    def test_update_last_used_no_throttle_when_null(self, manager):
+        """last_used 为 None 时直接写入"""
+        entry = KnowledgeBaseEntry(name="my_kb", path="/path", created="2024-01-01T00:00:00", last_used=None)
+        manager._config = GlobalConfig(knowledge_bases={"my_kb": entry})
+
+        with patch.object(manager, "_save", return_value=True):
+            result = manager.update_last_used("my_kb")
+
+        assert result is True
+        assert entry.last_used is not None
 
 
 class TestMigrateDefaultKbPath:

--- a/tests/unit/test_use_kb_env_var.py
+++ b/tests/unit/test_use_kb_env_var.py
@@ -108,3 +108,38 @@ class TestUseKbEnvVar:
                     with use_kb(None) as _:
                         # 验证去除了空格后使用的是 "work"
                         mock_manager.config_manager.get_kb_path.assert_called_once_with("work")
+
+    def test_explicit_kb_updates_last_used(self):
+        """通过 --kb 指定知识库时应更新 last_used"""
+        with patch("jfox.config._reset_singletons"):
+            with patch("jfox.kb_manager.get_kb_manager") as mock_get_manager:
+                mock_manager = Mock()
+                mock_manager.config_manager.kb_exists.return_value = True
+                mock_manager.config_manager.get_kb_path.return_value = (
+                    config.base_dir.parent / "work"
+                )
+                mock_manager.config_manager.update_last_used.return_value = True
+                mock_get_manager.return_value = mock_manager
+
+                with use_kb("work") as _:
+                    pass
+
+                mock_manager.config_manager.update_last_used.assert_called_once_with("work")
+
+    def test_env_var_kb_updates_last_used(self):
+        """通过 JFOX_KB 环境变量指定知识库时应更新 last_used"""
+        with patch.dict(os.environ, {"JFOX_KB": "work"}):
+            with patch("jfox.config._reset_singletons"):
+                with patch("jfox.kb_manager.get_kb_manager") as mock_get_manager:
+                    mock_manager = Mock()
+                    mock_manager.config_manager.kb_exists.return_value = True
+                    mock_manager.config_manager.get_kb_path.return_value = (
+                        config.base_dir.parent / "work"
+                    )
+                    mock_manager.config_manager.update_last_used.return_value = True
+                    mock_get_manager.return_value = mock_manager
+
+                    with use_kb(None) as _:
+                        pass
+
+                    mock_manager.config_manager.update_last_used.assert_called_once_with("work")

--- a/tests/unit/test_use_kb_env_var.py
+++ b/tests/unit/test_use_kb_env_var.py
@@ -68,14 +68,30 @@ class TestUseKbEnvVar:
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("JFOX_KB", None)
             with patch("jfox.kb_manager.get_kb_manager") as mock_get_manager:
-                # 不应调用 get_kb_manager，因为没有需要切换的知识库
+                mock_manager = Mock()
+                mock_manager.config_manager.get_default_kb_name.return_value = "default"
+                mock_manager.config_manager.update_last_used.return_value = True
+                mock_get_manager.return_value = mock_manager
                 original_base_dir = config.base_dir
 
                 with use_kb(None) as _:
-                    # 验证没有尝试获取 kb_manager
-                    mock_get_manager.assert_not_called()
                     # 验证配置没有被修改
                     assert config.base_dir == original_base_dir
+
+    def test_default_kb_updates_last_used(self):
+        """使用默认 KB 时应更新 last_used"""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("JFOX_KB", None)
+            with patch("jfox.kb_manager.get_kb_manager") as mock_get_manager:
+                mock_manager = Mock()
+                mock_manager.config_manager.get_default_kb_name.return_value = "default"
+                mock_manager.config_manager.update_last_used.return_value = True
+                mock_get_manager.return_value = mock_manager
+
+                with use_kb(None) as _:
+                    pass
+
+                mock_manager.config_manager.update_last_used.assert_called_once_with("default")
 
     def test_jfox_kb_with_whitespace_is_stripped(self):
         """JFOX_KB 值包含首尾空格时应被去除"""


### PR DESCRIPTION
## Summary

Fixes #221 — `jfox kb current` 和 `jfox kb list` 的 "Last Used" 字段始终显示 "Never"，即使知识库被频繁使用。

**根因：** `update_last_used()` 仅在 `jfox kb switch` 时调用，而所有日常命令（add、search、show 等）通过 `use_kb()` 上下文管理器的两条路径都没有更新这个字段。

**修复：**
1. 在 `update_last_used()` 内添加 5 分钟节流，避免高频命令反复写磁盘
2. 在 `use_kb()` Path A（默认 KB）中调用 `update_last_used()`
3. 在 `use_kb()` Path B（`--kb` / `JFOX_KB`）中调用 `update_last_used()`

## Test plan

- [x] 新增 3 个节流测试（skip recent / allow stale / no throttle when null）
- [x] 新增 3 个 `use_kb` 测试（default KB / explicit --kb / JFOX_KB env var）
- [x] 修复 1 个现有测试（`test_no_env_var_falls_back_to_global_default`）
- [x] 全量快排测试通过（419 passed, 0 failures）
- [ ] 手动验证：`jfox add` 后检查 `~/.zk_config.json` 的 `last_used` 不再为 null

🤖 Generated with [Claude Code](https://claude.com/claude-code)