### PR TITLE
feat: auto-summary daemon for Claude Code sessions

### DIFF
--- a/jfox/auto_summary/__init__.py
+++ b/jfox/auto_summary/__init__.py
@@ -1,0 +1,27 @@
+"""
+Claude Code 会话自动总结
+
+定时扫描 ~/.claude/projects/*/[uuid].jsonl，对静默超过阈值的"已结束"
+session 调用 claude -p 生成结构化摘要并写入 jfox 知识库。
+
+主要入口：
+- run_once(): 同步执行一轮扫描+总结
+- scan_pending(): 仅返回待处理 session 列表（dry-run）
+- start_background_loop(): 在 asyncio 事件循环中启动后台循环（daemon 用）
+"""
+
+from .ledger import Ledger, LedgerEntry, SessionStatus
+from .runner import RunReport, SummaryOutcome, run_once, scan_pending
+from .scanner import SessionFile, iter_session_files
+
+__all__ = [
+    "Ledger",
+    "LedgerEntry",
+    "SessionStatus",
+    "SessionFile",
+    "iter_session_files",
+    "run_once",
+    "scan_pending",
+    "RunReport",
+    "SummaryOutcome",
+]

--- a/jfox/auto_summary/cli.py
+++ b/jfox/auto_summary/cli.py
@@ -1,0 +1,225 @@
+"""
+CLI subapp: jfox auto-summary
+
+子命令：
+- run [--dry-run] [--verbose]    手动触发一轮扫描+总结
+- scan                           列出当前会被处理的 session（dry-run 视图）
+- status                         显示配置 + ledger 统计
+- enable [--interval] [--kb]     启用 auto-summary（可同时改若干字段）
+- disable                        禁用 auto-summary
+- forget <session_id>            从 ledger 中移除一条，使其下次重跑
+- prune [--days N]               清理 ledger 中早于 N 天的条目
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from ..global_config import get_global_config_manager
+from . import ledger as ledger_module
+from .ledger import Ledger
+from .runner import run_once, scan_pending
+
+console = Console(legacy_windows=False)
+
+auto_summary_app = typer.Typer(
+    name="auto-summary",
+    help="Claude Code 会话自动总结：定时扫描 ~/.claude/projects 并写入知识库",
+    no_args_is_help=True,
+)
+
+
+def _config():
+    return get_global_config_manager().get_auto_summary_config()
+
+
+@auto_summary_app.command("status")
+def status() -> None:
+    """显示 auto-summary 配置和 ledger 统计"""
+    cfg = _config()
+    led = Ledger()
+    stats = led.stats()
+
+    table = Table(title="auto-summary 配置", show_header=False)
+    table.add_column("项", style="cyan", no_wrap=True)
+    table.add_column("值", style="green")
+    table.add_row("enabled", "[green]是[/green]" if cfg.enabled else "[dim]否[/dim]")
+    table.add_row("扫描间隔", f"{cfg.interval_minutes} 分钟")
+    table.add_row("结束判定阈值", f"{cfg.idle_threshold_minutes} 分钟（mtime 静默）")
+    table.add_row("目标知识库", cfg.target_kb or "(default)")
+    table.add_row("单轮最多处理", str(cfg.max_per_tick))
+    table.add_row("最大 session 大小", f"{cfg.max_session_size_mb} MB")
+    table.add_row("最小 session 大小", f"{cfg.min_session_size_kb} KB")
+    table.add_row("跳过过旧 session 阈值", f"{cfg.skip_after_days} 天")
+    table.add_row("claude -p 超时", f"{cfg.claude_timeout_seconds} 秒")
+    table.add_row("claude 路径", cfg.claude_binary or "(从 PATH 解析)")
+    table.add_row("ledger 文件", str(ledger_module.DEFAULT_LEDGER_PATH))
+    console.print(table)
+
+    stat_table = Table(title="ledger 状态分布")
+    stat_table.add_column("状态", style="cyan")
+    stat_table.add_column("数量", style="green", justify="right")
+    for k, v in stats.items():
+        stat_table.add_row(k, str(v))
+    console.print(stat_table)
+
+
+@auto_summary_app.command("enable")
+def enable(
+    interval: Optional[int] = typer.Option(None, "--interval", help="扫描间隔（分钟，>=1）"),
+    idle_threshold: Optional[int] = typer.Option(
+        None, "--idle-threshold", help="session 结束判定的静默阈值（分钟）"
+    ),
+    kb: Optional[str] = typer.Option(None, "--kb", help="写入哪个知识库（默认 default）"),
+    max_per_tick: Optional[int] = typer.Option(
+        None, "--max-per-tick", help="每轮最多处理几个 session"
+    ),
+) -> None:
+    """启用 auto-summary，可同时调整其他字段"""
+    changes: dict = {"enabled": True}
+    if interval is not None:
+        if interval < 1:
+            console.print("[red]✗[/red] interval 必须 >= 1")
+            raise typer.Exit(1)
+        changes["interval_minutes"] = interval
+    if idle_threshold is not None:
+        if idle_threshold < 1:
+            console.print("[red]✗[/red] idle-threshold 必须 >= 1")
+            raise typer.Exit(1)
+        changes["idle_threshold_minutes"] = idle_threshold
+    if kb is not None:
+        changes["target_kb"] = kb or None
+    if max_per_tick is not None:
+        if max_per_tick < 1:
+            console.print("[red]✗[/red] max-per-tick 必须 >= 1")
+            raise typer.Exit(1)
+        changes["max_per_tick"] = max_per_tick
+
+    if get_global_config_manager().update_auto_summary_config(**changes):
+        console.print("[green]✓[/green] auto-summary 已启用")
+        console.print(
+            "[dim]提示：daemon 启动后才会真正在后台运行；CLI 仍可手动 jfox auto-summary run[/dim]"
+        )
+    else:
+        console.print("[red]✗[/red] 写入配置失败")
+        raise typer.Exit(1)
+
+
+@auto_summary_app.command("disable")
+def disable() -> None:
+    """禁用 auto-summary（daemon 将停止后台循环；ledger 不会被清空）"""
+    if get_global_config_manager().update_auto_summary_config(enabled=False):
+        console.print("[yellow]auto-summary 已禁用[/yellow]")
+    else:
+        console.print("[red]✗[/red] 写入配置失败")
+        raise typer.Exit(1)
+
+
+@auto_summary_app.command("scan")
+def scan() -> None:
+    """列出当前会被处理的 session（dry-run）"""
+    pending = scan_pending()
+    if not pending:
+        console.print("[dim]无待处理 session[/dim]")
+        return
+
+    table = Table(title=f"待处理 session ({len(pending)})")
+    table.add_column("project", style="cyan", overflow="fold")
+    table.add_column("session_id", style="yellow")
+    table.add_column("size", justify="right")
+    table.add_column("mtime", style="dim")
+    table.add_column("age", justify="right", style="dim")
+
+    for sf in pending:
+        mtime_str = datetime.fromtimestamp(sf.mtime).strftime("%Y-%m-%d %H:%M")
+        age_min = sf.age_seconds / 60
+        if age_min < 60:
+            age_str = f"{age_min:.0f}m"
+        elif age_min < 60 * 24:
+            age_str = f"{age_min / 60:.1f}h"
+        else:
+            age_str = f"{age_min / 60 / 24:.1f}d"
+        size_kb = sf.size_bytes / 1024
+        size_str = f"{size_kb:.0f} KB" if size_kb < 1024 else f"{size_kb / 1024:.1f} MB"
+        table.add_row(sf.project_dir_name, sf.session_id[:8], size_str, mtime_str, age_str)
+
+    console.print(table)
+
+
+@auto_summary_app.command("run")
+def run(
+    dry_run: bool = typer.Option(False, "--dry-run", help="只扫描不实际调用 claude 和写入"),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="详细输出每条结果"),
+) -> None:
+    """手动触发一轮 auto-summary（不依赖 daemon）"""
+    if not _config().enabled and not dry_run:
+        console.print(
+            "[yellow]提示：auto-summary 当前处于禁用状态[/yellow]，"
+            "本次手动 run 仍会执行，但 daemon 不会自动调度。"
+        )
+
+    report = run_once(dry_run=dry_run)
+    console.print(
+        f"扫描 {report.scanned}, 处理 {report.processed}, "
+        f"[green]成功 {report.success}[/green], "
+        f"[yellow]跳过 {report.skipped}[/yellow], "
+        f"[red]失败 {report.failed}[/red]"
+    )
+
+    if verbose or report.failed > 0:
+        for item in report.items:
+            line = f"  [{item.outcome.value}] {item.session_id[:8]}"
+            if item.title:
+                line += f" — {item.title}"
+            if item.note_id:
+                line += f" → {item.note_id}"
+            if item.reason:
+                line += f"  ({item.reason})"
+            if item.error:
+                line += f"  ERROR: {item.error}"
+            console.print(line)
+
+
+@auto_summary_app.command("forget")
+def forget(
+    session_id: str = typer.Argument(..., help="要从 ledger 移除的 session_id（支持完整或前缀）")
+) -> None:
+    """从 ledger 中移除一条，使其下次扫描时被重新处理"""
+    led = Ledger()
+    matches = [sid for sid in led.all_entries() if sid.startswith(session_id)]
+    if not matches:
+        console.print(f"[red]✗[/red] ledger 中没有匹配 '{session_id}' 的条目")
+        raise typer.Exit(1)
+    if len(matches) > 1:
+        console.print(f"[red]✗[/red] 前缀 '{session_id}' 命中 {len(matches)} 条，请输入更长的前缀")
+        for m in matches[:10]:
+            console.print(f"  - {m}")
+        raise typer.Exit(1)
+
+    target = matches[0]
+    if led.forget(target):
+        console.print(f"[green]✓[/green] 已从 ledger 移除 {target}")
+    else:
+        console.print("[red]✗[/red] 移除失败")
+        raise typer.Exit(1)
+
+
+@auto_summary_app.command("prune")
+def prune(
+    days: int = typer.Option(30, "--days", help="删除 ledger 中早于 N 天的条目"),
+) -> None:
+    """清理 ledger 中过旧的条目（不影响知识库笔记）"""
+    if days <= 0:
+        console.print("[red]✗[/red] days 必须 > 0")
+        raise typer.Exit(1)
+    led = Ledger()
+    n = led.prune_older_than(days)
+    console.print(f"[green]✓[/green] 已清理 {n} 条早于 {days} 天的 ledger 条目")
+
+
+__all__ = ["auto_summary_app"]

--- a/jfox/auto_summary/cli.py
+++ b/jfox/auto_summary/cli.py
@@ -13,8 +13,9 @@ CLI subapp: jfox auto-summary
 
 from __future__ import annotations
 
+import json as _json
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 import typer
 from rich.console import Console
@@ -24,6 +25,15 @@ from ..global_config import get_global_config_manager
 from . import ledger as ledger_module
 from .ledger import Ledger
 from .runner import run_once, scan_pending
+
+
+def _fmt(table: Optional[Table] = None, json_data: Any = None, fmt: str = "table") -> None:
+    """统一的输出路由：fmt=json 时输出 JSON 字符串，否则渲染 Table"""
+    if fmt == "json":
+        console.print(_json.dumps(json_data, ensure_ascii=False, indent=2))
+    elif table is not None:
+        console.print(table)
+
 
 console = Console(legacy_windows=False)
 
@@ -39,11 +49,24 @@ def _config():
 
 
 @auto_summary_app.command("status")
-def status() -> None:
+def status(
+    output_format: str = typer.Option("table", "--format", "-f", help="输出格式: table, json"),
+) -> None:
     """显示 auto-summary 配置和 ledger 统计"""
     cfg = _config()
     led = Ledger()
     stats = led.stats()
+
+    if output_format == "json":
+        _fmt(
+            json_data={
+                "config": cfg.to_dict(),
+                "ledger_file": str(ledger_module.DEFAULT_LEDGER_PATH),
+                "ledger_stats": stats,
+            },
+            fmt="json",
+        )
+        return
 
     table = Table(title="auto-summary 配置", show_header=False)
     table.add_column("项", style="cyan", no_wrap=True)
@@ -105,6 +128,10 @@ def enable(
         console.print(
             "[dim]提示：daemon 启动后才会真正在后台运行；CLI 仍可手动 jfox auto-summary run[/dim]"
         )
+        console.print(
+            "[yellow]⚠ 隐私声明：auto-summary 会将 Claude Code 会话记录通过 `claude -p` 发送至"
+            " Anthropic API 以生成摘要。仅传输会话文本，不传输额外数据。[/yellow]"
+        )
     else:
         console.print("[red]✗[/red] 写入配置失败")
         raise typer.Exit(1)
@@ -121,11 +148,34 @@ def disable() -> None:
 
 
 @auto_summary_app.command("scan")
-def scan() -> None:
+def scan(
+    output_format: str = typer.Option("table", "--format", "-f", help="输出格式: table, json"),
+) -> None:
     """列出当前会被处理的 session（dry-run）"""
     pending = scan_pending()
     if not pending:
-        console.print("[dim]无待处理 session[/dim]")
+        if output_format == "json":
+            _fmt(json_data={"pending": []}, fmt="json")
+        else:
+            console.print("[dim]无待处理 session[/dim]")
+        return
+
+    if output_format == "json":
+        _fmt(
+            json_data={
+                "pending": [
+                    {
+                        "session_id": sf.session_id,
+                        "project": sf.project_dir_name,
+                        "size_bytes": sf.size_bytes,
+                        "mtime": sf.mtime,
+                        "age_minutes": sf.age_seconds / 60,
+                    }
+                    for sf in pending
+                ]
+            },
+            fmt="json",
+        )
         return
 
     table = Table(title=f"待处理 session ({len(pending)})")

--- a/jfox/auto_summary/cli.py
+++ b/jfox/auto_summary/cli.py
@@ -102,6 +102,7 @@ def enable(
     max_per_tick: Optional[int] = typer.Option(
         None, "--max-per-tick", help="每轮最多处理几个 session"
     ),
+    output_format: str = typer.Option("table", "--format", "-f", help="输出格式: table, json"),
 ) -> None:
     """启用 auto-summary，可同时调整其他字段"""
     changes: dict = {"enabled": True}
@@ -124,6 +125,13 @@ def enable(
         changes["max_per_tick"] = max_per_tick
 
     if get_global_config_manager().update_auto_summary_config(**changes):
+        if output_format == "json":
+            _fmt(json_data={"success": True, "message": "auto-summary 已启用"}, fmt="json")
+            console.print(
+                "[yellow]⚠ 隐私声明：auto-summary 会将 Claude Code 会话记录通过 `claude -p` 发送至"
+                " Anthropic API 以生成摘要。仅传输会话文本，不传输额外数据。[/yellow]"
+            )
+            return
         console.print("[green]✓[/green] auto-summary 已启用")
         console.print(
             "[dim]提示：daemon 启动后才会真正在后台运行；CLI 仍可手动 jfox auto-summary run[/dim]"
@@ -133,16 +141,27 @@ def enable(
             " Anthropic API 以生成摘要。仅传输会话文本，不传输额外数据。[/yellow]"
         )
     else:
+        if output_format == "json":
+            _fmt(json_data={"success": False, "error": "写入配置失败"}, fmt="json")
+            raise typer.Exit(1)
         console.print("[red]✗[/red] 写入配置失败")
         raise typer.Exit(1)
 
 
 @auto_summary_app.command("disable")
-def disable() -> None:
+def disable(
+    output_format: str = typer.Option("table", "--format", "-f", help="输出格式: table, json"),
+) -> None:
     """禁用 auto-summary（daemon 将停止后台循环；ledger 不会被清空）"""
     if get_global_config_manager().update_auto_summary_config(enabled=False):
+        if output_format == "json":
+            _fmt(json_data={"success": True, "message": "auto-summary 已禁用"}, fmt="json")
+            return
         console.print("[yellow]auto-summary 已禁用[/yellow]")
     else:
+        if output_format == "json":
+            _fmt(json_data={"success": False, "error": "写入配置失败"}, fmt="json")
+            raise typer.Exit(1)
         console.print("[red]✗[/red] 写入配置失败")
         raise typer.Exit(1)
 
@@ -205,6 +224,7 @@ def scan(
 def run(
     dry_run: bool = typer.Option(False, "--dry-run", help="只扫描不实际调用 claude 和写入"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="详细输出每条结果"),
+    output_format: str = typer.Option("table", "--format", "-f", help="输出格式: table, json"),
 ) -> None:
     """手动触发一轮 auto-summary（不依赖 daemon）"""
     if not _config().enabled and not dry_run:
@@ -214,6 +234,31 @@ def run(
         )
 
     report = run_once(dry_run=dry_run)
+
+    if output_format == "json":
+        _fmt(
+            json_data={
+                "scanned": report.scanned,
+                "processed": report.processed,
+                "success": report.success,
+                "skipped": report.skipped,
+                "failed": report.failed,
+                "items": [
+                    {
+                        "session_id": it.session_id,
+                        "outcome": it.outcome.value,
+                        "note_id": it.note_id,
+                        "title": it.title,
+                        "reason": it.reason,
+                        "error": it.error,
+                    }
+                    for it in report.items
+                ],
+            },
+            fmt="json",
+        )
+        return
+
     console.print(
         f"扫描 {report.scanned}, 处理 {report.processed}, "
         f"[green]成功 {report.success}[/green], "
@@ -237,15 +282,32 @@ def run(
 
 @auto_summary_app.command("forget")
 def forget(
-    session_id: str = typer.Argument(..., help="要从 ledger 移除的 session_id（支持完整或前缀）")
+    session_id: str = typer.Argument(..., help="要从 ledger 移除的 session_id（支持完整或前缀）"),
+    output_format: str = typer.Option("table", "--format", "-f", help="输出格式: table, json"),
 ) -> None:
     """从 ledger 中移除一条，使其下次扫描时被重新处理"""
     led = Ledger()
     matches = [sid for sid in led.all_entries() if sid.startswith(session_id)]
     if not matches:
+        if output_format == "json":
+            _fmt(
+                json_data={"success": False, "error": f"ledger 中没有匹配 '{session_id}' 的条目"},
+                fmt="json",
+            )
+            raise typer.Exit(1)
         console.print(f"[red]✗[/red] ledger 中没有匹配 '{session_id}' 的条目")
         raise typer.Exit(1)
     if len(matches) > 1:
+        if output_format == "json":
+            _fmt(
+                json_data={
+                    "success": False,
+                    "error": f"前缀 '{session_id}' 命中 {len(matches)} 条，请输入更长的前缀",
+                    "matches": matches[:10],
+                },
+                fmt="json",
+            )
+            raise typer.Exit(1)
         console.print(f"[red]✗[/red] 前缀 '{session_id}' 命中 {len(matches)} 条，请输入更长的前缀")
         for m in matches[:10]:
             console.print(f"  - {m}")
@@ -253,8 +315,14 @@ def forget(
 
     target = matches[0]
     if led.forget(target):
+        if output_format == "json":
+            _fmt(json_data={"success": True, "removed": target}, fmt="json")
+            return
         console.print(f"[green]✓[/green] 已从 ledger 移除 {target}")
     else:
+        if output_format == "json":
+            _fmt(json_data={"success": False, "error": "移除失败"}, fmt="json")
+            raise typer.Exit(1)
         console.print("[red]✗[/red] 移除失败")
         raise typer.Exit(1)
 
@@ -262,13 +330,20 @@ def forget(
 @auto_summary_app.command("prune")
 def prune(
     days: int = typer.Option(30, "--days", help="删除 ledger 中早于 N 天的条目"),
+    output_format: str = typer.Option("table", "--format", "-f", help="输出格式: table, json"),
 ) -> None:
     """清理 ledger 中过旧的条目（不影响知识库笔记）"""
     if days <= 0:
+        if output_format == "json":
+            _fmt(json_data={"success": False, "error": "days 必须 > 0"}, fmt="json")
+            raise typer.Exit(1)
         console.print("[red]✗[/red] days 必须 > 0")
         raise typer.Exit(1)
     led = Ledger()
     n = led.prune_older_than(days)
+    if output_format == "json":
+        _fmt(json_data={"success": True, "pruned": n, "older_than_days": days}, fmt="json")
+        return
     console.print(f"[green]✓[/green] 已清理 {n} 条早于 {days} 天的 ledger 条目")
 
 

--- a/jfox/auto_summary/extractor.py
+++ b/jfox/auto_summary/extractor.py
@@ -1,0 +1,164 @@
+"""
+从 Claude Code session jsonl 提取出可读对话文本，剔除工具调用、attachment、
+system-reminder 等噪音。供 claude -p 总结时阅读。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# 单次喂给 claude -p 的最大字符数。超出则保留首尾各一半（开头有上下文，结尾有结论）
+DEFAULT_MAX_DIALOG_CHARS = 30000
+
+
+@dataclass
+class ExtractedDialog:
+    """extract_dialog 的返回结构"""
+
+    cwd: Optional[str] = None
+    git_branch: Optional[str] = None
+    started_at: Optional[str] = None
+    ended_at: Optional[str] = None
+    project_dir_name: Optional[str] = None
+    user_turn_count: int = 0
+    assistant_turn_count: int = 0
+    truncated: bool = False
+    dialog_text: str = ""
+
+
+def _is_system_reminder_text(text: str) -> bool:
+    """识别整段 system-reminder（开头/结尾标签都在）"""
+    s = text.strip()
+    return s.startswith("<system-reminder>") and s.endswith("</system-reminder>")
+
+
+def _coerce_text(content: Any) -> str:
+    """把 Claude Code 的多形态 content 字段拍平成纯文本。
+
+    - str → 直接返回（system-reminder 除外）
+    - list → 拼接其中所有 type=text 的 text；逐项剔除 system-reminder；
+             丢弃 tool_use/tool_result/image
+    - dict → 取 text 字段或递归
+    - 其他 → 空串
+    """
+    if isinstance(content, str):
+        return "" if _is_system_reminder_text(content) else content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            itype = item.get("type")
+            if itype == "text":
+                t = item.get("text") or ""
+                if isinstance(t, str) and t.strip() and not _is_system_reminder_text(t):
+                    parts.append(t)
+            # tool_use / tool_result / image / thinking 等一律忽略
+        return "\n".join(parts).strip()
+    if isinstance(content, dict):
+        if isinstance(content.get("text"), str):
+            t = content["text"]
+            return "" if _is_system_reminder_text(t) else t
+        return _coerce_text(content.get("content"))
+    return ""
+
+
+def _extract_role_and_text(record: dict[str, Any]) -> Optional[tuple[str, str]]:
+    """从一行 jsonl 记录里抽出 (role, text)；不感兴趣的记录返回 None"""
+    rec_type = record.get("type")
+
+    # Claude Code 的两种主要消息形态：
+    # 1) {"type": "user"/"assistant", "message": {"role": ..., "content": ...}, ...}
+    # 2) {"type": "user"/"assistant", "content": ..., "role": ...}
+    if rec_type in ("user", "assistant"):
+        message = record.get("message") if isinstance(record.get("message"), dict) else None
+        if message is not None:
+            text = _coerce_text(message.get("content"))
+            role = message.get("role") or rec_type
+        else:
+            text = _coerce_text(record.get("content"))
+            role = record.get("role") or rec_type
+        text = text.strip()
+        if not text:
+            return None
+        # _coerce_text 已在 item 级剔除 system-reminder；这里再做一次最终兜底
+        if _is_system_reminder_text(text):
+            return None
+        return role, text
+
+    return None
+
+
+def _truncate(text: str, max_chars: int) -> tuple[str, bool]:
+    if len(text) <= max_chars:
+        return text, False
+    half = max_chars // 2
+    head = text[:half]
+    tail = text[-half:]
+    sep = "\n\n... [省略中间内容以控制长度] ...\n\n"
+    return head + sep + tail, True
+
+
+def extract_dialog(
+    jsonl_path: Path,
+    max_dialog_chars: int = DEFAULT_MAX_DIALOG_CHARS,
+) -> ExtractedDialog:
+    """
+    读取 jsonl，返回 ExtractedDialog。
+
+    只保留 user/assistant 的纯文本，剔除 tool_use / tool_result / attachment /
+    system-reminder。元数据从首条带 cwd/gitBranch 的记录里取。
+    """
+    result = ExtractedDialog()
+    turns: list[str] = []
+
+    try:
+        with open(jsonl_path, "r", encoding="utf-8", errors="replace") as f:
+            for line_no, raw in enumerate(f, start=1):
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    rec = json.loads(raw)
+                except json.JSONDecodeError as e:
+                    logger.debug("第 %d 行 JSON 解析失败: %s", line_no, e)
+                    continue
+                if not isinstance(rec, dict):
+                    continue
+
+                # 元数据收集（首次出现时记录）
+                if result.cwd is None and isinstance(rec.get("cwd"), str):
+                    result.cwd = rec["cwd"]
+                if result.git_branch is None and isinstance(rec.get("gitBranch"), str):
+                    result.git_branch = rec["gitBranch"]
+                ts = rec.get("timestamp")
+                if isinstance(ts, str):
+                    if result.started_at is None:
+                        result.started_at = ts
+                    result.ended_at = ts
+
+                extracted = _extract_role_and_text(rec)
+                if extracted is None:
+                    continue
+                role, text = extracted
+                if role == "user":
+                    result.user_turn_count += 1
+                elif role == "assistant":
+                    result.assistant_turn_count += 1
+                turns.append(f"## {role}\n\n{text}")
+    except OSError as e:
+        logger.warning("读取 %s 失败: %s", jsonl_path, e)
+        return result
+
+    full = "\n\n---\n\n".join(turns)
+    truncated_text, truncated = _truncate(full, max_dialog_chars)
+    result.dialog_text = truncated_text
+    result.truncated = truncated
+    result.project_dir_name = jsonl_path.parent.name
+    return result

--- a/jfox/auto_summary/ledger.py
+++ b/jfox/auto_summary/ledger.py
@@ -1,0 +1,243 @@
+"""
+auto-summary 状态文件：~/.zk_auto_summary_state.json
+
+记录每个 session 的处理状态（成功 / 跳过 / 永久失败），防止重复处理；
+失败超过 max_retries 后转为 failed_permanent，永久跳过。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_LEDGER_PATH = Path.home() / ".zk_auto_summary_state.json"
+SCHEMA_VERSION = 1
+DEFAULT_MAX_RETRIES = 3
+
+
+class SessionStatus(str, Enum):
+    SUCCESS = "success"
+    SKIPPED = "skipped"
+    FAILED_TRANSIENT = "failed_transient"  # 可重试
+    FAILED_PERMANENT = "failed_permanent"  # 不再重试
+
+
+_TERMINAL_STATUSES = {
+    SessionStatus.SUCCESS,
+    SessionStatus.SKIPPED,
+    SessionStatus.FAILED_PERMANENT,
+}
+
+
+@dataclass
+class LedgerEntry:
+    project: str
+    processed_at: str
+    status: str  # SessionStatus.value
+    note_id: Optional[str] = None
+    retry_count: int = 0
+    last_error: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "LedgerEntry":
+        return cls(
+            project=str(data.get("project", "")),
+            processed_at=str(data.get("processed_at", "")),
+            status=str(data.get("status", SessionStatus.FAILED_TRANSIENT.value)),
+            note_id=data.get("note_id"),
+            retry_count=int(data.get("retry_count", 0)),
+            last_error=data.get("last_error"),
+        )
+
+
+@dataclass
+class _LedgerData:
+    version: int = SCHEMA_VERSION
+    sessions: dict[str, LedgerEntry] = field(default_factory=dict)
+
+
+class Ledger:
+    """
+    线程安全性说明：本实现非线程安全。daemon 后台循环和 CLI 手动 run 不会
+    并发修改同一份 ledger（CLI 命令本身会去 daemon 之外独立跑），单点写入足够。
+    """
+
+    def __init__(self, path: Optional[Path] = None, max_retries: int = DEFAULT_MAX_RETRIES):
+        self.path = path or DEFAULT_LEDGER_PATH
+        self.max_retries = max_retries
+        self._data = self._load()
+
+    def _load(self) -> _LedgerData:
+        if not self.path.exists():
+            return _LedgerData()
+        try:
+            with open(self.path, "r", encoding="utf-8") as f:
+                raw = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            backup_path = self._backup_corrupted_file()
+            logger.error(
+                "Ledger 文件解析失败 (%s)，已备份至 %s，将以空状态启动",
+                e,
+                backup_path or "(备份失败)",
+            )
+            return _LedgerData()
+
+        version = raw.get("version", SCHEMA_VERSION)
+        if version != SCHEMA_VERSION:
+            logger.warning(
+                "Ledger schema version=%s 与本程序期望 %s 不一致，仍按当前 schema 解析",
+                version,
+                SCHEMA_VERSION,
+            )
+        sessions_raw = raw.get("sessions", {})
+        sessions = {
+            sid: LedgerEntry.from_dict(d) for sid, d in sessions_raw.items() if isinstance(d, dict)
+        }
+        return _LedgerData(version=SCHEMA_VERSION, sessions=sessions)
+
+    def _backup_corrupted_file(self) -> Optional[Path]:
+        """把损坏的 ledger 文件改名为 *.corrupted-<ts>.json，返回新路径。失败返回 None。"""
+        if not self.path.exists():
+            return None
+        try:
+            ts = datetime.now().strftime("%Y%m%dT%H%M%S")
+            backup = self.path.with_suffix(f".corrupted-{ts}.json")
+            self.path.rename(backup)
+            return backup
+        except OSError as e:
+            logger.error("备份损坏的 ledger 文件失败: %s", e)
+            return None
+
+    def _save(self) -> bool:
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "version": self._data.version,
+                "sessions": {sid: e.to_dict() for sid, e in self._data.sessions.items()},
+            }
+            # 原子写：tempfile + os.replace；避免半截写入导致下次 _load 失败、清空所有历史
+            fd, tmp_path = tempfile.mkstemp(
+                prefix=self.path.name + ".",
+                suffix=".tmp",
+                dir=str(self.path.parent),
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    json.dump(payload, f, ensure_ascii=False, indent=2)
+                os.replace(tmp_path, self.path)
+            except Exception:
+                # 清理半成品 tmp 文件，再抛
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
+            return True
+        except OSError as e:
+            logger.error("保存 ledger 失败: %s", e)
+            return False
+
+    # 查询 -----------------------------------------------------------------
+
+    def get(self, session_id: str) -> Optional[LedgerEntry]:
+        return self._data.sessions.get(session_id)
+
+    def is_done(self, session_id: str) -> bool:
+        """该 session 是否已经"了结"（成功 / 跳过 / 永久失败）"""
+        entry = self.get(session_id)
+        if entry is None:
+            return False
+        try:
+            return SessionStatus(entry.status) in _TERMINAL_STATUSES
+        except ValueError:
+            return False
+
+    def all_entries(self) -> dict[str, LedgerEntry]:
+        return dict(self._data.sessions)
+
+    def stats(self) -> dict[str, int]:
+        counts = {s.value: 0 for s in SessionStatus}
+        for e in self._data.sessions.values():
+            counts[e.status] = counts.get(e.status, 0) + 1
+        return counts
+
+    # 写入 -----------------------------------------------------------------
+
+    def record_success(self, session_id: str, project: str, note_id: str) -> bool:
+        self._data.sessions[session_id] = LedgerEntry(
+            project=project,
+            processed_at=datetime.now().isoformat(),
+            status=SessionStatus.SUCCESS.value,
+            note_id=note_id,
+            retry_count=self._existing_retry_count(session_id),
+            last_error=None,
+        )
+        return self._save()
+
+    def record_skip(self, session_id: str, project: str, reason: str) -> bool:
+        self._data.sessions[session_id] = LedgerEntry(
+            project=project,
+            processed_at=datetime.now().isoformat(),
+            status=SessionStatus.SKIPPED.value,
+            note_id=None,
+            retry_count=self._existing_retry_count(session_id),
+            last_error=reason,
+        )
+        return self._save()
+
+    def record_failure(self, session_id: str, project: str, error: str) -> bool:
+        prev = self.get(session_id)
+        retries = (prev.retry_count if prev else 0) + 1
+        permanent = retries >= self.max_retries
+        status = SessionStatus.FAILED_PERMANENT if permanent else SessionStatus.FAILED_TRANSIENT
+        self._data.sessions[session_id] = LedgerEntry(
+            project=project,
+            processed_at=datetime.now().isoformat(),
+            status=status.value,
+            note_id=prev.note_id if prev else None,
+            retry_count=retries,
+            last_error=error[:500],  # 截断防膨胀
+        )
+        return self._save()
+
+    def forget(self, session_id: str) -> bool:
+        """从 ledger 中移除某条，使其下次扫描时被重新处理"""
+        if session_id not in self._data.sessions:
+            return False
+        del self._data.sessions[session_id]
+        return self._save()
+
+    def prune_older_than(self, days: int) -> int:
+        """删除 processed_at 早于 N 天的条目，返回删除数量"""
+        if days <= 0:
+            return 0
+        cutoff = datetime.now().timestamp() - days * 86400
+        to_delete = []
+        for sid, entry in self._data.sessions.items():
+            try:
+                ts = datetime.fromisoformat(entry.processed_at).timestamp()
+            except ValueError:
+                continue
+            if ts < cutoff:
+                to_delete.append(sid)
+        for sid in to_delete:
+            del self._data.sessions[sid]
+        if to_delete:
+            self._save()
+        return len(to_delete)
+
+    def _existing_retry_count(self, session_id: str) -> int:
+        prev = self.get(session_id)
+        return prev.retry_count if prev else 0

--- a/jfox/auto_summary/ledger.py
+++ b/jfox/auto_summary/ledger.py
@@ -94,6 +94,16 @@ class Ledger:
             )
             return _LedgerData()
 
+        # 合法 JSON 但非 dict → 视为损坏，同样备份
+        if not isinstance(raw, dict):
+            backup_path = self._backup_corrupted_file()
+            logger.error(
+                "Ledger 文件期望 dict 但得到 %s，已备份至 %s，将以空状态启动",
+                type(raw).__name__,
+                backup_path or "(备份失败)",
+            )
+            return _LedgerData()
+
         version = raw.get("version", SCHEMA_VERSION)
         if version != SCHEMA_VERSION:
             logger.warning(

--- a/jfox/auto_summary/loop.py
+++ b/jfox/auto_summary/loop.py
@@ -1,0 +1,79 @@
+"""
+daemon 后台循环：每 interval_minutes 调用一次 run_once。
+
+提供：
+- auto_summary_loop(stop_event): asyncio task body
+- _tick_once(): 同步 wrapper（在 executor 中执行 run_once，避免阻塞事件循环）
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from ..global_config import get_global_config_manager
+from .runner import run_once
+
+logger = logging.getLogger(__name__)
+
+
+def _tick_once() -> str:
+    """在 executor 中执行的同步函数。返回简短日志行供 await 后打印。"""
+    cfg = get_global_config_manager().get_auto_summary_config()
+    if not cfg.enabled:
+        return "auto-summary 已禁用，跳过本轮"
+    try:
+        report = run_once(cfg=cfg)
+    except Exception as e:  # 兜底，避免循环退出
+        logger.exception("auto-summary run_once 异常: %s", e)
+        return f"run_once 异常: {e}"
+
+    if report.scanned == 0:
+        return "无待处理 session"
+
+    return (
+        f"扫描 {report.scanned}, 处理 {report.processed}, "
+        f"成功 {report.success}, 跳过 {report.skipped}, 失败 {report.failed}"
+    )
+
+
+async def auto_summary_loop(stop_event: asyncio.Event) -> None:
+    """
+    后台循环主体。stop_event.set() 后立即退出。
+
+    每轮：
+    - 重新读取 GlobalConfig（用户可能在运行期改了 interval / enable）
+    - 通过 run_in_executor 跑 run_once，避免阻塞 daemon 的 HTTP 请求
+    - sleep interval（可被 stop_event 提前中断）
+    """
+    logger.info("auto-summary 后台循环已启动")
+    loop = asyncio.get_running_loop()
+
+    # 启动后短暂延迟，让 daemon 完成模型加载
+    try:
+        await asyncio.wait_for(stop_event.wait(), timeout=10)
+        logger.info("auto-summary 后台循环：启动延迟期间收到停止信号，退出")
+        return
+    except asyncio.TimeoutError:
+        pass
+
+    while not stop_event.is_set():
+        cfg = get_global_config_manager().get_auto_summary_config()
+        interval_sec = max(60, cfg.interval_minutes * 60)
+
+        if cfg.enabled:
+            try:
+                summary = await loop.run_in_executor(None, _tick_once)
+                logger.info("auto-summary tick: %s", summary)
+            except Exception as e:
+                logger.exception("auto-summary tick 异常: %s", e)
+        else:
+            logger.debug("auto-summary 处于禁用状态，等待下一轮")
+
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval_sec)
+            break  # stop_event 已 set
+        except asyncio.TimeoutError:
+            continue
+
+    logger.info("auto-summary 后台循环已退出")

--- a/jfox/auto_summary/loop.py
+++ b/jfox/auto_summary/loop.py
@@ -18,8 +18,14 @@ logger = logging.getLogger(__name__)
 
 
 def _tick_once() -> str:
-    """在 executor 中执行的同步函数。返回简短日志行供 await 后打印。"""
-    cfg = get_global_config_manager().get_auto_summary_config()
+    """在 executor 中执行的同步函数。返回简短日志行供 await 后打印。
+
+    每轮先 reload 全局配置：daemon 进程可能持有旧缓存，CLI `enable` / `disable`
+    已写入新值到磁盘。
+    """
+    gm = get_global_config_manager()
+    gm.reload()
+    cfg = gm.get_auto_summary_config()
     if not cfg.enabled:
         return "auto-summary 已禁用，跳过本轮"
     try:

--- a/jfox/auto_summary/runner.py
+++ b/jfox/auto_summary/runner.py
@@ -1,0 +1,547 @@
+"""
+auto-summary 的核心：调用 claude -p 生成结构化摘要并写入 jfox 知识库。
+
+run_once(): 同步执行一轮扫描 + 总结，返回处理报告
+scan_pending(): 仅返回待处理 session（dry-run）
+summarize_one(): 处理单个 session（供 CLI 单条触发或测试）
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Optional
+
+from ..global_config import AutoSummaryConfig, get_global_config_manager
+from .extractor import extract_dialog
+from .ledger import Ledger, SessionStatus
+from .scanner import (
+    DEFAULT_PROJECT_BLOCKLIST_SUBSTRINGS,
+    SessionFile,
+    default_claude_projects_dir,
+    is_running_inside_isolated_dir,
+    isolated_runs_dir,
+    iter_session_files,
+)
+
+logger = logging.getLogger(__name__)
+
+
+SYSTEM_PROMPT = """你是知识库归档助手。我会通过用户消息提供一段 Claude Code 会话的对话记录（可能被截断）。
+
+你的任务：阅读对话并输出一个**单一的 JSON 对象**，描述这次会话的内容。
+
+强约束：
+1. 输出**必须**是合法 JSON，不要 Markdown 围栏、不要任何前后说明文字
+2. 不允许调用任何工具，仅做纯文本生成
+3. 字段：
+   - skip (bool): 仅当对话内容很少 / 无实质工作 / 仅做闲聊或试探时设 true
+   - reason (str): 当 skip=true 时填跳过原因，否则空串
+   - title (str): 该会话的概括标题，<= 50 个汉字。中文。
+   - topic (str): 简短主题词，例如 "auto-summary 设计" 或 "PR #220 review"。中文。
+   - summary_md (str): Markdown 正文，包含三个二级章节：
+       ## 做了什么
+       <要点列表>
+       ## 关键决策
+       <要点列表>
+       ## 未决事项
+       <要点列表，没有则写 "无">
+     正文中文，简洁，每个要点一行。
+   - tags (list[str]): 3-6 个标签，小写英文或中文短词，不带 # 号
+4. JSON 字段顺序无要求，但所有字段必须出现"""
+
+
+class SummaryOutcome(str, Enum):
+    SUCCESS = "success"
+    SKIPPED = "skipped"
+    FAILED = "failed"  # transient
+    FAILED_PERMANENT = "failed_permanent"
+
+
+@dataclass
+class SummaryResult:
+    """summarize_one 的返回"""
+
+    session_id: str
+    outcome: SummaryOutcome
+    note_id: Optional[str] = None
+    title: Optional[str] = None
+    reason: Optional[str] = None  # skip / failure 原因
+    error: Optional[str] = None
+
+
+@dataclass
+class RunReport:
+    """一轮 run_once 的总报告"""
+
+    scanned: int = 0  # 扫描到的候选 session 数（已过滤 ledger）
+    processed: int = 0  # 实际尝试 summarize 的数量
+    success: int = 0
+    skipped: int = 0
+    failed: int = 0
+    items: list[SummaryResult] = field(default_factory=list)
+
+
+# =============================================================================
+# 主入口
+# =============================================================================
+
+
+def scan_pending(
+    cfg: Optional[AutoSummaryConfig] = None,
+    claude_projects_dir: Optional[Path] = None,
+    ledger: Optional[Ledger] = None,
+) -> list[SessionFile]:
+    """返回当前会被 run_once 处理的 session 列表（已过滤 ledger 中已了结的）"""
+    cfg = cfg or get_global_config_manager().get_auto_summary_config()
+    ledger = ledger if ledger is not None else Ledger()
+
+    pending: list[SessionFile] = []
+    for sf in iter_session_files(
+        claude_projects_dir=claude_projects_dir,
+        idle_threshold_minutes=cfg.idle_threshold_minutes,
+        max_session_size_mb=cfg.max_session_size_mb,
+        min_session_size_kb=cfg.min_session_size_kb,
+        skip_after_days=cfg.skip_after_days,
+    ):
+        if ledger.is_done(sf.session_id):
+            continue
+        pending.append(sf)
+    return pending
+
+
+def run_once(
+    cfg: Optional[AutoSummaryConfig] = None,
+    claude_projects_dir: Optional[Path] = None,
+    ledger: Optional[Ledger] = None,
+    dry_run: bool = False,
+) -> RunReport:
+    """
+    同步执行一轮扫描 + 总结。
+
+    daemon 后台循环和 CLI `auto-summary run` 都通过这个函数。
+    返回 RunReport；失败的单个 session 不会让整轮中断。
+    """
+    cfg = cfg or get_global_config_manager().get_auto_summary_config()
+    ledger = ledger if ledger is not None else Ledger()
+
+    if is_running_inside_isolated_dir():
+        logger.info("当前 cwd 在 auto-summary 隔离目录内，跳过本轮以避免递归")
+        return RunReport()
+
+    pending = scan_pending(cfg=cfg, claude_projects_dir=claude_projects_dir, ledger=ledger)
+    report = RunReport(scanned=len(pending))
+
+    if dry_run or not pending:
+        return report
+
+    limit = max(1, cfg.max_per_tick)
+    for sf in pending[:limit]:
+        result = summarize_one(sf, cfg=cfg, ledger=ledger)
+        report.items.append(result)
+        report.processed += 1
+        if result.outcome == SummaryOutcome.SUCCESS:
+            report.success += 1
+        elif result.outcome == SummaryOutcome.SKIPPED:
+            report.skipped += 1
+        else:
+            report.failed += 1
+
+    return report
+
+
+def summarize_one(
+    session_file: SessionFile,
+    cfg: Optional[AutoSummaryConfig] = None,
+    ledger: Optional[Ledger] = None,
+) -> SummaryResult:
+    """处理单个 session 文件，写入笔记并更新 ledger"""
+    cfg = cfg or get_global_config_manager().get_auto_summary_config()
+    ledger = ledger if ledger is not None else Ledger()
+    project = session_file.project_dir_name
+
+    # 1) 抽对话
+    extracted = extract_dialog(session_file.path)
+    if not extracted.dialog_text or extracted.user_turn_count == 0:
+        ledger.record_skip(session_file.session_id, project, "no user content")
+        return SummaryResult(
+            session_id=session_file.session_id,
+            outcome=SummaryOutcome.SKIPPED,
+            reason="no user content",
+        )
+
+    # 2) 调 claude -p
+    try:
+        claude_output = _invoke_claude(
+            extracted_dialog_text=_build_user_prompt(session_file, extracted), cfg=cfg
+        )
+    except _ClaudeNotFound as e:
+        logger.exception("claude 二进制定位失败 session=%s", session_file.session_id)
+        ledger.record_failure(session_file.session_id, project, str(e))
+        return SummaryResult(
+            session_id=session_file.session_id,
+            outcome=_failed_outcome(ledger, session_file.session_id),
+            error=str(e),
+        )
+    except _ClaudeInvocationError as e:
+        logger.exception("claude -p 调用失败 session=%s", session_file.session_id)
+        ledger.record_failure(session_file.session_id, project, str(e))
+        return SummaryResult(
+            session_id=session_file.session_id,
+            outcome=_failed_outcome(ledger, session_file.session_id),
+            error=str(e),
+        )
+
+    # 3) 解析 claude 返回的 JSON
+    try:
+        parsed = _parse_claude_json(claude_output)
+    except _ParseError as e:
+        logger.warning(
+            "解析 claude 输出失败 session=%s err=%s preview=%r",
+            session_file.session_id,
+            e,
+            claude_output[:300],
+        )
+        ledger.record_failure(session_file.session_id, project, f"parse error: {e}")
+        return SummaryResult(
+            session_id=session_file.session_id,
+            outcome=_failed_outcome(ledger, session_file.session_id),
+            error=f"parse error: {e}",
+        )
+
+    # 4) skip 分支
+    if parsed.get("skip") is True:
+        reason = str(parsed.get("reason") or "claude marked skip")
+        ledger.record_skip(session_file.session_id, project, reason)
+        return SummaryResult(
+            session_id=session_file.session_id,
+            outcome=SummaryOutcome.SKIPPED,
+            reason=reason,
+        )
+
+    # 5) 写入知识库
+    title = (parsed.get("title") or "").strip() or f"会话 {session_file.session_id[:8]}"
+    topic = (parsed.get("topic") or "").strip() or "claude-code-session"
+    summary_md = (parsed.get("summary_md") or "").strip()
+    tags = parsed.get("tags") or []
+    if not isinstance(tags, list):
+        tags = []
+    tags = [str(t).strip() for t in tags if str(t).strip()]
+    base_tags = ["session", "auto-summary"]
+    for bt in base_tags:
+        if bt not in tags:
+            tags.append(bt)
+
+    if not summary_md:
+        ledger.record_failure(session_file.session_id, project, "empty summary_md")
+        return SummaryResult(
+            session_id=session_file.session_id,
+            outcome=_failed_outcome(ledger, session_file.session_id),
+            error="claude 返回的 summary_md 为空",
+        )
+
+    full_content = _compose_note_body(extracted, summary_md, session_file)
+
+    try:
+        note_id = _save_session_note(
+            content=full_content,
+            title=title,
+            tags=tags,
+            topic=topic,
+            target_kb=cfg.target_kb,
+        )
+    except Exception as e:
+        logger.exception("保存会话笔记失败 session=%s", session_file.session_id)
+        ledger.record_failure(session_file.session_id, project, f"save error: {e}")
+        return SummaryResult(
+            session_id=session_file.session_id,
+            outcome=_failed_outcome(ledger, session_file.session_id),
+            error=f"save error: {e}",
+        )
+
+    ledger.record_success(session_file.session_id, project, note_id)
+    return SummaryResult(
+        session_id=session_file.session_id,
+        outcome=SummaryOutcome.SUCCESS,
+        note_id=note_id,
+        title=title,
+    )
+
+
+# =============================================================================
+# 内部：claude 调用
+# =============================================================================
+
+
+class _ClaudeNotFound(RuntimeError):
+    pass
+
+
+class _ClaudeInvocationError(RuntimeError):
+    pass
+
+
+class _ParseError(ValueError):
+    pass
+
+
+def _resolve_claude_binary(cfg: AutoSummaryConfig) -> str:
+    """返回 claude 可执行文件的绝对路径"""
+    if cfg.claude_binary:
+        candidate = cfg.claude_binary
+        if Path(candidate).is_file():
+            return candidate
+        resolved = shutil.which(candidate)
+        if resolved:
+            return resolved
+        raise _ClaudeNotFound(f"配置的 claude_binary 不可执行: {candidate}")
+
+    resolved = shutil.which("claude")
+    if not resolved:
+        raise _ClaudeNotFound(
+            "未找到 'claude' 命令。请确认已安装 Claude Code CLI 并在 PATH 中，"
+            "或在配置中显式设置 claude_binary。"
+        )
+    return resolved
+
+
+def _build_user_prompt(session_file: SessionFile, extracted) -> str:
+    """构造给 claude -p 的 stdin 输入：metadata 头 + dialog 正文"""
+    lines = [
+        "# Claude Code 会话摘要请求",
+        "",
+        f"- session_id: {session_file.session_id}",
+        f"- project_dir: {session_file.project_dir_name}",
+    ]
+    if extracted.cwd:
+        lines.append(f"- cwd: {extracted.cwd}")
+    if extracted.git_branch:
+        lines.append(f"- git_branch: {extracted.git_branch}")
+    if extracted.started_at:
+        lines.append(f"- started_at: {extracted.started_at}")
+    if extracted.ended_at:
+        lines.append(f"- ended_at: {extracted.ended_at}")
+    lines.append(
+        f"- 用户轮次: {extracted.user_turn_count}, 助手轮次: {extracted.assistant_turn_count}"
+    )
+    if extracted.truncated:
+        lines.append("- 注意：对话过长，已截断中段")
+    lines.append("")
+    lines.append("# 对话记录")
+    lines.append("")
+    lines.append(extracted.dialog_text)
+    lines.append("")
+    lines.append("---")
+    lines.append("现在请按 system prompt 要求输出 JSON。")
+    return "\n".join(lines)
+
+
+def _invoke_claude(extracted_dialog_text: str, cfg: AutoSummaryConfig) -> str:
+    """调用 claude -p，返回原始 stdout（非空字符串）"""
+    binary = _resolve_claude_binary(cfg)
+    cwd = isolated_runs_dir()
+
+    cmd = [
+        binary,
+        "-p",
+        "--output-format",
+        "json",
+        "--append-system-prompt",
+        SYSTEM_PROMPT,
+        "--permission-mode",
+        "bypassPermissions",
+    ]
+
+    # Windows 下对 .cmd 要走 shell 解释（shutil.which 可能返回 .cmd 路径）
+    use_shell = os.name == "nt" and binary.lower().endswith((".cmd", ".bat"))
+
+    # 隔离环境：避免继承 JFOX_KB / JFOX_DAEMON_PROCESS 等可能影响子 claude 行为的变量
+    env = os.environ.copy()
+    for noisy in ("JFOX_KB", "JFOX_DAEMON_PROCESS"):
+        env.pop(noisy, None)
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            input=extracted_dialog_text,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=str(cwd),
+            timeout=max(30, cfg.claude_timeout_seconds),
+            env=env,
+            shell=use_shell,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise _ClaudeInvocationError(f"claude -p 超时（{cfg.claude_timeout_seconds}s）") from e
+    except OSError as e:
+        raise _ClaudeInvocationError(f"启动 claude 失败: {e}") from e
+
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()[:500]
+        raise _ClaudeInvocationError(
+            f"claude -p 退出码 {proc.returncode}: {stderr or '(no stderr)'}"
+        )
+
+    out = (proc.stdout or "").strip()
+    if not out:
+        stderr_hint = (proc.stderr or "").strip()[:200]
+        raise _ClaudeInvocationError(f"claude -p 返回空 stdout (stderr: {stderr_hint or '(none)'})")
+    return out
+
+
+def _parse_claude_json(stdout: str) -> dict[str, Any]:
+    """
+    claude -p --output-format json 的外层封装格式可能含有 'result' 字段，
+    其内才是模型的真实输出。这里先剥外壳再找内层 JSON。
+    """
+    # 第一层：claude CLI 的 JSON envelope
+    inner_text: Optional[str] = None
+    try:
+        envelope = json.loads(stdout)
+        if isinstance(envelope, dict):
+            for key in ("result", "text", "content", "response"):
+                v = envelope.get(key)
+                if isinstance(v, str) and v.strip():
+                    inner_text = v
+                    break
+            # 如果外层就是我们要的 JSON 对象（直接含 title/summary_md），返回即可
+            if inner_text is None and any(k in envelope for k in ("summary_md", "title", "skip")):
+                return envelope
+    except json.JSONDecodeError:
+        # 不是 JSON 包装，可能 claude 直接吐了模型输出
+        inner_text = stdout
+
+    if inner_text is None:
+        raise _ParseError("未从 claude 输出中找到内层文本")
+
+    return _extract_object(inner_text)
+
+
+_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def _extract_object(text: str) -> dict[str, Any]:
+    """从可能含有 markdown 围栏或前后说明的字符串里抠出第一个 JSON 对象"""
+    text = text.strip()
+    if not text:
+        raise _ParseError("空文本")
+
+    # 直接尝试
+    try:
+        obj = json.loads(text)
+        if isinstance(obj, dict):
+            return obj
+    except json.JSONDecodeError:
+        pass
+
+    # 剥 ```json fences```
+    fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    if fenced:
+        try:
+            obj = json.loads(fenced.group(1))
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            pass
+
+    # 找第一个大括号包裹的整体（可能尾巴有逗号等问题）
+    match = _OBJECT_RE.search(text)
+    if match:
+        candidate = match.group(0)
+        try:
+            obj = json.loads(candidate)
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError as e:
+            raise _ParseError(f"找到了 {{...}} 但无法解析: {e}") from e
+
+    raise _ParseError("文本中找不到 JSON 对象")
+
+
+# =============================================================================
+# 内部：写入知识库
+# =============================================================================
+
+
+def _compose_note_body(extracted, summary_md: str, sf: SessionFile) -> str:
+    """拼装最终笔记 Markdown 正文，附带元数据 footer"""
+    meta_lines = ["---", "## 元数据", ""]
+    if extracted.cwd:
+        meta_lines.append(f"- 工作目录: `{extracted.cwd}`")
+    if extracted.git_branch:
+        meta_lines.append(f"- Git 分支: `{extracted.git_branch}`")
+    if extracted.started_at:
+        meta_lines.append(f"- 起始时间: {extracted.started_at}")
+    if extracted.ended_at:
+        meta_lines.append(f"- 结束时间: {extracted.ended_at}")
+    meta_lines.append(
+        f"- 对话轮次: 用户 {extracted.user_turn_count} / 助手 {extracted.assistant_turn_count}"
+    )
+    meta_lines.append(f"- session_id: `{sf.session_id}`")
+    meta_lines.append(f"- 项目目录: `{sf.project_dir_name}`")
+    meta_lines.append("- 来源: jfox auto-summary")
+    return summary_md.strip() + "\n\n" + "\n".join(meta_lines)
+
+
+def _save_session_note(
+    content: str,
+    title: str,
+    tags: list[str],
+    topic: str,
+    target_kb: Optional[str],
+) -> str:
+    """
+    在指定 KB 内创建一条 session 类型笔记，返回 note_id。
+
+    不复用 cli._add_note_impl 是为了避免它的 print 输出污染 daemon 日志。
+    """
+    # 延迟导入，避免循环 / 加载成本
+    from .. import note as note_module
+    from ..config import use_kb
+    from ..models import NoteType
+
+    with use_kb(target_kb):
+        new_note = note_module.create_note(
+            content=content,
+            title=title,
+            note_type=NoteType.SESSION,
+            tags=tags,
+            links=[],
+            source=None,
+            topic=topic,
+        )
+        if not note_module.save_note(new_note):
+            raise RuntimeError("note_module.save_note 返回 False")
+        return new_note.id
+
+
+def _failed_outcome(ledger: Ledger, session_id: str) -> SummaryOutcome:
+    """根据 ledger 中最新状态返回 transient or permanent"""
+    entry = ledger.get(session_id)
+    if entry is None:
+        return SummaryOutcome.FAILED
+    if entry.status == SessionStatus.FAILED_PERMANENT.value:
+        return SummaryOutcome.FAILED_PERMANENT
+    return SummaryOutcome.FAILED
+
+
+# Re-export
+__all__ = [
+    "SummaryOutcome",
+    "SummaryResult",
+    "RunReport",
+    "scan_pending",
+    "run_once",
+    "summarize_one",
+    "DEFAULT_PROJECT_BLOCKLIST_SUBSTRINGS",
+    "default_claude_projects_dir",
+]

--- a/jfox/auto_summary/runner.py
+++ b/jfox/auto_summary/runner.py
@@ -295,13 +295,15 @@ class _ParseError(ValueError):
 def _resolve_claude_binary(cfg: AutoSummaryConfig) -> str:
     """返回 claude 可执行文件的绝对路径"""
     if cfg.claude_binary:
-        candidate = cfg.claude_binary
-        if Path(candidate).is_file():
-            return candidate
-        resolved = shutil.which(candidate)
+        candidate = Path(cfg.claude_binary).expanduser().resolve()
+        if candidate.is_file():
+            return str(candidate)
+        resolved = shutil.which(str(candidate))
         if resolved:
             return resolved
-        raise _ClaudeNotFound(f"配置的 claude_binary 不可执行: {candidate}")
+        raise _ClaudeNotFound(
+            f"配置的 claude_binary 不可执行: {cfg.claude_binary} (展开后: {candidate})"
+        )
 
     resolved = shutil.which("claude")
     if not resolved:
@@ -426,7 +428,32 @@ def _parse_claude_json(stdout: str) -> dict[str, Any]:
     return _extract_object(inner_text)
 
 
-_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
+def _extract_balanced_json(text: str, start: int) -> Optional[str]:
+    """从 text[start] 处（必须是 '{'）开始，找到配对的 '}' 返回子串。
+
+    正确处理字符串内的转义引号和嵌套大括号。"""
+    depth = 0
+    in_string = False
+    escape = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+        else:
+            if ch == '"':
+                in_string = True
+            elif ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[start : i + 1]
+    return None
 
 
 def _extract_object(text: str) -> dict[str, Any]:
@@ -453,16 +480,17 @@ def _extract_object(text: str) -> dict[str, Any]:
         except json.JSONDecodeError:
             pass
 
-    # 找第一个大括号包裹的整体（可能尾巴有逗号等问题）
-    match = _OBJECT_RE.search(text)
-    if match:
-        candidate = match.group(0)
-        try:
-            obj = json.loads(candidate)
-            if isinstance(obj, dict):
-                return obj
-        except json.JSONDecodeError as e:
-            raise _ParseError(f"找到了 {{...}} 但无法解析: {e}") from e
+    # 找第一个平衡的大括号对象（不用贪婪正则，避免跨对象匹配）
+    brace_idx = text.find("{")
+    if brace_idx >= 0:
+        candidate = _extract_balanced_json(text, brace_idx)
+        if candidate is not None:
+            try:
+                obj = json.loads(candidate)
+                if isinstance(obj, dict):
+                    return obj
+            except json.JSONDecodeError as e:
+                raise _ParseError(f"找到了 {{...}} 但无法解析: {e}") from e
 
     raise _ParseError("文本中找不到 JSON 对象")
 

--- a/jfox/auto_summary/scanner.py
+++ b/jfox/auto_summary/scanner.py
@@ -1,0 +1,161 @@
+"""
+扫描 ~/.claude/projects/ 下的 Claude Code session 文件，筛选出"已结束、待总结"的。
+
+判定结束：mtime 距今超过 idle_threshold_minutes。
+排除条件：在 ledger 黑名单内 / 项目目录在硬编码黑名单内 / size 超阈值或太小 / 太老。
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Sequence
+
+logger = logging.getLogger(__name__)
+
+# claude -p 自身会创建 session 文件，下列子串若出现在 project 目录名中则跳过，避免递归
+DEFAULT_PROJECT_BLOCKLIST_SUBSTRINGS: tuple[str, ...] = (
+    "jfox-auto-summary-runs",
+    "auto-session-summary",
+)
+
+
+def default_claude_projects_dir() -> Path:
+    """返回 ~/.claude/projects/ 的路径"""
+    return Path.home() / ".claude" / "projects"
+
+
+@dataclass(frozen=True)
+class SessionFile:
+    """一个待处理的 session 文件"""
+
+    session_id: str  # UUID（去掉 .jsonl 后缀的文件名）
+    project_dir_name: str  # ~/.claude/projects/ 下的目录名
+    path: Path
+    mtime: float  # epoch seconds
+    size_bytes: int
+
+    @property
+    def age_seconds(self) -> float:
+        return max(0.0, time.time() - self.mtime)
+
+    @property
+    def size_mb(self) -> float:
+        return self.size_bytes / (1024 * 1024)
+
+
+def _is_blocked_project(name: str, blocklist: Sequence[str]) -> bool:
+    lname = name.lower()
+    return any(token.lower() in lname for token in blocklist)
+
+
+def iter_session_files(
+    claude_projects_dir: Path | None = None,
+    idle_threshold_minutes: int = 30,
+    max_session_size_mb: int = 10,
+    min_session_size_kb: int = 5,
+    skip_after_days: int = 7,
+    project_blocklist: Sequence[str] = DEFAULT_PROJECT_BLOCKLIST_SUBSTRINGS,
+    now: float | None = None,
+) -> Iterator[SessionFile]:
+    """
+    遍历 claude_projects_dir 下所有 .jsonl session 文件，仅产出满足以下条件的：
+
+    - 文件大小落在 [min_session_size_kb*1024, max_session_size_mb*1024*1024] 内
+    - mtime 距今 >= idle_threshold_minutes（已静默）
+    - mtime 距今 <= skip_after_days（不太老）
+    - 项目目录名不在 project_blocklist 内
+
+    不读取 ledger，调用方负责再过滤 ledger 中已处理的 session。
+    """
+    base = claude_projects_dir or default_claude_projects_dir()
+    if not base.exists() or not base.is_dir():
+        logger.debug("Claude projects 目录不存在: %s", base)
+        return
+
+    current_time = now if now is not None else time.time()
+    idle_threshold_sec = max(0, idle_threshold_minutes) * 60
+    skip_after_sec = max(0, skip_after_days) * 86400
+    min_size = max(0, min_session_size_kb) * 1024
+    max_size = max(0, max_session_size_mb) * 1024 * 1024
+
+    for project_dir in sorted(base.iterdir()):
+        if not project_dir.is_dir():
+            continue
+        if _is_blocked_project(project_dir.name, project_blocklist):
+            logger.debug("跳过黑名单项目: %s", project_dir.name)
+            continue
+
+        for entry in sorted(project_dir.iterdir()):
+            if not entry.is_file() or entry.suffix.lower() != ".jsonl":
+                continue
+            try:
+                stat = entry.stat()
+            except OSError as e:
+                logger.debug("无法 stat %s: %s", entry, e)
+                continue
+
+            size = stat.st_size
+            mtime = stat.st_mtime
+            age = current_time - mtime
+
+            if size < min_size:
+                continue
+            if max_size and size > max_size:
+                logger.debug("跳过过大 session %s (%.1f MB)", entry.name, size / (1024 * 1024))
+                continue
+            if age < idle_threshold_sec:
+                continue
+            if skip_after_sec and age > skip_after_sec:
+                logger.debug("跳过过旧 session %s (%.1f 天)", entry.name, age / 86400)
+                continue
+
+            yield SessionFile(
+                session_id=entry.stem,
+                project_dir_name=project_dir.name,
+                path=entry,
+                mtime=mtime,
+                size_bytes=size,
+            )
+
+
+def isolated_runs_dir() -> Path:
+    """返回 claude -p 隔离工作目录，并按需创建。
+
+    runner 会在此目录下调用 claude -p，对应的 ~/.claude/projects/ 目录名包含
+    'jfox-auto-summary-runs' 子串，会被默认黑名单排除，避免递归总结自身。
+    """
+    p = Path.home() / ".jfox-auto-summary-runs"
+    p.mkdir(parents=True, exist_ok=True)
+    # 占位文件，方便用户知道这是干什么的
+    readme = p / "README.txt"
+    if not readme.exists():
+        try:
+            readme.write_text(
+                "This directory is the isolated cwd for `jfox auto-summary` runs.\n"
+                "Each invocation of `claude -p` from auto-summary uses this as its\n"
+                "working directory so that the resulting Claude Code session files\n"
+                "land in a project path that is excluded from auto-summary scans.\n"
+                "Safe to delete — will be recreated on next run.\n",
+                encoding="utf-8",
+            )
+        except OSError:
+            pass
+    return p
+
+
+def is_running_inside_isolated_dir() -> bool:
+    """判断当前进程是否运行在隔离目录或其子目录下（防止误总结自己）"""
+    try:
+        cwd = Path(os.getcwd()).resolve()
+    except OSError:
+        return False
+    iso = (Path.home() / ".jfox-auto-summary-runs").resolve()
+    try:
+        cwd.relative_to(iso)
+        return True
+    except ValueError:
+        return False

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -93,6 +93,11 @@ app.add_typer(template_app, name="template", help="Manage note templates")
 model_app = typer.Typer(name="model", help="模型管理")
 app.add_typer(model_app, name="model", help="模型管理")
 
+# Auto-summary 子命令组（Claude Code 会话定时自动总结）
+from .auto_summary.cli import auto_summary_app  # noqa: E402
+
+app.add_typer(auto_summary_app, name="auto-summary")
+
 console = Console(legacy_windows=False)
 
 

--- a/jfox/daemon/server.py
+++ b/jfox/daemon/server.py
@@ -6,10 +6,11 @@
 """
 
 import argparse
+import asyncio
 import logging
 import os
 from contextlib import asynccontextmanager
-from typing import List
+from typing import List, Optional
 
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -21,6 +22,10 @@ _backend = None
 
 # uvicorn Server 实例（用于 graceful shutdown）
 _server = None
+
+# auto-summary 后台 task 与停止信号
+_auto_summary_task: Optional[asyncio.Task] = None
+_auto_summary_stop_event: Optional[asyncio.Event] = None
 
 
 def _load_model():
@@ -43,10 +48,61 @@ def _load_model():
         os._exit(1)
 
 
+def _maybe_start_auto_summary() -> None:
+    """如果用户启用了 auto-summary，启动后台循环 task"""
+    global _auto_summary_task, _auto_summary_stop_event
+    try:
+        from ..auto_summary.loop import auto_summary_loop
+        from ..global_config import get_global_config_manager
+
+        cfg = get_global_config_manager().get_auto_summary_config()
+        if not cfg.enabled:
+            logger.info("Daemon: auto-summary 未启用（config.auto_summary.enabled=false）")
+            return
+
+        _auto_summary_stop_event = asyncio.Event()
+        _auto_summary_task = asyncio.create_task(auto_summary_loop(_auto_summary_stop_event))
+        logger.info(
+            "Daemon: auto-summary 后台循环已启动 (interval=%dm, idle_threshold=%dm)",
+            cfg.interval_minutes,
+            cfg.idle_threshold_minutes,
+        )
+    except Exception as e:
+        logger.exception("Daemon: 启动 auto-summary 后台循环失败: %s", e)
+
+
+async def _maybe_stop_auto_summary() -> None:
+    """关闭 auto-summary 后台循环（lifespan shutdown 阶段调用）"""
+    global _auto_summary_task, _auto_summary_stop_event
+    if _auto_summary_stop_event is not None:
+        _auto_summary_stop_event.set()
+    if _auto_summary_task is not None:
+        try:
+            await asyncio.wait_for(_auto_summary_task, timeout=5)
+        except asyncio.TimeoutError:
+            logger.warning("Daemon: auto-summary task 5s 内未退出，取消之")
+            _auto_summary_task.cancel()
+            # 等待 cancel 实际生效；如果 task 阻塞在 executor 的 claude -p 上，
+            # task.cancel() 不会终止 subprocess，仍会阻塞，但等到子进程超时（cfg.claude_timeout_seconds）后会返回
+            try:
+                await asyncio.gather(_auto_summary_task, return_exceptions=True)
+            except Exception as inner:
+                logger.warning("Daemon: 等待 auto-summary 取消时异常: %s", inner)
+        except Exception as e:
+            logger.warning("Daemon: 等待 auto-summary 退出时异常: %s", e)
+            _auto_summary_task.cancel()
+    _auto_summary_task = None
+    _auto_summary_stop_event = None
+
+
 @asynccontextmanager
 async def lifespan(app):
     _load_model()
-    yield
+    _maybe_start_auto_summary()
+    try:
+        yield
+    finally:
+        await _maybe_stop_auto_summary()
 
 
 app = FastAPI(title="JFox Embedding Daemon", lifespan=lifespan)
@@ -131,6 +187,32 @@ def encode_single(req: EncodeSingleRequest):
         embedding=embedding.tolist(),
         dimension=_backend.dimension,
     )
+
+
+@app.get("/auto_summary/status")
+def auto_summary_status():
+    """auto-summary 后台循环状态（仅供调试观察）"""
+    from ..auto_summary.ledger import Ledger
+    from ..global_config import get_global_config_manager
+
+    cfg = get_global_config_manager().get_auto_summary_config()
+    running = _auto_summary_task is not None and not _auto_summary_task.done()
+    try:
+        ledger_stats = Ledger().stats()
+    except Exception as e:
+        ledger_stats = {"error": str(e)}
+
+    return {
+        "config": {
+            "enabled": cfg.enabled,
+            "interval_minutes": cfg.interval_minutes,
+            "idle_threshold_minutes": cfg.idle_threshold_minutes,
+            "max_per_tick": cfg.max_per_tick,
+            "target_kb": cfg.target_kb,
+        },
+        "task_running": running,
+        "ledger": ledger_stats,
+    }
 
 
 # =============================================================================

--- a/jfox/global_config.py
+++ b/jfox/global_config.py
@@ -141,6 +141,15 @@ class GlobalConfigManager:
         self.config_path = config_path or DEFAULT_CONFIG_PATH
         self._config: Optional[GlobalConfig] = None
 
+    def reload(self) -> GlobalConfig:
+        """强制重新从磁盘加载配置（丢弃进程内缓存）
+
+        daemon 后台循环或跨进程协作中，CLI 可能已修改磁盘上的配置；
+        调用此方法使配置从文件重新读取，而非返回旧缓存。
+        """
+        self._config = None
+        return self._load()
+
     def _load(self) -> GlobalConfig:
         """加载配置，如果不存在则创建默认配置"""
         if self._config is not None:

--- a/jfox/global_config.py
+++ b/jfox/global_config.py
@@ -45,16 +45,76 @@ class KnowledgeBaseEntry:
 
 
 @dataclass
+class AutoSummaryConfig:
+    """Claude Code 会话自动总结配置（opt-in，默认关闭）"""
+
+    enabled: bool = False
+    interval_minutes: int = 30  # 后台循环每多少分钟扫一次
+    idle_threshold_minutes: int = 30  # session 文件 mtime 静默多久才视为已结束
+    target_kb: Optional[str] = None  # 写入哪个知识库；None 用 default
+    max_session_size_mb: int = 10  # 超过此大小的 session 跳过（避免 token 爆炸）
+    min_session_size_kb: int = 5  # 太小的 session 跳过（无实质内容）
+    max_per_tick: int = 5  # 每轮最多处理几个 session
+    skip_after_days: int = 7  # 超过此天数的旧 session 不再补做
+    claude_timeout_seconds: int = 120  # claude -p 调用超时
+    claude_binary: Optional[str] = None  # claude 命令路径；None 表示从 PATH 解析
+
+    def __post_init__(self) -> None:
+        # 把负值/0 当成"用默认值"而非崩溃；空字符串 target_kb 等价于 None
+        if self.interval_minutes < 1:
+            self.interval_minutes = 30
+        if self.idle_threshold_minutes < 1:
+            self.idle_threshold_minutes = 30
+        if self.max_session_size_mb < 1:
+            self.max_session_size_mb = 10
+        if self.min_session_size_kb < 0:
+            self.min_session_size_kb = 0
+        if self.max_per_tick < 1:
+            self.max_per_tick = 1
+        if self.skip_after_days < 0:
+            self.skip_after_days = 0
+        if self.claude_timeout_seconds < 30:
+            self.claude_timeout_seconds = 30
+        # 大小区间健全性：min_kb 不应大于 max_mb*1024
+        if self.min_session_size_kb >= self.max_session_size_mb * 1024:
+            self.min_session_size_kb = max(0, self.max_session_size_mb * 1024 - 1)
+        if isinstance(self.target_kb, str) and not self.target_kb.strip():
+            self.target_kb = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Optional[Dict[str, Any]]) -> "AutoSummaryConfig":
+        if not data:
+            return cls()
+        return cls(
+            enabled=bool(data.get("enabled", False)),
+            interval_minutes=int(data.get("interval_minutes", 30)),
+            idle_threshold_minutes=int(data.get("idle_threshold_minutes", 30)),
+            target_kb=data.get("target_kb"),
+            max_session_size_mb=int(data.get("max_session_size_mb", 10)),
+            min_session_size_kb=int(data.get("min_session_size_kb", 5)),
+            max_per_tick=int(data.get("max_per_tick", 5)),
+            skip_after_days=int(data.get("skip_after_days", 7)),
+            claude_timeout_seconds=int(data.get("claude_timeout_seconds", 120)),
+            claude_binary=data.get("claude_binary"),
+        )
+
+
+@dataclass
 class GlobalConfig:
     """全局配置"""
 
     default: str = DEFAULT_KB_NAME
     knowledge_bases: Dict[str, KnowledgeBaseEntry] = field(default_factory=dict)
+    auto_summary: AutoSummaryConfig = field(default_factory=AutoSummaryConfig)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
             "default": self.default,
             "knowledge_bases": {name: kb.to_dict() for name, kb in self.knowledge_bases.items()},
+            "auto_summary": self.auto_summary.to_dict(),
         }
 
     @classmethod
@@ -66,6 +126,7 @@ class GlobalConfig:
         return cls(
             default=data.get("default", DEFAULT_KB_NAME),
             knowledge_bases=kbs,
+            auto_summary=AutoSummaryConfig.from_dict(data.get("auto_summary")),
         )
 
 
@@ -322,6 +383,19 @@ class GlobalConfigManager:
             return self._save()
 
         return False
+
+    def get_auto_summary_config(self) -> AutoSummaryConfig:
+        """获取自动总结配置"""
+        return self._load().auto_summary
+
+    def update_auto_summary_config(self, **changes: Any) -> bool:
+        """更新自动总结配置中的若干字段，未传入的字段保持原样"""
+        config = self._load()
+        current = asdict(config.auto_summary)
+        current.update({k: v for k, v in changes.items() if k in current})
+        config.auto_summary = AutoSummaryConfig.from_dict(current)
+        self._config = config
+        return self._save()
 
 
 # 全局配置管理器实例

--- a/tests/unit/test_auto_summary_extractor.py
+++ b/tests/unit/test_auto_summary_extractor.py
@@ -1,0 +1,178 @@
+"""
+测试类型: 单元测试
+目标模块: jfox.auto_summary.extractor
+预估耗时: < 1秒
+依赖要求: 无外部依赖
+"""
+
+import json
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+from jfox.auto_summary.extractor import (
+    DEFAULT_MAX_DIALOG_CHARS,
+    extract_dialog,
+)
+
+
+def _write_jsonl(path, records):
+    with open(path, "w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+
+class TestExtractDialog:
+    def test_strips_tool_use_and_attachments(self, tmp_path):
+        path = tmp_path / "session.jsonl"
+        _write_jsonl(
+            path,
+            [
+                {"type": "last-prompt", "leafUuid": "x"},
+                {"type": "permission-mode", "permissionMode": "bypassPermissions"},
+                {
+                    "type": "attachment",
+                    "attachment": {"foo": "bar"},
+                    "cwd": "C:/work",
+                    "gitBranch": "main",
+                },
+                {
+                    "type": "user",
+                    "timestamp": "2026-05-19T13:47:35Z",
+                    "message": {"role": "user", "content": "你好，帮我看下代码"},
+                },
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-05-19T13:47:40Z",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "好的，我看一下。"},
+                            {"type": "tool_use", "name": "Read", "input": {"file_path": "/a"}},
+                        ],
+                    },
+                },
+                {
+                    "type": "user",
+                    "timestamp": "2026-05-19T13:47:50Z",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {"type": "tool_result", "content": "..."},
+                            {"type": "text", "text": "继续"},
+                        ],
+                    },
+                },
+            ],
+        )
+
+        result = extract_dialog(path)
+
+        assert result.cwd == "C:/work"
+        assert result.git_branch == "main"
+        assert result.user_turn_count == 2
+        assert result.assistant_turn_count == 1
+        assert "你好，帮我看下代码" in result.dialog_text
+        assert "好的，我看一下。" in result.dialog_text
+        assert "继续" in result.dialog_text
+        # tool_use / tool_result / attachment should not leak through
+        assert "tool_use" not in result.dialog_text
+        assert "tool_result" not in result.dialog_text
+        assert "attachment" not in result.dialog_text
+        assert result.started_at is not None
+        assert result.ended_at is not None
+        assert not result.truncated
+
+    def test_drops_system_reminder_only_messages(self, tmp_path):
+        path = tmp_path / "session.jsonl"
+        _write_jsonl(
+            path,
+            [
+                {
+                    "type": "user",
+                    "timestamp": "2026-05-19T10:00:00Z",
+                    "message": {
+                        "role": "user",
+                        "content": "<system-reminder>noise</system-reminder>",
+                    },
+                },
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-05-19T10:00:01Z",
+                    "message": {"role": "assistant", "content": "ok"},
+                },
+            ],
+        )
+
+        result = extract_dialog(path)
+        assert result.user_turn_count == 0
+        assert result.assistant_turn_count == 1
+        assert "noise" not in result.dialog_text
+        assert "ok" in result.dialog_text
+
+    def test_drops_system_reminder_inside_multi_item_content(self, tmp_path):
+        """system-reminder 与真实文本混在同一个 content 数组里时，应只剔除 system-reminder 段，
+        保留用户的真实输入。回归保护：避免 system-reminder 噪音泄漏到 summary prompt。"""
+        path = tmp_path / "session.jsonl"
+        _write_jsonl(
+            path,
+            [
+                {
+                    "type": "user",
+                    "timestamp": "2026-05-19T10:00:00Z",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "<system-reminder>noise here</system-reminder>",
+                            },
+                            {"type": "text", "text": "实际的用户输入"},
+                        ],
+                    },
+                },
+            ],
+        )
+
+        result = extract_dialog(path)
+        assert result.user_turn_count == 1
+        assert "实际的用户输入" in result.dialog_text
+        assert "noise here" not in result.dialog_text
+        assert "system-reminder" not in result.dialog_text
+
+    def test_truncation_when_too_long(self, tmp_path):
+        path = tmp_path / "session.jsonl"
+        big = "x" * 20000
+        records = [
+            {
+                "type": "user",
+                "timestamp": "2026-05-19T10:00:00Z",
+                "message": {"role": "user", "content": big},
+            }
+            for _ in range(5)  # 5 * 20000 = 100k > 30k 默认上限
+        ]
+        _write_jsonl(path, records)
+
+        result = extract_dialog(path)
+        assert result.truncated
+        assert len(result.dialog_text) <= DEFAULT_MAX_DIALOG_CHARS + 200  # +separator
+        assert "省略中间" in result.dialog_text
+
+    def test_handles_malformed_jsonl_lines(self, tmp_path):
+        path = tmp_path / "session.jsonl"
+        with open(path, "w", encoding="utf-8") as f:
+            f.write('{"type":"user","message":{"role":"user","content":"hello"}}\n')
+            f.write("not json at all\n")
+            f.write('{"type":"assistant","message":{"role":"assistant","content":"hi"}}\n')
+
+        result = extract_dialog(path)
+        assert result.user_turn_count == 1
+        assert result.assistant_turn_count == 1
+        assert "hello" in result.dialog_text
+        assert "hi" in result.dialog_text
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        result = extract_dialog(tmp_path / "no_such.jsonl")
+        assert result.dialog_text == ""
+        assert result.user_turn_count == 0

--- a/tests/unit/test_auto_summary_ledger.py
+++ b/tests/unit/test_auto_summary_ledger.py
@@ -1,0 +1,126 @@
+"""
+测试类型: 单元测试
+目标模块: jfox.auto_summary.ledger
+预估耗时: < 1秒
+依赖要求: 无外部依赖
+"""
+
+import json
+from datetime import datetime, timedelta
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+from jfox.auto_summary.ledger import Ledger, SessionStatus
+
+
+@pytest.fixture
+def tmp_ledger(tmp_path):
+    return Ledger(path=tmp_path / "state.json", max_retries=3)
+
+
+class TestLedger:
+    def test_empty_ledger_has_no_entries(self, tmp_ledger):
+        assert tmp_ledger.all_entries() == {}
+        assert tmp_ledger.get("anything") is None
+        assert tmp_ledger.is_done("anything") is False
+
+    def test_record_success_persists(self, tmp_path):
+        path = tmp_path / "s.json"
+        led = Ledger(path=path)
+        assert led.record_success("sid1", "proj1", "20260519100000")
+        assert led.is_done("sid1")
+        # reload & verify
+        led2 = Ledger(path=path)
+        entry = led2.get("sid1")
+        assert entry is not None
+        assert entry.status == SessionStatus.SUCCESS.value
+        assert entry.note_id == "20260519100000"
+
+    def test_record_skip_marks_done(self, tmp_ledger):
+        tmp_ledger.record_skip("sid", "proj", "trivial chat")
+        assert tmp_ledger.is_done("sid")
+        entry = tmp_ledger.get("sid")
+        assert entry.status == SessionStatus.SKIPPED.value
+        assert entry.last_error == "trivial chat"
+
+    def test_record_failure_increments_retry_and_promotes_to_permanent(self, tmp_ledger):
+        # 第一次：transient
+        tmp_ledger.record_failure("sid", "proj", "claude timeout")
+        e1 = tmp_ledger.get("sid")
+        assert e1.status == SessionStatus.FAILED_TRANSIENT.value
+        assert e1.retry_count == 1
+        assert tmp_ledger.is_done("sid") is False  # transient 不算了结
+
+        # 第二次：仍 transient
+        tmp_ledger.record_failure("sid", "proj", "again")
+        e2 = tmp_ledger.get("sid")
+        assert e2.status == SessionStatus.FAILED_TRANSIENT.value
+        assert e2.retry_count == 2
+
+        # 第三次：到达 max_retries=3，转 permanent
+        tmp_ledger.record_failure("sid", "proj", "final")
+        e3 = tmp_ledger.get("sid")
+        assert e3.status == SessionStatus.FAILED_PERMANENT.value
+        assert e3.retry_count == 3
+        assert tmp_ledger.is_done("sid") is True
+
+    def test_forget_removes_entry(self, tmp_ledger):
+        tmp_ledger.record_success("sid", "proj", "n1")
+        assert tmp_ledger.forget("sid") is True
+        assert tmp_ledger.get("sid") is None
+        assert tmp_ledger.forget("sid") is False  # 已经不在
+
+    def test_prune_older_than(self, tmp_path):
+        path = tmp_path / "s.json"
+        old_ts = (datetime.now() - timedelta(days=40)).isoformat()
+        new_ts = datetime.now().isoformat()
+        # 直接构造数据并写盘，再重新加载
+        raw = {
+            "version": 1,
+            "sessions": {
+                "old": {
+                    "project": "p",
+                    "processed_at": old_ts,
+                    "status": "success",
+                    "note_id": "n1",
+                    "retry_count": 0,
+                    "last_error": None,
+                },
+                "new": {
+                    "project": "p",
+                    "processed_at": new_ts,
+                    "status": "success",
+                    "note_id": "n2",
+                    "retry_count": 0,
+                    "last_error": None,
+                },
+            },
+        }
+        path.write_text(json.dumps(raw), encoding="utf-8")
+
+        led2 = Ledger(path=path)
+        deleted = led2.prune_older_than(days=30)
+        assert deleted == 1
+        assert led2.get("old") is None
+        assert led2.get("new") is not None
+
+    def test_stats_counts_per_status(self, tmp_ledger):
+        tmp_ledger.record_success("a", "p", "n")
+        tmp_ledger.record_skip("b", "p", "x")
+        tmp_ledger.record_failure("c", "p", "fail")
+
+        stats = tmp_ledger.stats()
+        assert stats[SessionStatus.SUCCESS.value] == 1
+        assert stats[SessionStatus.SKIPPED.value] == 1
+        assert stats[SessionStatus.FAILED_TRANSIENT.value] == 1
+        assert stats[SessionStatus.FAILED_PERMANENT.value] == 0
+
+    def test_corrupted_file_falls_back_to_empty(self, tmp_path):
+        path = tmp_path / "broken.json"
+        path.write_text("{not valid json", encoding="utf-8")
+        led = Ledger(path=path)
+        assert led.all_entries() == {}
+        # 写入仍然能工作
+        assert led.record_success("sid", "p", "n")

--- a/tests/unit/test_auto_summary_runner.py
+++ b/tests/unit/test_auto_summary_runner.py
@@ -1,0 +1,364 @@
+"""
+测试类型: 单元测试
+目标模块: jfox.auto_summary.runner（mock subprocess + filesystem）
+预估耗时: < 2秒
+依赖要求: 无网络，无 claude 二进制
+"""
+
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+from jfox.auto_summary import runner as runner_module
+from jfox.auto_summary.ledger import Ledger, SessionStatus
+from jfox.auto_summary.runner import (
+    SummaryOutcome,
+    _extract_object,
+    _parse_claude_json,
+    summarize_one,
+)
+from jfox.auto_summary.scanner import SessionFile
+from jfox.global_config import AutoSummaryConfig
+
+# ---------------------------------------------------------------------------
+# JSON 解析单元测试
+# ---------------------------------------------------------------------------
+
+
+class TestParseClaudeJson:
+    def test_envelope_with_result_field(self):
+        envelope = {
+            "type": "result",
+            "result": '{"skip": false, "title": "测试", "topic": "t", "summary_md": "x", "tags": []}',
+        }
+        parsed = _parse_claude_json(json.dumps(envelope))
+        assert parsed["title"] == "测试"
+        assert parsed["skip"] is False
+
+    def test_direct_inner_json(self):
+        # claude 直接吐出内层对象（无 envelope）
+        raw = '{"skip": true, "reason": "trivial", "title": "", "topic": "", "summary_md": "", "tags": []}'
+        parsed = _parse_claude_json(raw)
+        assert parsed["skip"] is True
+        assert parsed["reason"] == "trivial"
+
+    def test_inner_with_markdown_fence(self):
+        envelope = {"result": '```json\n{"skip": false, "title": "a"}\n```'}
+        parsed = _parse_claude_json(json.dumps(envelope))
+        assert parsed["title"] == "a"
+
+    def test_inner_with_prose_around_json(self):
+        envelope = {"result": '好的，下面是结果：\n{"skip": false, "title": "hi"}\n谢谢'}
+        parsed = _parse_claude_json(json.dumps(envelope))
+        assert parsed["title"] == "hi"
+
+    def test_completely_unparseable_raises(self):
+        envelope = {"result": "I don't understand."}
+        with pytest.raises(runner_module._ParseError):
+            _parse_claude_json(json.dumps(envelope))
+
+    def test_extract_object_finds_first_obj(self):
+        text = 'junk before {"a": 1, "b": 2} junk after'
+        obj = _extract_object(text)
+        assert obj == {"a": 1, "b": 2}
+
+
+# ---------------------------------------------------------------------------
+# summarize_one 行为测试（mock claude 调用 + mock 笔记写入）
+# ---------------------------------------------------------------------------
+
+
+def _make_session_jsonl(tmp_path, sid="abcd1234"):
+    proj = tmp_path / "C--Users-test-proj"
+    proj.mkdir(parents=True, exist_ok=True)
+    p = proj / f"{sid}.jsonl"
+    p.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "user",
+                        "timestamp": "2026-05-19T10:00:00Z",
+                        "cwd": "C:/work",
+                        "gitBranch": "main",
+                        "message": {"role": "user", "content": "帮我做一个 X"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "timestamp": "2026-05-19T10:00:30Z",
+                        "message": {"role": "assistant", "content": "好的，我开始"},
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return SessionFile(
+        session_id=sid,
+        project_dir_name=proj.name,
+        path=p,
+        mtime=p.stat().st_mtime,
+        size_bytes=p.stat().st_size,
+    )
+
+
+@pytest.fixture
+def fake_cfg(tmp_path):
+    return AutoSummaryConfig(
+        enabled=True,
+        target_kb=None,
+        claude_timeout_seconds=10,
+        claude_binary=str(tmp_path / "fake-claude"),  # 不存在，让 _resolve_claude_binary 走 which
+    )
+
+
+@pytest.fixture
+def ledger(tmp_path):
+    return Ledger(path=tmp_path / "state.json", max_retries=3)
+
+
+def _make_completed_proc(stdout, returncode=0, stderr=""):
+    return subprocess.CompletedProcess(
+        args=["claude", "-p"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def test_summarize_one_success(tmp_path, ledger, fake_cfg):
+    sf = _make_session_jsonl(tmp_path)
+    inner = {
+        "skip": False,
+        "title": "实现 auto-summary",
+        "topic": "feature",
+        "summary_md": "## 做了什么\n- xxx\n\n## 关键决策\n- yyy\n\n## 未决事项\n无",
+        "tags": ["python", "knowledge-base"],
+    }
+    fake_stdout = json.dumps({"type": "result", "result": json.dumps(inner)})
+
+    with (
+        patch.object(runner_module, "_resolve_claude_binary", return_value="claude"),
+        patch.object(subprocess, "run", return_value=_make_completed_proc(fake_stdout)),
+        patch.object(runner_module, "_save_session_note", return_value="20260519T100000"),
+    ):
+        result = summarize_one(sf, cfg=fake_cfg, ledger=ledger)
+
+    assert result.outcome == SummaryOutcome.SUCCESS
+    assert result.note_id == "20260519T100000"
+    assert result.title == "实现 auto-summary"
+    entry = ledger.get(sf.session_id)
+    assert entry is not None
+    assert entry.status == SessionStatus.SUCCESS.value
+
+
+def test_summarize_one_claude_marks_skip(tmp_path, ledger, fake_cfg):
+    sf = _make_session_jsonl(tmp_path, sid="skip0001")
+    inner = {
+        "skip": True,
+        "reason": "对话过短",
+        "title": "",
+        "topic": "",
+        "summary_md": "",
+        "tags": [],
+    }
+    fake_stdout = json.dumps({"result": json.dumps(inner)})
+
+    with (
+        patch.object(runner_module, "_resolve_claude_binary", return_value="claude"),
+        patch.object(subprocess, "run", return_value=_make_completed_proc(fake_stdout)),
+        patch.object(runner_module, "_save_session_note") as save_mock,
+    ):
+        result = summarize_one(sf, cfg=fake_cfg, ledger=ledger)
+
+    assert result.outcome == SummaryOutcome.SKIPPED
+    assert result.reason == "对话过短"
+    save_mock.assert_not_called()
+    entry = ledger.get(sf.session_id)
+    assert entry.status == SessionStatus.SKIPPED.value
+
+
+def test_summarize_one_claude_nonzero_exit_marks_failure(tmp_path, ledger, fake_cfg):
+    sf = _make_session_jsonl(tmp_path, sid="fail0001")
+    proc = _make_completed_proc("", returncode=2, stderr="boom")
+
+    with (
+        patch.object(runner_module, "_resolve_claude_binary", return_value="claude"),
+        patch.object(subprocess, "run", return_value=proc),
+    ):
+        result = summarize_one(sf, cfg=fake_cfg, ledger=ledger)
+
+    assert result.outcome == SummaryOutcome.FAILED  # transient on first attempt
+    entry = ledger.get(sf.session_id)
+    assert entry.status == SessionStatus.FAILED_TRANSIENT.value
+    assert entry.retry_count == 1
+
+
+def test_summarize_one_invalid_json_marks_failure(tmp_path, ledger, fake_cfg):
+    sf = _make_session_jsonl(tmp_path, sid="parse001")
+    proc = _make_completed_proc('{"result": "not a json object at all"}')
+
+    with (
+        patch.object(runner_module, "_resolve_claude_binary", return_value="claude"),
+        patch.object(subprocess, "run", return_value=proc),
+    ):
+        result = summarize_one(sf, cfg=fake_cfg, ledger=ledger)
+
+    assert result.outcome == SummaryOutcome.FAILED
+    entry = ledger.get(sf.session_id)
+    assert "parse error" in (entry.last_error or "")
+
+
+def test_summarize_one_empty_dialog_skips_without_calling_claude(tmp_path, ledger, fake_cfg):
+    proj = tmp_path / "C--Users-test-empty"
+    proj.mkdir(parents=True)
+    p = proj / "empty01.jsonl"
+    p.write_text(
+        json.dumps({"type": "permission-mode", "permissionMode": "x"}) + "\n",
+        encoding="utf-8",
+    )
+    sf = SessionFile(
+        session_id="empty01",
+        project_dir_name=proj.name,
+        path=p,
+        mtime=p.stat().st_mtime,
+        size_bytes=p.stat().st_size,
+    )
+
+    with patch.object(subprocess, "run") as run_mock:
+        result = summarize_one(sf, cfg=fake_cfg, ledger=ledger)
+
+    assert result.outcome == SummaryOutcome.SKIPPED
+    run_mock.assert_not_called()
+
+
+def test_summarize_one_empty_summary_md_marks_failure(tmp_path, ledger, fake_cfg):
+    """claude 返回 skip=false 但 summary_md 为空白时应标记失败，不写笔记。"""
+    sf = _make_session_jsonl(tmp_path, sid="empty_md")
+    inner = {
+        "skip": False,
+        "title": "x",
+        "topic": "y",
+        "summary_md": "   \n  ",
+        "tags": ["a"],
+    }
+    fake_stdout = json.dumps({"result": json.dumps(inner)})
+
+    with (
+        patch.object(runner_module, "_resolve_claude_binary", return_value="claude"),
+        patch.object(subprocess, "run", return_value=_make_completed_proc(fake_stdout)),
+        patch.object(runner_module, "_save_session_note") as save_mock,
+    ):
+        result = summarize_one(sf, cfg=fake_cfg, ledger=ledger)
+
+    assert result.outcome == SummaryOutcome.FAILED
+    save_mock.assert_not_called()
+    entry = ledger.get(sf.session_id)
+    assert "summary_md" in (entry.last_error or "")
+
+
+def test_summarize_one_timeout_marks_failure(tmp_path, ledger, fake_cfg):
+    sf = _make_session_jsonl(tmp_path, sid="timeout1")
+
+    def raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=10)
+
+    with (
+        patch.object(runner_module, "_resolve_claude_binary", return_value="claude"),
+        patch.object(subprocess, "run", side_effect=raise_timeout),
+    ):
+        result = summarize_one(sf, cfg=fake_cfg, ledger=ledger)
+
+    assert result.outcome == SummaryOutcome.FAILED
+    entry = ledger.get(sf.session_id)
+    assert "超时" in (entry.last_error or "")
+
+
+# ---------------------------------------------------------------------------
+# run_once orchestration tests
+# ---------------------------------------------------------------------------
+
+
+def test_run_once_recursion_guard_skips_when_inside_isolated_dir(tmp_path, fake_cfg):
+    """关键安全测试：若当前 cwd 在 ~/.jfox-auto-summary-runs/ 内，run_once 应原地返回，
+    避免 daemon 总结自己产生的 session 而陷入死循环。"""
+    led = Ledger(path=tmp_path / "state.json")
+
+    with (
+        patch.object(runner_module, "is_running_inside_isolated_dir", return_value=True),
+        patch.object(runner_module, "summarize_one") as summarize_mock,
+        patch.object(runner_module, "scan_pending") as scan_mock,
+    ):
+        report = runner_module.run_once(cfg=fake_cfg, ledger=led)
+
+    assert report.scanned == 0
+    assert report.processed == 0
+    summarize_mock.assert_not_called()
+    scan_mock.assert_not_called()
+
+
+def test_run_once_honors_max_per_tick(tmp_path, fake_cfg):
+    """关键 DoS 防护测试：扫描出 5 个 session，max_per_tick=2 时只处理 2 个。"""
+    from jfox.auto_summary.scanner import SessionFile
+
+    led = Ledger(path=tmp_path / "state.json")
+    fake_cfg.max_per_tick = 2
+
+    fake_sessions = [
+        SessionFile(
+            session_id=f"sess{i:04d}",
+            project_dir_name="proj",
+            path=tmp_path / f"sess{i}.jsonl",
+            mtime=0.0,
+            size_bytes=10240,
+        )
+        for i in range(5)
+    ]
+
+    def fake_summarize(sf, cfg, ledger):
+        return runner_module.SummaryResult(
+            session_id=sf.session_id,
+            outcome=SummaryOutcome.SUCCESS,
+            note_id=f"n_{sf.session_id}",
+        )
+
+    with (
+        patch.object(runner_module, "scan_pending", return_value=fake_sessions),
+        patch.object(runner_module, "summarize_one", side_effect=fake_summarize) as summarize_mock,
+    ):
+        report = runner_module.run_once(cfg=fake_cfg, ledger=led)
+
+    assert report.scanned == 5
+    assert report.processed == 2
+    assert report.success == 2
+    assert summarize_mock.call_count == 2
+    # 应处理前两个，按列表顺序
+    assert [c.args[0].session_id for c in summarize_mock.call_args_list] == [
+        "sess0000",
+        "sess0001",
+    ]
+
+
+def test_run_once_dry_run_skips_summarize(tmp_path, fake_cfg):
+    """dry_run 模式仍统计 scanned，但不调 summarize_one。"""
+    from jfox.auto_summary.scanner import SessionFile
+
+    led = Ledger(path=tmp_path / "state.json")
+    fake_sessions = [
+        SessionFile(
+            session_id="x", project_dir_name="p", path=tmp_path / "x.jsonl", mtime=0, size_bytes=10
+        )
+    ]
+
+    with (
+        patch.object(runner_module, "scan_pending", return_value=fake_sessions),
+        patch.object(runner_module, "summarize_one") as summarize_mock,
+    ):
+        report = runner_module.run_once(cfg=fake_cfg, ledger=led, dry_run=True)
+
+    assert report.scanned == 1
+    assert report.processed == 0
+    summarize_mock.assert_not_called()

--- a/tests/unit/test_auto_summary_scanner.py
+++ b/tests/unit/test_auto_summary_scanner.py
@@ -1,0 +1,127 @@
+"""
+测试类型: 单元测试
+目标模块: jfox.auto_summary.scanner
+预估耗时: < 1秒
+依赖要求: 无外部依赖
+"""
+
+import os
+import time
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+from jfox.auto_summary.scanner import (
+    DEFAULT_PROJECT_BLOCKLIST_SUBSTRINGS,
+    iter_session_files,
+)
+
+
+def _make_session(project_dir, name, size_bytes, mtime_offset_seconds=0):
+    """在 project_dir 下创建一个指定大小的 jsonl，可设置 mtime 偏移（负值 = 过去）"""
+    project_dir.mkdir(parents=True, exist_ok=True)
+    p = project_dir / f"{name}.jsonl"
+    p.write_bytes(b"x" * size_bytes)
+    if mtime_offset_seconds != 0:
+        ts = time.time() + mtime_offset_seconds
+        os.utime(p, (ts, ts))
+    return p
+
+
+class TestIterSessionFiles:
+    def test_returns_idle_sessions_within_size_window(self, tmp_path):
+        proj = tmp_path / "C--Users-test-foo"
+        # 30 分钟前修改的文件，大小 100KB
+        _make_session(proj, "session-a", 100 * 1024, mtime_offset_seconds=-31 * 60)
+
+        results = list(
+            iter_session_files(
+                claude_projects_dir=tmp_path,
+                idle_threshold_minutes=30,
+                max_session_size_mb=10,
+                min_session_size_kb=5,
+                skip_after_days=7,
+            )
+        )
+
+        assert len(results) == 1
+        assert results[0].session_id == "session-a"
+        assert results[0].project_dir_name == "C--Users-test-foo"
+
+    def test_skips_recently_modified(self, tmp_path):
+        proj = tmp_path / "p1"
+        _make_session(proj, "fresh", 50 * 1024, mtime_offset_seconds=-60)  # 1 分钟前
+
+        results = list(iter_session_files(claude_projects_dir=tmp_path, idle_threshold_minutes=30))
+        assert results == []
+
+    def test_skips_too_small(self, tmp_path):
+        proj = tmp_path / "p1"
+        _make_session(proj, "tiny", 1024, mtime_offset_seconds=-60 * 60)  # 1KB
+
+        results = list(
+            iter_session_files(
+                claude_projects_dir=tmp_path,
+                idle_threshold_minutes=10,
+                min_session_size_kb=5,
+            )
+        )
+        assert results == []
+
+    def test_skips_too_large(self, tmp_path):
+        proj = tmp_path / "p1"
+        # 11MB > 10MB 上限
+        _make_session(proj, "huge", 11 * 1024 * 1024, mtime_offset_seconds=-60 * 60)
+
+        results = list(
+            iter_session_files(
+                claude_projects_dir=tmp_path,
+                idle_threshold_minutes=10,
+                max_session_size_mb=10,
+            )
+        )
+        assert results == []
+
+    def test_skips_too_old(self, tmp_path):
+        proj = tmp_path / "p1"
+        _make_session(proj, "ancient", 100 * 1024, mtime_offset_seconds=-30 * 86400)  # 30 天
+
+        results = list(
+            iter_session_files(
+                claude_projects_dir=tmp_path,
+                idle_threshold_minutes=10,
+                skip_after_days=7,
+            )
+        )
+        assert results == []
+
+    def test_blocklist_filters_isolated_runs_dir(self, tmp_path):
+        # 假装一个由 auto-summary 自身产生的项目目录
+        bad_proj = tmp_path / "C--Users-test--jfox-auto-summary-runs"
+        good_proj = tmp_path / "C--Users-test-real"
+        _make_session(bad_proj, "self", 100 * 1024, mtime_offset_seconds=-60 * 60)
+        _make_session(good_proj, "real", 100 * 1024, mtime_offset_seconds=-60 * 60)
+
+        results = list(
+            iter_session_files(
+                claude_projects_dir=tmp_path,
+                idle_threshold_minutes=10,
+                project_blocklist=DEFAULT_PROJECT_BLOCKLIST_SUBSTRINGS,
+            )
+        )
+        names = {r.session_id for r in results}
+        assert names == {"real"}
+
+    def test_ignores_non_jsonl_files(self, tmp_path):
+        proj = tmp_path / "p1"
+        proj.mkdir()
+        (proj / "notes.txt").write_text("hello", encoding="utf-8")
+        (proj / "subdir").mkdir()  # 不应被当成 session 文件
+
+        results = list(iter_session_files(claude_projects_dir=tmp_path, idle_threshold_minutes=0))
+        assert results == []
+
+    def test_missing_root_dir_yields_nothing(self, tmp_path):
+        results = list(iter_session_files(claude_projects_dir=tmp_path / "does-not-exist"))
+        assert results == []


### PR DESCRIPTION
## Summary

- 新增 `jfox auto-summary` 子命令组 + daemon 内置后台循环：定时扫描 `~/.claude/projects/*.jsonl`，对静默超过阈值的"已结束" session 调用 `claude -p` 生成结构化摘要，写入 jfox 知识库
- 默认 **opt-in**（`auto_summary.enabled=false`），需要 `jfox auto-summary enable` + 重启 daemon 才会真正在后台跑；CLI 仍可随时手动 `jfox auto-summary run` 触发
- 单轮上限 `max_per_tick=5`，size/age 过滤 + 项目目录黑名单 + 隔离 cwd 三层防御，避免递归总结自身

## 主要变更

| 类型 | 文件 |
|------|------|
| 新增包 | `jfox/auto_summary/{scanner,extractor,ledger,runner,loop,cli}.py` |
| 修改 | `jfox/global_config.py`：加 `AutoSummaryConfig` dataclass，`__post_init__` 校验 |
| 修改 | `jfox/daemon/server.py`：lifespan 启停后台 task；新增 `/auto_summary/status` |
| 修改 | `jfox/cli.py`：注册 `auto-summary` Typer subapp |
| 测试 | `tests/unit/test_auto_summary_*.py`（38 用例，含 recursion guard / max_per_tick / system-reminder 泄漏回归） |

## Test plan

- [x] uv run pytest tests/unit/test_auto_summary_*.py — 38/38 pass，<1s
- [x] uv run pytest tests/unit/test_global_config.py — 50/50 pass（向后兼容）
- [x] uv run black + uv run ruff check 全清
- [x] jfox auto-summary --help、status、scan 在 Windows 实际环境 smoke test 通过；scan 命中 18 个真实候选 session
- [ ] 待手动：用户在 Windows 启用 daemon 跑一宿，观察 ~/.jfox_daemon.log 与笔记落库
- [ ] 待手动：迁移到 7700k_modultra 长期跑

## 关键设计点 / 安全保护

- **opt-in**：默认关闭，避免历史会话被一次性洗一波
- **__post_init__ 校验**：interval_minutes < 1 / max_per_tick < 1 等边界值自动 fallback 到默认，防止 tight-loop
- **原子 ledger 写入**：tempfile + os.replace；崩溃中段不会损坏 state，避免重新总结所有 session
- **损坏 ledger 备份**：*.corrupted-<ts>.json，error 级日志通知，不再静默重置
- **system-reminder 过滤**：在 _coerce_text item 级剔除（避免 multi-content array 中混在真实文本旁边的 system-reminder 泄漏到 prompt）
- **recursion guard**：cwd=~/.jfox-auto-summary-runs/ + 项目目录黑名单 + is_running_inside_isolated_dir() 三重保险
- **claude -p 失败可见性**：logger.exception 在每个 record_failure 前调用，daemon log 保留完整 traceback

## 后续待跟进（非阻塞）

- 跑稳后考虑将 SummaryOutcome 与 SessionStatus 合并（重复语义；可在独立 cleanup PR 中做）
- daemon shutdown 时若 task 阻塞在 in-flight claude -p 上，仍受 claude_timeout_seconds 影响；与既有 daemon-stop-bug 合并处理
- /auto_summary/status 暴露 _auto_summary_start_failed 标志，方便排查"daemon 起来但 auto-summary 静默失败"的边界

🤖 Generated with [Claude Code](https://claude.com/claude-code)