### PR TITLE
feat: replace hf-mirror.com with ModelScope for model download

### DIFF
--- a/jfox/daemon/process.py
+++ b/jfox/daemon/process.py
@@ -149,8 +149,7 @@ def _check_model_cache() -> dict:
         local_path = _LOCAL_MODEL_DIR / safe_name
         if local_path.exists():
             has_weight = any(
-                (local_path / candidate).exists()
-                for candidate in _WEIGHT_FILE_CANDIDATES
+                (local_path / candidate).exists() for candidate in _WEIGHT_FILE_CANDIDATES
             )
             size_hint = "2GB" if "bge-m3" in model_name else "90MB"
             return {

--- a/jfox/daemon/process.py
+++ b/jfox/daemon/process.py
@@ -155,7 +155,7 @@ def _check_model_cache() -> dict:
             has_weight = any(
                 (local_path / candidate).exists() for candidate in _WEIGHT_FILE_CANDIDATES
             )
-            if has_weight:
+            if has_weight and (local_path / "config.json").exists():
                 size_hint = "2GB" if "bge-m3" in model_name else "90MB"
                 return {
                     "needs_download": False,

--- a/jfox/daemon/process.py
+++ b/jfox/daemon/process.py
@@ -142,6 +142,23 @@ def _check_model_cache() -> dict:
             except (ImportError, OSError):
                 model_name = _CPU_DEFAULT_MODEL
 
+        # 检查本地模型目录
+        from ..model_downloader import _LOCAL_MODEL_DIR, _WEIGHT_FILE_CANDIDATES
+
+        safe_name = model_name.replace("/", "--")
+        local_path = _LOCAL_MODEL_DIR / safe_name
+        if local_path.exists():
+            has_weight = any(
+                (local_path / candidate).exists()
+                for candidate in _WEIGHT_FILE_CANDIDATES
+            )
+            size_hint = "2GB" if "bge-m3" in model_name else "90MB"
+            return {
+                "needs_download": not has_weight,
+                "model_name": model_name,
+                "size_hint": size_hint,
+            }
+
         # 检查 HuggingFace 缓存
         hf_home = os.environ.get("HF_HOME", str(Path.home() / ".cache" / "huggingface"))
         hub_cache = os.environ.get("HUGGINGFACE_HUB_CACHE", str(Path(hf_home) / "hub"))
@@ -205,7 +222,8 @@ def start_daemon(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> bool:
             downloader = ModelDownloader(cache_info["model_name"])
             if not downloader.ensure_cached():
                 logger.error("模型自动下载失败")
-                # 不阻断启动，让 daemon 自己去尝试加载（会暴露更详细的错误日志）
+                print(downloader.get_manual_instructions(), file=sys.stderr)
+                return False
         except (ImportError, OSError) as e:
             logger.warning(f"模型下载检查异常: {e}")
 

--- a/jfox/daemon/process.py
+++ b/jfox/daemon/process.py
@@ -143,25 +143,31 @@ def _check_model_cache() -> dict:
                 model_name = _CPU_DEFAULT_MODEL
 
         # 检查本地模型目录
-        from ..model_downloader import _LOCAL_MODEL_DIR, _WEIGHT_FILE_CANDIDATES
+        from ..model_downloader import (
+            _LOCAL_MODEL_DIR,
+            _WEIGHT_FILE_CANDIDATES,
+            _safe_model_name,
+        )
 
-        safe_name = model_name.replace("/", "--")
+        safe_name = _safe_model_name(model_name)
         local_path = _LOCAL_MODEL_DIR / safe_name
         if local_path.exists():
             has_weight = any(
                 (local_path / candidate).exists() for candidate in _WEIGHT_FILE_CANDIDATES
             )
-            size_hint = "2GB" if "bge-m3" in model_name else "90MB"
-            return {
-                "needs_download": not has_weight,
-                "model_name": model_name,
-                "size_hint": size_hint,
-            }
+            if has_weight:
+                size_hint = "2GB" if "bge-m3" in model_name else "90MB"
+                return {
+                    "needs_download": False,
+                    "model_name": model_name,
+                    "size_hint": size_hint,
+                }
+            # 本地目录存在但无有效权重，继续检查 HF Hub 缓存
 
         # 检查 HuggingFace 缓存
         hf_home = os.environ.get("HF_HOME", str(Path.home() / ".cache" / "huggingface"))
         hub_cache = os.environ.get("HUGGINGFACE_HUB_CACHE", str(Path(hf_home) / "hub"))
-        model_cache_dir = Path(hub_cache) / f"models--{model_name.replace('/', '--')}"
+        model_cache_dir = Path(hub_cache) / f"models--{safe_name}"
 
         size_hint = "2GB" if "bge-m3" in model_name else "90MB"
 

--- a/jfox/embedding_backend.py
+++ b/jfox/embedding_backend.py
@@ -82,8 +82,9 @@ class EmbeddingBackend:
         """获取本地模型目录路径"""
         if not self.model_name or self.model_name == "auto":
             return None
-        safe_name = self.model_name.replace("/", "--")
-        local = Path.home() / ".zettelkasten" / ".models" / safe_name
+        from .model_downloader import _get_local_model_path_for_name
+
+        local = _get_local_model_path_for_name(self.model_name)
         return local if local.exists() else None
 
     def load(self):

--- a/jfox/embedding_backend.py
+++ b/jfox/embedding_backend.py
@@ -79,13 +79,19 @@ class EmbeddingBackend:
         return False
 
     def _get_local_model_path(self) -> Optional[Path]:
-        """获取本地模型目录路径"""
+        """获取本地模型目录路径（验证目录内包含有效模型文件）"""
         if not self.model_name or self.model_name == "auto":
             return None
-        from .model_downloader import _get_local_model_path_for_name
+        from .model_downloader import _WEIGHT_FILE_CANDIDATES, _get_local_model_path_for_name
 
         local = _get_local_model_path_for_name(self.model_name)
-        return local if local.exists() else None
+        if not local.exists():
+            return None
+
+        # 验证目录包含有效模型文件（config.json + 至少一个权重文件）
+        has_config = (local / "config.json").exists()
+        has_weight = any((local / candidate).exists() for candidate in _WEIGHT_FILE_CANDIDATES)
+        return local if (has_config and has_weight) else None
 
     def load(self):
         """加载模型（支持 device 自动检测和 GPU 加速）"""

--- a/jfox/embedding_backend.py
+++ b/jfox/embedding_backend.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from pathlib import Path
 from typing import List, Optional
 
 import numpy as np
@@ -77,6 +78,14 @@ class EmbeddingBackend:
         self._use_daemon = False
         return False
 
+    def _get_local_model_path(self) -> Optional[Path]:
+        """获取本地模型目录路径"""
+        if not self.model_name or self.model_name == "auto":
+            return None
+        safe_name = self.model_name.replace("/", "--")
+        local = Path.home() / ".zettelkasten" / ".models" / safe_name
+        return local if local.exists() else None
+
     def load(self):
         """加载模型（支持 device 自动检测和 GPU 加速）"""
         if self.model is not None:
@@ -94,7 +103,12 @@ class EmbeddingBackend:
         try:
             from sentence_transformers import SentenceTransformer
 
-            self.model = SentenceTransformer(self.model_name, device=self._resolved_device)
+            # 优先从本地目录加载
+            local_path = self._get_local_model_path()
+            if local_path is not None:
+                self.model = SentenceTransformer(str(local_path), device=self._resolved_device)
+            else:
+                self.model = SentenceTransformer(self.model_name, device=self._resolved_device)
             self._resolved_dim = self.model.get_sentence_embedding_dimension()
             logger.info(
                 f"模型已加载: {self.model_name} "

--- a/jfox/model_downloader.py
+++ b/jfox/model_downloader.py
@@ -79,9 +79,9 @@ class ModelDownloader:
             return True
         logger.warning("步骤 1 失败，进入步骤 2")
 
-        # Step 2: 镜像站下载
-        logger.info(f"步骤 2: 切换 HF_ENDPOINT={_DEFAULT_MIRROR} 重试...")
-        if self._try_hf_hub_download(endpoint=_DEFAULT_MIRROR):
+        # Step 2: 重试 huggingface_hub 下载
+        logger.info("步骤 2: 重试 huggingface_hub 下载...")
+        if self._try_hf_hub_download():
             logger.info("步骤 2 成功，模型已缓存")
             return True
         logger.warning("步骤 2 失败，进入步骤 3")
@@ -132,18 +132,12 @@ class ModelDownloader:
         safe_name = self.model_name.replace("/", "--")
         return _LOCAL_MODEL_DIR / safe_name
 
-    def _try_hf_hub_download(self, endpoint: Optional[str] = None) -> bool:
+    def _try_hf_hub_download(self) -> bool:
         """
-        使用 huggingface_hub 下载模型。
-        endpoint=None 为正常模式；endpoint 为镜像站地址。
+        使用 huggingface_hub 直接下载模型。
         """
-        env_backup = None
         try:
             from huggingface_hub import hf_hub_download
-
-            if endpoint:
-                env_backup = os.environ.get("HF_ENDPOINT")
-                os.environ["HF_ENDPOINT"] = endpoint
 
             # 按优先级尝试下载权重文件
             weight_downloaded = False
@@ -182,11 +176,6 @@ class ModelDownloader:
         except Exception as e:
             logger.warning(f"huggingface_hub 下载失败: {e}")
             return False
-        finally:
-            if env_backup is not None:
-                os.environ["HF_ENDPOINT"] = env_backup
-            elif endpoint and "HF_ENDPOINT" in os.environ:
-                del os.environ["HF_ENDPOINT"]
 
     def _try_curl_download(self) -> bool:
         """

--- a/jfox/model_downloader.py
+++ b/jfox/model_downloader.py
@@ -5,7 +5,6 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Optional
 from urllib.request import urlretrieve
 
 logger = logging.getLogger(__name__)

--- a/jfox/model_downloader.py
+++ b/jfox/model_downloader.py
@@ -47,7 +47,6 @@ _REQUIRED_FILES = [
     "config.json",
     "tokenizer.json",
     "tokenizer_config.json",
-    "sentence_bert_config.json",
 ]
 
 
@@ -114,7 +113,8 @@ class ModelDownloader:
         if local_path.exists():
             for candidate in _WEIGHT_FILE_CANDIDATES:
                 if (local_path / candidate).exists():
-                    return True
+                    if (local_path / "config.json").exists():
+                        return True
         return False
 
     def _check_hf_hub_cached(self) -> bool:
@@ -207,7 +207,7 @@ class ModelDownloader:
             try:
                 with urlopen(url, timeout=60) as resp:
                     with open(tmp_dest, "wb") as f:
-                        f.write(resp.read())
+                        shutil.copyfileobj(resp, f)
                 if tmp_dest.exists() and tmp_dest.stat().st_size > 0:
                     tmp_dest.replace(dest)
                     logger.info(f"权重文件 {candidate} 下载成功")
@@ -238,7 +238,7 @@ class ModelDownloader:
             try:
                 with urlopen(url, timeout=60) as resp:
                     with open(tmp_dest, "wb") as f:
-                        f.write(resp.read())
+                        shutil.copyfileobj(resp, f)
                 if tmp_dest.exists() and tmp_dest.stat().st_size > 0:
                     tmp_dest.replace(dest)
                 else:
@@ -358,6 +358,11 @@ class ModelDownloader:
     def _cleanup_partial(self, local_path: Path):
         """下载失败时清理残留文件和空目录"""
         try:
+            # 清理已下载的权重文件和必需文件
+            for candidate in _WEIGHT_FILE_CANDIDATES:
+                (local_path / candidate).unlink(missing_ok=True)
+            for fname in _REQUIRED_FILES:
+                (local_path / fname).unlink(missing_ok=True)
             # 清理临时文件
             for tmp in local_path.glob(".*.tmp"):
                 tmp.unlink(missing_ok=True)

--- a/jfox/model_downloader.py
+++ b/jfox/model_downloader.py
@@ -152,7 +152,7 @@ class ModelDownloader:
                     logger.debug(f"权重文件 {candidate} 下载成功")
                     break
                 except Exception as e:
-                    logger.debug(f"权重文件 {candidate} 尝试失败 ({e})，尝试下一个")
+                    logger.warning(f"权重文件 {candidate} 尝试失败 ({e})，尝试下一个")
                     continue
 
             if not weight_downloaded:
@@ -201,7 +201,7 @@ class ModelDownloader:
                     weight_downloaded = True
                     break
                 else:
-                    logger.debug(f"权重文件 {candidate} 下载后为空，尝试下一个")
+                    logger.warning(f"权重文件 {candidate} 下载后为空，尝试下一个")
             except Exception as e:
                 logger.warning(f"权重文件 {candidate} 下载失败 ({e})，尝试下一个")
                 continue
@@ -273,9 +273,9 @@ class ModelDownloader:
                     weight_downloaded = True
                     break
                 else:
-                    logger.debug(f"{candidate} 下载失败或为空，跳过")
+                    logger.warning(f"{candidate} 下载失败或为空，跳过")
             except (OSError, subprocess.TimeoutExpired) as e:
-                logger.debug(f"{candidate} 下载异常: {e}")
+                logger.warning(f"{candidate} 下载异常: {e}")
 
         if not weight_downloaded:
             logger.error("所有权重文件候选下载失败，步骤 3 未完成")
@@ -313,19 +313,21 @@ class ModelDownloader:
                 if result.returncode == 0 and dest.exists() and dest.stat().st_size > 0:
                     pass  # 下载成功
                 else:
-                    logger.debug(f"{fname} 下载失败或为空，跳过")
+                    logger.warning(f"{fname} 下载失败或为空，跳过")
             except (OSError, subprocess.TimeoutExpired) as e:
-                logger.debug(f"{fname} 下载异常: {e}")
+                logger.warning(f"{fname} 下载异常: {e}")
 
         return True
 
     def get_manual_instructions(self) -> str:
         """获取手动下载说明"""
+        mirror = os.environ.get("JFOX_MODEL_MIRROR", _DEFAULT_MIRROR)
         candidates = " / ".join(_WEIGHT_FILE_CANDIDATES)
+        local_path = self._get_local_model_path()
         return (
             f"自动下载失败。请手动下载模型:\n"
-            f"  1. 访问 {_DEFAULT_MIRROR}/{self.model_name}\n"
+            f"  1. 访问 {mirror}/models/{self.model_name}\n"
             f"  2. 下载权重文件（{candidates}）和 config.json\n"
-            f"  3. 放置到 {self._model_cache}/snapshots/\n"
-            f"  或运行: bash scripts/download-model-intranet.sh"
+            f"  3. 放置到 {local_path}/\n"
+            f"  或设置环境变量 JFOX_MODEL_MIRROR 使用其他镜像"
         )

--- a/jfox/model_downloader.py
+++ b/jfox/model_downloader.py
@@ -8,6 +8,7 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 from urllib.parse import quote
+from urllib.request import urlretrieve
 
 logger = logging.getLogger(__name__)
 
@@ -79,15 +80,15 @@ class ModelDownloader:
             return True
         logger.warning("步骤 1 失败，进入步骤 2")
 
-        # Step 2: 重试 huggingface_hub 下载
-        logger.info("步骤 2: 重试 huggingface_hub 下载...")
-        if self._try_hf_hub_download():
+        # Step 2: ModelScope HTTP 下载
+        logger.info("步骤 2: 使用 ModelScope HTTP 下载...")
+        if self._try_modelscope_http():
             logger.info("步骤 2 成功，模型已缓存")
             return True
         logger.warning("步骤 2 失败，进入步骤 3")
 
         # Step 3: curl 子进程下载
-        logger.info("步骤 3: 使用 curl 子进程从镜像站下载...")
+        logger.info("步骤 3: 使用 curl 从 ModelScope 下载...")
         if self._try_curl_download():
             logger.info("步骤 3 成功，模型已缓存")
             return True
@@ -176,6 +177,57 @@ class ModelDownloader:
         except Exception as e:
             logger.warning(f"huggingface_hub 下载失败: {e}")
             return False
+
+    def _try_modelscope_http(self) -> bool:
+        """
+        使用 urllib.request 从 ModelScope HTTP 下载模型文件到本地目录。
+        """
+        mirror = os.environ.get("JFOX_MODEL_MIRROR", _DEFAULT_MIRROR)
+        local_path = self._get_local_model_path()
+        local_path.mkdir(parents=True, exist_ok=True)
+
+        # 按优先级尝试下载权重文件
+        weight_downloaded = False
+        for candidate in _WEIGHT_FILE_CANDIDATES:
+            url = _MODELSCOPE_API_TEMPLATE.format(
+                mirror=mirror,
+                model_id=self.model_name,
+                file_path=candidate,
+            )
+            dest = local_path / candidate
+            logger.info(f"试用权重文件 {candidate}...")
+            try:
+                urlretrieve(url, str(dest))
+                if dest.exists() and dest.stat().st_size > 0:
+                    logger.info(f"权重文件 {candidate} 下载成功")
+                    weight_downloaded = True
+                    break
+                else:
+                    logger.debug(f"权重文件 {candidate} 下载后为空，尝试下一个")
+            except Exception as e:
+                logger.warning(f"权重文件 {candidate} 下载失败 ({e})，尝试下一个")
+                continue
+
+        if not weight_downloaded:
+            logger.warning("所有权重文件候选均下载失败")
+            return False
+
+        # 下载其他必需文件（不失败）
+        for fname in _REQUIRED_FILES:
+            url = _MODELSCOPE_API_TEMPLATE.format(
+                mirror=mirror,
+                model_id=self.model_name,
+                file_path=fname,
+            )
+            dest = local_path / fname
+            try:
+                urlretrieve(url, str(dest))
+                if not (dest.exists() and dest.stat().st_size > 0):
+                    logger.debug(f"{fname} 下载后为空，跳过")
+            except Exception as e:
+                logger.warning(f"{fname} 下载失败 ({e})，跳过")
+
+        return True
 
     def _try_curl_download(self) -> bool:
         """

--- a/jfox/model_downloader.py
+++ b/jfox/model_downloader.py
@@ -4,10 +4,8 @@ import logging
 import os
 import shutil
 import subprocess
-import tempfile
 from pathlib import Path
 from typing import Optional
-from urllib.parse import quote
 from urllib.request import urlretrieve
 
 logger = logging.getLogger(__name__)
@@ -231,110 +229,95 @@ class ModelDownloader:
 
     def _try_curl_download(self) -> bool:
         """
-        使用 curl 子进程下载模型文件到 HF 缓存目录。
-        按 HF 缓存目录结构放置，使 sentence-transformers 认为"模型已缓存"。
+        使用 curl 子进程从 ModelScope API 下载模型文件到本地目录。
         """
         if not shutil.which("curl"):
             logger.warning("系统未安装 curl，跳过步骤 3")
             return False
 
-        # 构建镜像站 URL（对模型名进行 URL 编码，防止特殊字符破坏 URL）
-        encoded_name = quote(self.model_name, safe="/")
-        base_url = f"{_DEFAULT_MIRROR}/{encoded_name}/resolve/main"
+        mirror = os.environ.get("JFOX_MODEL_MIRROR", _DEFAULT_MIRROR)
+        local_path = self._get_local_model_path()
+        local_path.mkdir(parents=True, exist_ok=True)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tmp_path = Path(tmpdir)
-            downloaded = []
+        # 按优先级尝试下载权重文件
+        weight_downloaded = False
+        for candidate in _WEIGHT_FILE_CANDIDATES:
+            url = _MODELSCOPE_API_TEMPLATE.format(
+                mirror=mirror,
+                model_id=self.model_name,
+                file_path=candidate,
+            )
+            dest = local_path / candidate
+            logger.info(f"试用权重文件 {candidate}...")
+            try:
+                result = subprocess.run(
+                    [
+                        "curl",
+                        "-L",
+                        "-f",
+                        "-s",
+                        "-S",
+                        "--connect-timeout",
+                        "10",
+                        "--max-time",
+                        str(_TIMEOUT_CURL),
+                        "-o",
+                        str(dest),
+                        url,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=_TIMEOUT_CURL + 5,
+                )
+                if result.returncode == 0 and dest.exists() and dest.stat().st_size > 0:
+                    weight_downloaded = True
+                    break
+                else:
+                    logger.debug(f"{candidate} 下载失败或为空，跳过")
+            except (OSError, subprocess.TimeoutExpired) as e:
+                logger.debug(f"{candidate} 下载异常: {e}")
 
-            # 按优先级尝试下载权重文件
-            weight_downloaded = False
-            for candidate in _WEIGHT_FILE_CANDIDATES:
-                url = f"{base_url}/{candidate}"
-                dest = tmp_path / candidate
-                logger.info(f"试用权重文件 {candidate}...")
-                try:
-                    result = subprocess.run(
-                        [
-                            "curl",
-                            "-L",
-                            "-f",
-                            "-s",
-                            "-S",
-                            "--connect-timeout",
-                            "10",
-                            "--max-time",
-                            str(_TIMEOUT_CURL),
-                            "-o",
-                            str(dest),
-                            url,
-                        ],
-                        capture_output=True,
-                        text=True,
-                        timeout=_TIMEOUT_CURL + 5,
-                    )
-                    if result.returncode == 0 and dest.exists() and dest.stat().st_size > 0:
-                        downloaded.append(candidate)
-                        weight_downloaded = True
-                        break
-                    else:
-                        logger.debug(f"{candidate} 下载失败或为空，跳过")
-                except (OSError, subprocess.TimeoutExpired) as e:
-                    logger.debug(f"{candidate} 下载异常: {e}")
+        if not weight_downloaded:
+            logger.error("所有权重文件候选下载失败，步骤 3 未完成")
+            return False
 
-            if not weight_downloaded:
-                logger.error("所有权重文件候选下载失败，步骤 3 未完成")
-                return False
+        # 下载非权重必需文件
+        for fname in _REQUIRED_FILES:
+            url = _MODELSCOPE_API_TEMPLATE.format(
+                mirror=mirror,
+                model_id=self.model_name,
+                file_path=fname,
+            )
+            dest = local_path / fname
+            logger.info(f"下载 {fname}...")
+            try:
+                result = subprocess.run(
+                    [
+                        "curl",
+                        "-L",
+                        "-f",
+                        "-s",
+                        "-S",
+                        "--connect-timeout",
+                        "10",
+                        "--max-time",
+                        str(_TIMEOUT_CURL),
+                        "-o",
+                        str(dest),
+                        url,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=_TIMEOUT_CURL + 5,
+                )
+                if result.returncode == 0 and dest.exists() and dest.stat().st_size > 0:
+                    pass  # 下载成功
+                else:
+                    logger.debug(f"{fname} 下载失败或为空，跳过")
+            except (OSError, subprocess.TimeoutExpired) as e:
+                logger.debug(f"{fname} 下载异常: {e}")
 
-            # 下载非权重必需文件
-            for fname in _REQUIRED_FILES:
-                url = f"{base_url}/{fname}"
-                dest = tmp_path / fname
-                logger.info(f"下载 {fname}...")
-                try:
-                    result = subprocess.run(
-                        [
-                            "curl",
-                            "-L",
-                            "-f",
-                            "-s",
-                            "-S",
-                            "--connect-timeout",
-                            "10",
-                            "--max-time",
-                            str(_TIMEOUT_CURL),
-                            "-o",
-                            str(dest),
-                            url,
-                        ],
-                        capture_output=True,
-                        text=True,
-                        timeout=_TIMEOUT_CURL + 5,
-                    )
-                    if result.returncode == 0 and dest.exists() and dest.stat().st_size > 0:
-                        downloaded.append(fname)
-                    else:
-                        logger.debug(f"{fname} 下载失败或为空，跳过")
-                except (OSError, subprocess.TimeoutExpired) as e:
-                    logger.debug(f"{fname} 下载异常: {e}")
-
-            # 按 HF 缓存目录结构放置
-            import hashlib
-
-            commit_hash = hashlib.sha256(self.model_name.encode()).hexdigest()[:12]
-            snapshot_dir = self._model_cache / "snapshots" / commit_hash
-            snapshot_dir.mkdir(parents=True, exist_ok=True)
-
-            for fname in downloaded:
-                src = tmp_path / fname
-                dst = snapshot_dir / fname
-                shutil.copy2(str(src), str(dst))
-
-            # 创建 refs 指向 snapshot
-            refs_dir = self._model_cache / "refs"
-            refs_dir.mkdir(parents=True, exist_ok=True)
-            (refs_dir / "main").write_text(commit_hash, encoding="utf-8")
-
-            return True
+        return True
 
     def get_manual_instructions(self) -> str:
         """获取手动下载说明"""

--- a/jfox/model_downloader.py
+++ b/jfox/model_downloader.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
+from urllib.error import URLError
 from urllib.parse import quote
 from urllib.request import urlopen
 
@@ -191,7 +192,11 @@ class ModelDownloader:
         """
         mirror = os.environ.get("JFOX_MODEL_MIRROR", _DEFAULT_MIRROR).rstrip("/")
         local_path = self._get_local_model_path()
-        local_path.mkdir(parents=True, exist_ok=True)
+        try:
+            local_path.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            logger.error(f"无法创建模型目录 {local_path}: {e}")
+            return False
 
         # 按优先级尝试下载权重文件（先写入临时文件，成功后重命名）
         weight_downloaded = False
@@ -216,7 +221,7 @@ class ModelDownloader:
                 else:
                     logger.warning(f"权重文件 {candidate} 下载后为空，尝试下一个")
                     tmp_dest.unlink(missing_ok=True)
-            except Exception as e:
+            except (OSError, URLError, ValueError) as e:
                 logger.warning(f"权重文件 {candidate} 下载失败 ({e})，尝试下一个")
                 tmp_dest.unlink(missing_ok=True)
                 continue
@@ -244,7 +249,7 @@ class ModelDownloader:
                 else:
                     logger.warning(f"{fname} 下载后为空，跳过")
                     tmp_dest.unlink(missing_ok=True)
-            except Exception as e:
+            except (OSError, URLError, ValueError) as e:
                 logger.warning(f"{fname} 下载失败 ({e})，跳过")
                 tmp_dest.unlink(missing_ok=True)
 
@@ -266,9 +271,13 @@ class ModelDownloader:
 
         mirror = os.environ.get("JFOX_MODEL_MIRROR", _DEFAULT_MIRROR).rstrip("/")
         local_path = self._get_local_model_path()
-        local_path.mkdir(parents=True, exist_ok=True)
+        try:
+            local_path.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            logger.error(f"无法创建模型目录 {local_path}: {e}")
+            return False
 
-        # 按优先级尝试下载权重文件
+        # 按优先级尝试下载权重文件（先写入临时文件，成功后重命名）
         weight_downloaded = False
         for candidate in _WEIGHT_FILE_CANDIDATES:
             url = _MODELSCOPE_API_TEMPLATE.format(
@@ -277,6 +286,7 @@ class ModelDownloader:
                 file_path=quote(candidate, safe=""),
             )
             dest = local_path / candidate
+            tmp_dest = local_path / f".{candidate}.tmp"
             logger.info(f"试用权重文件 {candidate}...")
             try:
                 result = subprocess.run(
@@ -291,20 +301,23 @@ class ModelDownloader:
                         "--max-time",
                         str(_TIMEOUT_CURL),
                         "-o",
-                        str(dest),
+                        str(tmp_dest),
                         url,
                     ],
                     capture_output=True,
                     text=True,
                     timeout=_TIMEOUT_CURL + 5,
                 )
-                if result.returncode == 0 and dest.exists() and dest.stat().st_size > 0:
+                if result.returncode == 0 and tmp_dest.exists() and tmp_dest.stat().st_size > 0:
+                    tmp_dest.replace(dest)
                     weight_downloaded = True
                     break
                 else:
                     logger.warning(f"{candidate} 下载失败或为空，跳过")
+                    tmp_dest.unlink(missing_ok=True)
             except (OSError, subprocess.TimeoutExpired) as e:
                 logger.warning(f"{candidate} 下载异常: {e}")
+                tmp_dest.unlink(missing_ok=True)
 
         if not weight_downloaded:
             logger.error("所有权重文件候选下载失败，步骤 3 未完成")
@@ -319,6 +332,7 @@ class ModelDownloader:
                 file_path=quote(fname, safe=""),
             )
             dest = local_path / fname
+            tmp_dest = local_path / f".{fname}.tmp"
             logger.info(f"下载 {fname}...")
             try:
                 result = subprocess.run(
@@ -333,19 +347,21 @@ class ModelDownloader:
                         "--max-time",
                         str(_TIMEOUT_CURL),
                         "-o",
-                        str(dest),
+                        str(tmp_dest),
                         url,
                     ],
                     capture_output=True,
                     text=True,
                     timeout=_TIMEOUT_CURL + 5,
                 )
-                if result.returncode == 0 and dest.exists() and dest.stat().st_size > 0:
-                    pass  # 下载成功
+                if result.returncode == 0 and tmp_dest.exists() and tmp_dest.stat().st_size > 0:
+                    tmp_dest.replace(dest)
                 else:
                     logger.warning(f"{fname} 下载失败或为空，跳过")
+                    tmp_dest.unlink(missing_ok=True)
             except (OSError, subprocess.TimeoutExpired) as e:
                 logger.warning(f"{fname} 下载异常: {e}")
+                tmp_dest.unlink(missing_ok=True)
 
         # 验证 config.json 存在
         if not (local_path / "config.json").exists():

--- a/jfox/model_downloader.py
+++ b/jfox/model_downloader.py
@@ -11,12 +11,20 @@ from urllib.parse import quote
 
 logger = logging.getLogger(__name__)
 
-# 镜像站地址
-_HF_MIRROR = "https://hf-mirror.com"
-
 # 重试超时（秒）
 _TIMEOUT_HF_HUB = 60
 _TIMEOUT_CURL = 120
+
+# 默认镜像站
+_DEFAULT_MIRROR = "https://modelscope.cn"
+
+# 本地模型目录
+_LOCAL_MODEL_DIR = Path.home() / ".zettelkasten" / ".models"
+
+# ModelScope API 模板
+_MODELSCOPE_API_TEMPLATE = (
+    "{mirror}/api/v1/models/{model_id}/repo" "?FilePath={file_path}&Revision=master"
+)
 
 # 权重文件候选列表（按优先级排序：safetensors 优先，PyTorch 回退）
 _WEIGHT_FILE_CANDIDATES = [
@@ -72,8 +80,8 @@ class ModelDownloader:
         logger.warning("步骤 1 失败，进入步骤 2")
 
         # Step 2: 镜像站下载
-        logger.info(f"步骤 2: 切换 HF_ENDPOINT={_HF_MIRROR} 重试...")
-        if self._try_hf_hub_download(endpoint=_HF_MIRROR):
+        logger.info(f"步骤 2: 切换 HF_ENDPOINT={_DEFAULT_MIRROR} 重试...")
+        if self._try_hf_hub_download(endpoint=_DEFAULT_MIRROR):
             logger.info("步骤 2 成功，模型已缓存")
             return True
         logger.warning("步骤 2 失败，进入步骤 3")
@@ -88,6 +96,19 @@ class ModelDownloader:
         return False
 
     def _check_cached(self) -> bool:
+        """检查模型是否已缓存（HF Hub 缓存或本地目录）"""
+        # 优先检查 HF Hub 缓存（现有用户）
+        if self._check_hf_hub_cached():
+            return True
+        # 再检查本地模型目录（ModelScope 下载）
+        local_path = self._get_local_model_path()
+        if local_path.exists():
+            for candidate in _WEIGHT_FILE_CANDIDATES:
+                if (local_path / candidate).exists():
+                    return True
+        return False
+
+    def _check_hf_hub_cached(self) -> bool:
         """检查模型是否已在 HuggingFace 缓存目录中存在"""
         if not self._model_cache.exists():
             return False
@@ -105,6 +126,11 @@ class ModelDownloader:
             logger.warning(f"无法遍历缓存目录: {snapshots_dir}")
             return False
         return False
+
+    def _get_local_model_path(self) -> Path:
+        """获取本地模型目录路径"""
+        safe_name = self.model_name.replace("/", "--")
+        return _LOCAL_MODEL_DIR / safe_name
 
     def _try_hf_hub_download(self, endpoint: Optional[str] = None) -> bool:
         """
@@ -173,7 +199,7 @@ class ModelDownloader:
 
         # 构建镜像站 URL（对模型名进行 URL 编码，防止特殊字符破坏 URL）
         encoded_name = quote(self.model_name, safe="/")
-        base_url = f"{_HF_MIRROR}/{encoded_name}/resolve/main"
+        base_url = f"{_DEFAULT_MIRROR}/{encoded_name}/resolve/main"
 
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)
@@ -274,7 +300,7 @@ class ModelDownloader:
         candidates = " / ".join(_WEIGHT_FILE_CANDIDATES)
         return (
             f"自动下载失败。请手动下载模型:\n"
-            f"  1. 访问 {_HF_MIRROR}/{self.model_name}\n"
+            f"  1. 访问 {_DEFAULT_MIRROR}/{self.model_name}\n"
             f"  2. 下载权重文件（{candidates}）和 config.json\n"
             f"  3. 放置到 {self._model_cache}/snapshots/\n"
             f"  或运行: bash scripts/download-model-intranet.sh"

--- a/jfox/model_downloader.py
+++ b/jfox/model_downloader.py
@@ -5,7 +5,8 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from urllib.request import urlretrieve
+from urllib.parse import quote
+from urllib.request import urlopen
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,17 @@ _WEIGHT_FILE_CANDIDATES = [
     "pytorch_model.bin",
 ]
 
+
+def _safe_model_name(model_name: str) -> str:
+    """将模型名转换为安全的目录名，防止路径遍历"""
+    return model_name.replace("/", "--").replace("\\", "--").replace("..", "--")
+
+
+def _get_local_model_path_for_name(model_name: str) -> Path:
+    """获取指定模型名的本地目录路径"""
+    return _LOCAL_MODEL_DIR / _safe_model_name(model_name)
+
+
 # 非权重必需文件列表
 _REQUIRED_FILES = [
     "config.json",
@@ -45,8 +57,7 @@ class ModelDownloader:
     def __init__(self, model_name: str):
         self.model_name = model_name
         self._hf_hub_cache = self._get_hf_hub_cache()
-        # 同时替换正反斜杠，防止路径遍历
-        safe_name = model_name.replace("/", "--").replace("\\", "--")
+        safe_name = _safe_model_name(model_name)
         self._model_cache = self._hf_hub_cache / f"models--{safe_name}"
 
     def _get_hf_hub_cache(self) -> Path:
@@ -127,8 +138,7 @@ class ModelDownloader:
 
     def _get_local_model_path(self) -> Path:
         """获取本地模型目录路径"""
-        safe_name = self.model_name.replace("/", "--")
-        return _LOCAL_MODEL_DIR / safe_name
+        return _get_local_model_path_for_name(self.model_name)
 
     def _try_hf_hub_download(self) -> bool:
         """
@@ -179,50 +189,70 @@ class ModelDownloader:
         """
         使用 urllib.request 从 ModelScope HTTP 下载模型文件到本地目录。
         """
-        mirror = os.environ.get("JFOX_MODEL_MIRROR", _DEFAULT_MIRROR)
+        mirror = os.environ.get("JFOX_MODEL_MIRROR", _DEFAULT_MIRROR).rstrip("/")
         local_path = self._get_local_model_path()
         local_path.mkdir(parents=True, exist_ok=True)
 
-        # 按优先级尝试下载权重文件
+        # 按优先级尝试下载权重文件（先写入临时文件，成功后重命名）
         weight_downloaded = False
         for candidate in _WEIGHT_FILE_CANDIDATES:
             url = _MODELSCOPE_API_TEMPLATE.format(
                 mirror=mirror,
-                model_id=self.model_name,
-                file_path=candidate,
+                model_id=quote(self.model_name, safe=""),
+                file_path=quote(candidate, safe=""),
             )
             dest = local_path / candidate
+            tmp_dest = local_path / f".{candidate}.tmp"
             logger.info(f"试用权重文件 {candidate}...")
             try:
-                urlretrieve(url, str(dest))
-                if dest.exists() and dest.stat().st_size > 0:
+                with urlopen(url, timeout=60) as resp:
+                    with open(tmp_dest, "wb") as f:
+                        f.write(resp.read())
+                if tmp_dest.exists() and tmp_dest.stat().st_size > 0:
+                    tmp_dest.replace(dest)
                     logger.info(f"权重文件 {candidate} 下载成功")
                     weight_downloaded = True
                     break
                 else:
                     logger.warning(f"权重文件 {candidate} 下载后为空，尝试下一个")
+                    tmp_dest.unlink(missing_ok=True)
             except Exception as e:
                 logger.warning(f"权重文件 {candidate} 下载失败 ({e})，尝试下一个")
+                tmp_dest.unlink(missing_ok=True)
                 continue
 
         if not weight_downloaded:
             logger.warning("所有权重文件候选均下载失败")
+            self._cleanup_partial(local_path)
             return False
 
-        # 下载其他必需文件（不失败）
+        # 下载其他必需文件（config.json 必须成功）
         for fname in _REQUIRED_FILES:
             url = _MODELSCOPE_API_TEMPLATE.format(
                 mirror=mirror,
-                model_id=self.model_name,
-                file_path=fname,
+                model_id=quote(self.model_name, safe=""),
+                file_path=quote(fname, safe=""),
             )
             dest = local_path / fname
+            tmp_dest = local_path / f".{fname}.tmp"
             try:
-                urlretrieve(url, str(dest))
-                if not (dest.exists() and dest.stat().st_size > 0):
-                    logger.debug(f"{fname} 下载后为空，跳过")
+                with urlopen(url, timeout=60) as resp:
+                    with open(tmp_dest, "wb") as f:
+                        f.write(resp.read())
+                if tmp_dest.exists() and tmp_dest.stat().st_size > 0:
+                    tmp_dest.replace(dest)
+                else:
+                    logger.warning(f"{fname} 下载后为空，跳过")
+                    tmp_dest.unlink(missing_ok=True)
             except Exception as e:
                 logger.warning(f"{fname} 下载失败 ({e})，跳过")
+                tmp_dest.unlink(missing_ok=True)
+
+        # 验证 config.json 存在（SentenceTransformer 必需）
+        if not (local_path / "config.json").exists():
+            logger.error("config.json 下载失败，模型不完整")
+            self._cleanup_partial(local_path)
+            return False
 
         return True
 
@@ -234,7 +264,7 @@ class ModelDownloader:
             logger.warning("系统未安装 curl，跳过步骤 3")
             return False
 
-        mirror = os.environ.get("JFOX_MODEL_MIRROR", _DEFAULT_MIRROR)
+        mirror = os.environ.get("JFOX_MODEL_MIRROR", _DEFAULT_MIRROR).rstrip("/")
         local_path = self._get_local_model_path()
         local_path.mkdir(parents=True, exist_ok=True)
 
@@ -243,8 +273,8 @@ class ModelDownloader:
         for candidate in _WEIGHT_FILE_CANDIDATES:
             url = _MODELSCOPE_API_TEMPLATE.format(
                 mirror=mirror,
-                model_id=self.model_name,
-                file_path=candidate,
+                model_id=quote(self.model_name, safe=""),
+                file_path=quote(candidate, safe=""),
             )
             dest = local_path / candidate
             logger.info(f"试用权重文件 {candidate}...")
@@ -278,14 +308,15 @@ class ModelDownloader:
 
         if not weight_downloaded:
             logger.error("所有权重文件候选下载失败，步骤 3 未完成")
+            self._cleanup_partial(local_path)
             return False
 
         # 下载非权重必需文件
         for fname in _REQUIRED_FILES:
             url = _MODELSCOPE_API_TEMPLATE.format(
                 mirror=mirror,
-                model_id=self.model_name,
-                file_path=fname,
+                model_id=quote(self.model_name, safe=""),
+                file_path=quote(fname, safe=""),
             )
             dest = local_path / fname
             logger.info(f"下载 {fname}...")
@@ -316,11 +347,29 @@ class ModelDownloader:
             except (OSError, subprocess.TimeoutExpired) as e:
                 logger.warning(f"{fname} 下载异常: {e}")
 
+        # 验证 config.json 存在
+        if not (local_path / "config.json").exists():
+            logger.error("config.json 下载失败，模型不完整")
+            self._cleanup_partial(local_path)
+            return False
+
         return True
+
+    def _cleanup_partial(self, local_path: Path):
+        """下载失败时清理残留文件和空目录"""
+        try:
+            # 清理临时文件
+            for tmp in local_path.glob(".*.tmp"):
+                tmp.unlink(missing_ok=True)
+            # 如果目录为空则删除
+            if local_path.exists() and not any(local_path.iterdir()):
+                local_path.rmdir()
+        except OSError:
+            pass
 
     def get_manual_instructions(self) -> str:
         """获取手动下载说明"""
-        mirror = os.environ.get("JFOX_MODEL_MIRROR", _DEFAULT_MIRROR)
+        mirror = os.environ.get("JFOX_MODEL_MIRROR", _DEFAULT_MIRROR).rstrip("/")
         candidates = " / ".join(_WEIGHT_FILE_CANDIDATES)
         local_path = self._get_local_model_path()
         return (

--- a/tests/integration/test_model_download.py
+++ b/tests/integration/test_model_download.py
@@ -14,47 +14,59 @@ class TestModelDownloadRetryChain:
 
     @pytest.fixture
     def downloader(self, tmp_path):
-        with patch(
-            "jfox.model_downloader.ModelDownloader._get_hf_hub_cache",
-            return_value=tmp_path / "hub",
+        with (
+            patch(
+                "jfox.model_downloader.ModelDownloader._get_hf_hub_cache",
+                return_value=tmp_path / "hub",
+            ),
+            patch.object(
+                ModelDownloader,
+                "_get_local_model_path",
+                return_value=tmp_path / "local_models" / "sentence-transformers--all-MiniLM-L6-v2",
+            ),
         ):
-            return ModelDownloader("sentence-transformers/all-MiniLM-L6-v2")
+            yield ModelDownloader("sentence-transformers/all-MiniLM-L6-v2")
 
     def test_full_chain_step1_succeeds(self, downloader):
         """Step 1 成功，后续步骤不执行"""
-        with patch.object(downloader, "_try_hf_hub_download", side_effect=[True, False]) as mock_hf:
-            with patch.object(downloader, "_try_curl_download") as mock_curl:
-                result = downloader.ensure_cached()
-                assert result is True
-                assert mock_hf.call_count == 1
-                mock_curl.assert_not_called()
+        with patch.object(downloader, "_try_hf_hub_download", return_value=True) as mock_hf:
+            with patch.object(downloader, "_try_modelscope_http") as mock_http:
+                with patch.object(downloader, "_try_curl_download") as mock_curl:
+                    result = downloader.ensure_cached()
+                    assert result is True
+                    mock_hf.assert_called_once()
+                    mock_http.assert_not_called()
+                    mock_curl.assert_not_called()
 
     def test_full_chain_step1_fails_step2_succeeds(self, downloader):
         """Step 1 失败，Step 2 成功"""
-        with patch.object(downloader, "_try_hf_hub_download", side_effect=[False, True]) as mock_hf:
-            with patch.object(downloader, "_try_curl_download") as mock_curl:
-                result = downloader.ensure_cached()
-                assert result is True
-                calls = mock_hf.call_args_list
-                assert len(calls) == 2
-                assert calls[0][1].get("endpoint") is None
-                assert calls[1][1].get("endpoint") is not None
-                mock_curl.assert_not_called()
+        with patch.object(downloader, "_try_hf_hub_download", return_value=False) as mock_hf:
+            with patch.object(downloader, "_try_modelscope_http", return_value=True) as mock_http:
+                with patch.object(downloader, "_try_curl_download") as mock_curl:
+                    result = downloader.ensure_cached()
+                    assert result is True
+                    mock_hf.assert_called_once()
+                    mock_http.assert_called_once()
+                    mock_curl.assert_not_called()
 
     def test_full_chain_step1_2_fail_step3_succeeds(self, downloader):
         """Step 1/2 失败，Step 3 成功"""
-        with patch.object(downloader, "_try_hf_hub_download", return_value=False):
-            with patch.object(downloader, "_try_curl_download", return_value=True) as mock_curl:
-                result = downloader.ensure_cached()
-                assert result is True
-                mock_curl.assert_called_once()
+        with patch.object(downloader, "_try_hf_hub_download", return_value=False) as mock_hf:
+            with patch.object(downloader, "_try_modelscope_http", return_value=False) as mock_http:
+                with patch.object(downloader, "_try_curl_download", return_value=True) as mock_curl:
+                    result = downloader.ensure_cached()
+                    assert result is True
+                    mock_hf.assert_called_once()
+                    mock_http.assert_called_once()
+                    mock_curl.assert_called_once()
 
     def test_full_chain_all_fail(self, downloader):
         """全部失败，返回 False"""
         with patch.object(downloader, "_try_hf_hub_download", return_value=False):
-            with patch.object(downloader, "_try_curl_download", return_value=False):
-                result = downloader.ensure_cached()
-                assert result is False
+            with patch.object(downloader, "_try_modelscope_http", return_value=False):
+                with patch.object(downloader, "_try_curl_download", return_value=False):
+                    result = downloader.ensure_cached()
+                    assert result is False
 
     def test_daemon_start_calls_downloader(self):
         """验证 daemon start 启动前调用下载检查"""

--- a/tests/unit/test_daemon_process.py
+++ b/tests/unit/test_daemon_process.py
@@ -162,3 +162,90 @@ class TestDaemonModelCacheCheck:
         # 验证 health check 被调用了足够多次（使用 FIRST_RUN_TIMEOUT）
         # 由于第二次就返回了，至少被调用了 2 次
         assert mock_health.call_count >= 2
+
+
+class TestStartDaemonBlocking:
+    """测试下载失败时阻断启动"""
+
+    @patch("jfox.daemon.process._http_health_check", return_value=None)
+    @patch("jfox.daemon.process._check_model_cache")
+    @patch("jfox.model_downloader.ModelDownloader.ensure_cached", return_value=False)
+    @patch("jfox.model_downloader.ModelDownloader.get_manual_instructions", return_value="test instructions")
+    def test_blocks_when_download_fails(self, mock_instructions, mock_ensure, mock_cache, mock_health):
+        """模型下载失败时应阻断启动"""
+        from jfox.daemon.process import start_daemon
+
+        mock_cache.return_value = {
+            "needs_download": True,
+            "model_name": "sentence-transformers/all-MiniLM-L6-v2",
+            "size_hint": "90MB",
+        }
+        result = start_daemon()
+        assert result is False
+        mock_ensure.assert_called_once()
+
+    @patch("jfox.daemon.process._check_model_cache")
+    @patch("jfox.model_downloader.ModelDownloader.ensure_cached", return_value=True)
+    @patch("jfox.daemon.process.subprocess.Popen")
+    @patch("jfox.daemon.process._http_health_check")
+    def test_starts_when_download_succeeds(
+        self, mock_health, mock_popen, mock_ensure, mock_cache
+    ):
+        """模型下载成功时正常启动"""
+        from jfox.daemon.process import start_daemon
+
+        mock_cache.return_value = {
+            "needs_download": True,
+            "model_name": "sentence-transformers/all-MiniLM-L6-v2",
+            "size_hint": "90MB",
+        }
+        mock_health.side_effect = [None, {"pid": 9999}]
+        mock_popen.return_value.pid = 1234
+
+        result = start_daemon()
+        assert result is True
+
+
+class TestCheckModelCacheLocalDir:
+    """测试本地模型目录预检"""
+
+    def test_local_dir_with_weight(self):
+        """本地目录存在权重文件时 needs_download=False"""
+        from jfox.daemon.process import _check_model_cache
+        from jfox.model_downloader import _LOCAL_MODEL_DIR
+
+        local_path = _LOCAL_MODEL_DIR / "sentence-transformers--all-MiniLM-L6-v2"
+        local_path.mkdir(parents=True, exist_ok=True)
+        (local_path / "model.safetensors").write_text("fake")
+
+        try:
+            with patch("jfox.config.config") as mock_cfg:
+                mock_cfg.embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
+                result = _check_model_cache()
+                assert result["needs_download"] is False
+                assert result["model_name"] == "sentence-transformers/all-MiniLM-L6-v2"
+        finally:
+            import shutil
+
+            if local_path.exists():
+                shutil.rmtree(local_path.parent, ignore_errors=True)
+
+    def test_local_dir_without_weight(self):
+        """本地目录存在但无权重文件时 needs_download=True"""
+        from jfox.daemon.process import _check_model_cache
+        from jfox.model_downloader import _LOCAL_MODEL_DIR
+
+        local_path = _LOCAL_MODEL_DIR / "sentence-transformers--all-MiniLM-L6-v2"
+        local_path.mkdir(parents=True, exist_ok=True)
+        (local_path / "config.json").write_text("fake")
+
+        try:
+            with patch("jfox.config.config") as mock_cfg:
+                mock_cfg.embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
+                result = _check_model_cache()
+                assert result["needs_download"] is True
+        finally:
+            import shutil
+
+            if local_path.exists():
+                shutil.rmtree(local_path.parent, ignore_errors=True)

--- a/tests/unit/test_daemon_process.py
+++ b/tests/unit/test_daemon_process.py
@@ -233,8 +233,8 @@ class TestCheckModelCacheLocalDir:
             if local_path.exists():
                 shutil.rmtree(local_path.parent, ignore_errors=True)
 
-    def test_local_dir_without_weight(self):
-        """本地目录存在但无权重文件时 needs_download=True"""
+    def test_local_dir_without_weight(self, tmp_path):
+        """本地目录存在但无权重文件时，HF Hub 也无缓存，needs_download=True"""
         from jfox.daemon.process import _check_model_cache
         from jfox.model_downloader import _LOCAL_MODEL_DIR
 
@@ -245,8 +245,10 @@ class TestCheckModelCacheLocalDir:
         try:
             with patch("jfox.config.config") as mock_cfg:
                 mock_cfg.embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
-                result = _check_model_cache()
-                assert result["needs_download"] is True
+                # 隔离 HF Hub 缓存，避免测试机已有缓存导致结果不确定
+                with patch.dict("os.environ", {"HF_HOME": str(tmp_path / "empty_hf_home")}):
+                    result = _check_model_cache()
+                    assert result["needs_download"] is True
         finally:
             import shutil
 

--- a/tests/unit/test_daemon_process.py
+++ b/tests/unit/test_daemon_process.py
@@ -212,26 +212,29 @@ class TestStartDaemonBlocking:
 class TestCheckModelCacheLocalDir:
     """测试本地模型目录预检"""
 
-    def test_local_dir_with_weight(self):
-        """本地目录存在权重文件时 needs_download=False"""
+    def test_local_dir_with_weight(self, tmp_path):
+        """本地目录存在权重文件和 config.json 时 needs_download=False"""
         from jfox.daemon.process import _check_model_cache
         from jfox.model_downloader import _LOCAL_MODEL_DIR
 
         local_path = _LOCAL_MODEL_DIR / "sentence-transformers--all-MiniLM-L6-v2"
         local_path.mkdir(parents=True, exist_ok=True)
         (local_path / "model.safetensors").write_text("fake")
+        (local_path / "config.json").write_text("{}")
 
         try:
             with patch("jfox.config.config") as mock_cfg:
                 mock_cfg.embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
-                result = _check_model_cache()
-                assert result["needs_download"] is False
-                assert result["model_name"] == "sentence-transformers/all-MiniLM-L6-v2"
+                # 隔离 HF Hub 缓存，确保测试走本地目录分支
+                with patch.dict("os.environ", {"HF_HOME": str(tmp_path / "empty_hf_home")}):
+                    result = _check_model_cache()
+                    assert result["needs_download"] is False
+                    assert result["model_name"] == "sentence-transformers/all-MiniLM-L6-v2"
         finally:
             import shutil
 
             if local_path.exists():
-                shutil.rmtree(local_path.parent, ignore_errors=True)
+                shutil.rmtree(local_path, ignore_errors=True)
 
     def test_local_dir_without_weight(self, tmp_path):
         """本地目录存在但无权重文件时，HF Hub 也无缓存，needs_download=True"""
@@ -253,4 +256,4 @@ class TestCheckModelCacheLocalDir:
             import shutil
 
             if local_path.exists():
-                shutil.rmtree(local_path.parent, ignore_errors=True)
+                shutil.rmtree(local_path, ignore_errors=True)

--- a/tests/unit/test_daemon_process.py
+++ b/tests/unit/test_daemon_process.py
@@ -170,8 +170,13 @@ class TestStartDaemonBlocking:
     @patch("jfox.daemon.process._http_health_check", return_value=None)
     @patch("jfox.daemon.process._check_model_cache")
     @patch("jfox.model_downloader.ModelDownloader.ensure_cached", return_value=False)
-    @patch("jfox.model_downloader.ModelDownloader.get_manual_instructions", return_value="test instructions")
-    def test_blocks_when_download_fails(self, mock_instructions, mock_ensure, mock_cache, mock_health):
+    @patch(
+        "jfox.model_downloader.ModelDownloader.get_manual_instructions",
+        return_value="test instructions",
+    )
+    def test_blocks_when_download_fails(
+        self, mock_instructions, mock_ensure, mock_cache, mock_health
+    ):
         """模型下载失败时应阻断启动"""
         from jfox.daemon.process import start_daemon
 
@@ -188,9 +193,7 @@ class TestStartDaemonBlocking:
     @patch("jfox.model_downloader.ModelDownloader.ensure_cached", return_value=True)
     @patch("jfox.daemon.process.subprocess.Popen")
     @patch("jfox.daemon.process._http_health_check")
-    def test_starts_when_download_succeeds(
-        self, mock_health, mock_popen, mock_ensure, mock_cache
-    ):
+    def test_starts_when_download_succeeds(self, mock_health, mock_popen, mock_ensure, mock_cache):
         """模型下载成功时正常启动"""
         from jfox.daemon.process import start_daemon
 

--- a/tests/unit/test_embedding_local_load.py
+++ b/tests/unit/test_embedding_local_load.py
@@ -33,6 +33,35 @@ class TestEmbeddingLocalLoad:
             result = backend._get_local_model_path()
             assert result is None
 
+    def test_get_local_model_path_empty_dir(self, backend, tmp_path):
+        """本地目录存在但为空时返回 None"""
+        fake_local = tmp_path / ".models" / "sentence-transformers--all-MiniLM-L6-v2"
+        fake_local.mkdir(parents=True)
+
+        with patch("jfox.model_downloader._LOCAL_MODEL_DIR", tmp_path / ".models"):
+            result = backend._get_local_model_path()
+            assert result is None
+
+    def test_get_local_model_path_config_only(self, backend, tmp_path):
+        """仅有 config.json 无权重文件时返回 None"""
+        fake_local = tmp_path / ".models" / "sentence-transformers--all-MiniLM-L6-v2"
+        fake_local.mkdir(parents=True)
+        (fake_local / "config.json").write_text("{}")
+
+        with patch("jfox.model_downloader._LOCAL_MODEL_DIR", tmp_path / ".models"):
+            result = backend._get_local_model_path()
+            assert result is None
+
+    def test_get_local_model_path_weight_only(self, backend, tmp_path):
+        """仅有权重文件无 config.json 时返回 None"""
+        fake_local = tmp_path / ".models" / "sentence-transformers--all-MiniLM-L6-v2"
+        fake_local.mkdir(parents=True)
+        (fake_local / "model.safetensors").write_text("fake")
+
+        with patch("jfox.model_downloader._LOCAL_MODEL_DIR", tmp_path / ".models"):
+            result = backend._get_local_model_path()
+            assert result is None
+
     def test_load_uses_local_path_when_available(self, backend):
         """本地目录存在时优先使用本地路径加载"""
         mock_model = MagicMock()

--- a/tests/unit/test_embedding_local_load.py
+++ b/tests/unit/test_embedding_local_load.py
@@ -16,9 +16,11 @@ class TestEmbeddingLocalLoad:
         return EmbeddingBackend(device="cpu", model_name="sentence-transformers/all-MiniLM-L6-v2")
 
     def test_get_local_model_path_when_exists(self, backend, tmp_path):
-        """本地目录存在时返回路径"""
+        """本地目录存在有效模型文件时返回路径"""
         fake_local = tmp_path / ".models" / "sentence-transformers--all-MiniLM-L6-v2"
         fake_local.mkdir(parents=True)
+        (fake_local / "config.json").write_text("{}")
+        (fake_local / "model.safetensors").write_text("fake")
 
         with patch("jfox.model_downloader._LOCAL_MODEL_DIR", tmp_path / ".models"):
             result = backend._get_local_model_path()

--- a/tests/unit/test_embedding_local_load.py
+++ b/tests/unit/test_embedding_local_load.py
@@ -1,0 +1,68 @@
+"""EmbeddingBackend 本地路径加载测试"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestEmbeddingLocalLoad:
+    """测试本地模型目录加载"""
+
+    @pytest.fixture
+    def backend(self):
+        from jfox.embedding_backend import EmbeddingBackend
+
+        return EmbeddingBackend(device="cpu", model_name="sentence-transformers/all-MiniLM-L6-v2")
+
+    def test_get_local_model_path_when_exists(self, backend, tmp_path):
+        """本地目录存在时返回路径"""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        fake_local = (
+            fake_home / ".zettelkasten" / ".models" / "sentence-transformers--all-MiniLM-L6-v2"
+        )
+        fake_local.mkdir(parents=True)
+
+        with patch("jfox.embedding_backend.Path.home", return_value=fake_home):
+            result = backend._get_local_model_path()
+            assert result is not None
+            assert "all-MiniLM-L6-v2" in str(result)
+
+    def test_get_local_model_path_when_not_exists(self, backend, tmp_path):
+        """本地目录不存在时返回 None"""
+        fake_home = tmp_path / "no_models_home"
+        fake_home.mkdir()
+
+        with patch("jfox.embedding_backend.Path.home", return_value=fake_home):
+            result = backend._get_local_model_path()
+            assert result is None
+
+    def test_load_uses_local_path_when_available(self, backend):
+        """本地目录存在时优先使用本地路径加载"""
+        mock_model = MagicMock()
+        mock_model.get_sentence_embedding_dimension.return_value = 384
+        fake_path = Path("/fake/local/model")
+
+        with patch.object(backend, "_get_local_model_path", return_value=fake_path):
+            with patch(
+                "sentence_transformers.SentenceTransformer", return_value=mock_model
+            ) as mock_st:
+                with patch.object(backend, "_check_daemon", return_value=False):
+                    backend.load()
+                    mock_st.assert_called_once_with(str(fake_path), device="cpu")
+
+    def test_load_uses_model_name_when_no_local(self, backend):
+        """本地目录不存在时使用模型名加载"""
+        mock_model = MagicMock()
+        mock_model.get_sentence_embedding_dimension.return_value = 384
+
+        with patch.object(backend, "_get_local_model_path", return_value=None):
+            with patch(
+                "sentence_transformers.SentenceTransformer", return_value=mock_model
+            ) as mock_st:
+                with patch.object(backend, "_check_daemon", return_value=False):
+                    backend.load()
+                    mock_st.assert_called_once_with(
+                        "sentence-transformers/all-MiniLM-L6-v2", device="cpu"
+                    )

--- a/tests/unit/test_embedding_local_load.py
+++ b/tests/unit/test_embedding_local_load.py
@@ -17,24 +17,17 @@ class TestEmbeddingLocalLoad:
 
     def test_get_local_model_path_when_exists(self, backend, tmp_path):
         """本地目录存在时返回路径"""
-        fake_home = tmp_path / "home"
-        fake_home.mkdir()
-        fake_local = (
-            fake_home / ".zettelkasten" / ".models" / "sentence-transformers--all-MiniLM-L6-v2"
-        )
+        fake_local = tmp_path / ".models" / "sentence-transformers--all-MiniLM-L6-v2"
         fake_local.mkdir(parents=True)
 
-        with patch("jfox.embedding_backend.Path.home", return_value=fake_home):
+        with patch("jfox.model_downloader._LOCAL_MODEL_DIR", tmp_path / ".models"):
             result = backend._get_local_model_path()
             assert result is not None
             assert "all-MiniLM-L6-v2" in str(result)
 
     def test_get_local_model_path_when_not_exists(self, backend, tmp_path):
         """本地目录不存在时返回 None"""
-        fake_home = tmp_path / "no_models_home"
-        fake_home.mkdir()
-
-        with patch("jfox.embedding_backend.Path.home", return_value=fake_home):
+        with patch("jfox.model_downloader._LOCAL_MODEL_DIR", tmp_path / ".models"):
             result = backend._get_local_model_path()
             assert result is None
 

--- a/tests/unit/test_model_downloader.py
+++ b/tests/unit/test_model_downloader.py
@@ -206,12 +206,16 @@ class TestModelDownloader:
 
     def test_try_modelscope_http_success(self, downloader):
         """ModelScope HTTP 下载成功"""
-        with patch("jfox.model_downloader.urlretrieve") as mock_retrieve:
+        with patch("jfox.model_downloader.urlopen") as mock_open:
 
-            def urlretrieve_side_effect(url, dest):
-                Path(dest).write_text("fake model")
+            def urlopen_side_effect(url, timeout=None):
+                mock_resp = MagicMock()
+                mock_resp.read.return_value = b"fake model"
+                mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+                mock_resp.__exit__ = MagicMock(return_value=False)
+                return mock_resp
 
-            mock_retrieve.side_effect = urlretrieve_side_effect
+            mock_open.side_effect = urlopen_side_effect
 
             result = downloader._try_modelscope_http()
             assert result is True
@@ -222,35 +226,43 @@ class TestModelDownloader:
         """model.safetensors 不存在时回退到 pytorch_model.bin"""
         call_count = 0
 
-        def urlretrieve_side_effect(url, dest):
+        def urlopen_side_effect(url, timeout=None):
             nonlocal call_count
             call_count += 1
-            if "model.safetensors" in url:
+            mock_resp = MagicMock()
+            if "model.safetensors" in str(url):
                 raise Exception("404")
-            Path(dest).write_text("fake model")
+            mock_resp.read.return_value = b"fake model"
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
 
-        with patch("jfox.model_downloader.urlretrieve") as mock_retrieve:
-            mock_retrieve.side_effect = urlretrieve_side_effect
+        with patch("jfox.model_downloader.urlopen") as mock_open:
+            mock_open.side_effect = urlopen_side_effect
             result = downloader._try_modelscope_http()
             assert result is True
             assert call_count >= 1
 
     def test_try_modelscope_http_all_fail(self, downloader):
         """所有权重文件下载失败"""
-        with patch("jfox.model_downloader.urlretrieve", side_effect=Exception("network")):
+        with patch("jfox.model_downloader.urlopen", side_effect=Exception("network")):
             result = downloader._try_modelscope_http()
             assert result is False
 
     def test_try_modelscope_http_custom_mirror(self, downloader):
         """JFOX_MODEL_MIRROR 环境变量生效"""
         with patch.dict(os.environ, {"JFOX_MODEL_MIRROR": "https://custom.mirror.com"}):
-            with patch("jfox.model_downloader.urlretrieve") as mock_retrieve:
+            with patch("jfox.model_downloader.urlopen") as mock_open:
 
-                def urlretrieve_side_effect(url, dest):
-                    assert "custom.mirror.com" in url
-                    Path(dest).write_text("fake")
+                def urlopen_side_effect(url, timeout=None):
+                    assert "custom.mirror.com" in str(url)
+                    mock_resp = MagicMock()
+                    mock_resp.read.return_value = b"fake"
+                    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+                    mock_resp.__exit__ = MagicMock(return_value=False)
+                    return mock_resp
 
-                mock_retrieve.side_effect = urlretrieve_side_effect
+                mock_open.side_effect = urlopen_side_effect
                 result = downloader._try_modelscope_http()
                 assert result is True
 

--- a/tests/unit/test_model_downloader.py
+++ b/tests/unit/test_model_downloader.py
@@ -3,6 +3,7 @@
 import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from urllib.error import URLError
 
 import pytest
 
@@ -232,7 +233,7 @@ class TestModelDownloader:
             call_count += 1
             mock_resp = MagicMock()
             if "model.safetensors" in str(url):
-                raise Exception("404")
+                raise URLError("404")
             mock_resp.read.side_effect = [b"fake model", b""]
             mock_resp.__enter__ = MagicMock(return_value=mock_resp)
             mock_resp.__exit__ = MagicMock(return_value=False)
@@ -246,7 +247,7 @@ class TestModelDownloader:
 
     def test_try_modelscope_http_all_fail(self, downloader):
         """所有权重文件下载失败"""
-        with patch("jfox.model_downloader.urlopen", side_effect=Exception("network")):
+        with patch("jfox.model_downloader.urlopen", side_effect=URLError("network")):
             result = downloader._try_modelscope_http()
             assert result is False
 

--- a/tests/unit/test_model_downloader.py
+++ b/tests/unit/test_model_downloader.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from jfox.model_downloader import _DEFAULT_MIRROR, ModelDownloader
+from jfox.model_downloader import ModelDownloader
 
 
 class TestModelDownloader:

--- a/tests/unit/test_model_downloader.py
+++ b/tests/unit/test_model_downloader.py
@@ -135,13 +135,59 @@ class TestModelDownloader:
             result = downloader._try_hf_hub_download()
             assert result is True
 
+    def test_try_curl_download_success(self, downloader):
+        """curl 下载成功，文件写入本地目录"""
+        local_path = downloader._get_local_model_path()
+
+        def subprocess_side_effect(*args, **kwargs):
+            cmd = args[0]
+            outfile = cmd[cmd.index("-o") + 1]
+            Path(outfile).write_text("fake model")
+            return MagicMock(returncode=0)
+
+        with patch("jfox.model_downloader.shutil.which", return_value="curl"):
+            with patch(
+                "jfox.model_downloader.subprocess.run",
+                side_effect=subprocess_side_effect,
+            ) as mock_run:
+                result = downloader._try_curl_download()
+                assert result is True
+                assert (local_path / "model.safetensors").exists()
+                # 验证 curl 调用了 ModelScope API URL
+                calls = mock_run.call_args_list
+                assert len(calls) >= 1
+                cmd = calls[0][0][0]
+                url = cmd[-1]
+                assert "modelscope.cn" in url or "api/v1/models" in url
+
+    def test_try_curl_download_custom_mirror(self, downloader):
+        """JFOX_MODEL_MIRROR 环境变量生效"""
+        with patch.dict(os.environ, {"JFOX_MODEL_MIRROR": "https://custom.mirror.com"}):
+
+            def subprocess_side_effect(*args, **kwargs):
+                cmd = args[0]
+                outfile = cmd[cmd.index("-o") + 1]
+                Path(outfile).write_text("fake model")
+                return MagicMock(returncode=0)
+
+            with patch("jfox.model_downloader.shutil.which", return_value="curl"):
+                with patch(
+                    "jfox.model_downloader.subprocess.run",
+                    side_effect=subprocess_side_effect,
+                ) as mock_run:
+                    result = downloader._try_curl_download()
+                    assert result is True
+                    calls = mock_run.call_args_list
+                    url = calls[0][0][0][-1]
+                    assert "custom.mirror.com" in url
+
     def test_cleanup_partial(self, downloader):
-        """验证部分下载残留被清理（通过 TemporaryDirectory 自动实现）"""
+        """curl 返回成功码但未写入文件，视为失败"""
         with patch("jfox.model_downloader.shutil.which", return_value="curl"):
             with patch("jfox.model_downloader.subprocess.run") as mock_run:
                 mock_run.return_value = MagicMock(returncode=0)
                 result = downloader._try_curl_download()
-                # curl 未实际下载文件，返回 False；TemporaryDirectory 自动清理
+                # subprocess 返回 0 但文件不存在，返回 False
                 assert result is False
 
     def test_check_cached_local_dir_with_weight(self, downloader):

--- a/tests/unit/test_model_downloader.py
+++ b/tests/unit/test_model_downloader.py
@@ -1,5 +1,7 @@
 """ModelDownloader 单元测试"""
 
+import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -65,36 +67,43 @@ class TestModelDownloader:
     def test_ensure_cached_step1_succeeds(self, downloader):
         """Step 1 成功，后续步骤不执行"""
         with patch.object(downloader, "_try_hf_hub_download", return_value=True) as mock_hf:
-            with patch.object(downloader, "_try_curl_download") as mock_curl:
-                result = downloader.ensure_cached()
-                assert result is True
-                assert mock_hf.call_count == 1
-                mock_curl.assert_not_called()
+            with patch.object(downloader, "_try_modelscope_http") as mock_http:
+                with patch.object(downloader, "_try_curl_download") as mock_curl:
+                    result = downloader.ensure_cached()
+                    assert result is True
+                    mock_hf.assert_called_once()
+                    mock_http.assert_not_called()
+                    mock_curl.assert_not_called()
 
     def test_ensure_cached_step1_fails_step2_succeeds(self, downloader):
         """Step 1 失败，Step 2 成功"""
-        with patch.object(downloader, "_try_hf_hub_download", side_effect=[False, True]) as mock_hf:
-            with patch.object(downloader, "_try_curl_download") as mock_curl:
-                result = downloader.ensure_cached()
-                assert result is True
-                assert mock_hf.call_count == 2
-                mock_curl.assert_not_called()
+        with patch.object(downloader, "_try_hf_hub_download", return_value=False) as mock_hf:
+            with patch.object(downloader, "_try_modelscope_http", return_value=True) as mock_http:
+                with patch.object(downloader, "_try_curl_download") as mock_curl:
+                    result = downloader.ensure_cached()
+                    assert result is True
+                    mock_hf.assert_called_once()
+                    mock_http.assert_called_once()
+                    mock_curl.assert_not_called()
 
     def test_ensure_cached_step1_2_fail_step3_succeeds(self, downloader):
         """Step 1/2 失败，Step 3 成功"""
         with patch.object(downloader, "_try_hf_hub_download", return_value=False) as mock_hf:
-            with patch.object(downloader, "_try_curl_download", return_value=True) as mock_curl:
-                result = downloader.ensure_cached()
-                assert result is True
-                assert mock_hf.call_count == 2
-                mock_curl.assert_called_once()
+            with patch.object(downloader, "_try_modelscope_http", return_value=False) as mock_http:
+                with patch.object(downloader, "_try_curl_download", return_value=True) as mock_curl:
+                    result = downloader.ensure_cached()
+                    assert result is True
+                    mock_hf.assert_called_once()
+                    mock_http.assert_called_once()
+                    mock_curl.assert_called_once()
 
     def test_ensure_cached_all_fail(self, downloader):
         """全部失败，返回 False"""
         with patch.object(downloader, "_try_hf_hub_download", return_value=False):
-            with patch.object(downloader, "_try_curl_download", return_value=False):
-                result = downloader.ensure_cached()
-                assert result is False
+            with patch.object(downloader, "_try_modelscope_http", return_value=False):
+                with patch.object(downloader, "_try_curl_download", return_value=False):
+                    result = downloader.ensure_cached()
+                    assert result is False
 
     def test_try_curl_download_no_curl(self, downloader):
         """curl 不存在时返回 False"""
@@ -148,3 +157,53 @@ class TestModelDownloader:
         local.mkdir(parents=True, exist_ok=True)
         (local / "config.json").write_text("fake")
         assert downloader._check_cached() is False
+
+    def test_try_modelscope_http_success(self, downloader):
+        """ModelScope HTTP 下载成功"""
+        with patch("jfox.model_downloader.urlretrieve") as mock_retrieve:
+
+            def urlretrieve_side_effect(url, dest):
+                Path(dest).write_text("fake model")
+
+            mock_retrieve.side_effect = urlretrieve_side_effect
+
+            result = downloader._try_modelscope_http()
+            assert result is True
+            local_path = downloader._get_local_model_path()
+            assert (local_path / "model.safetensors").exists()
+
+    def test_try_modelscope_http_fallback_to_pytorch(self, downloader):
+        """model.safetensors 不存在时回退到 pytorch_model.bin"""
+        call_count = 0
+
+        def urlretrieve_side_effect(url, dest):
+            nonlocal call_count
+            call_count += 1
+            if "model.safetensors" in url:
+                raise Exception("404")
+            Path(dest).write_text("fake model")
+
+        with patch("jfox.model_downloader.urlretrieve") as mock_retrieve:
+            mock_retrieve.side_effect = urlretrieve_side_effect
+            result = downloader._try_modelscope_http()
+            assert result is True
+            assert call_count >= 1
+
+    def test_try_modelscope_http_all_fail(self, downloader):
+        """所有权重文件下载失败"""
+        with patch("jfox.model_downloader.urlretrieve", side_effect=Exception("network")):
+            result = downloader._try_modelscope_http()
+            assert result is False
+
+    def test_try_modelscope_http_custom_mirror(self, downloader):
+        """JFOX_MODEL_MIRROR 环境变量生效"""
+        with patch.dict(os.environ, {"JFOX_MODEL_MIRROR": "https://custom.mirror.com"}):
+            with patch("jfox.model_downloader.urlretrieve") as mock_retrieve:
+
+                def urlretrieve_side_effect(url, dest):
+                    assert "custom.mirror.com" in url
+                    Path(dest).write_text("fake")
+
+                mock_retrieve.side_effect = urlretrieve_side_effect
+                result = downloader._try_modelscope_http()
+                assert result is True

--- a/tests/unit/test_model_downloader.py
+++ b/tests/unit/test_model_downloader.py
@@ -191,10 +191,11 @@ class TestModelDownloader:
                 assert result is False
 
     def test_check_cached_local_dir_with_weight(self, downloader):
-        """本地目录存在权重文件时返回 True"""
+        """本地目录存在权重文件和 config.json 时返回 True"""
         local = downloader._get_local_model_path()
         local.mkdir(parents=True, exist_ok=True)
         (local / "model.safetensors").write_text("fake")
+        (local / "config.json").write_text("fake")
         assert downloader._check_cached() is True
 
     def test_check_cached_local_dir_without_weight(self, downloader):
@@ -210,7 +211,7 @@ class TestModelDownloader:
 
             def urlopen_side_effect(url, timeout=None):
                 mock_resp = MagicMock()
-                mock_resp.read.return_value = b"fake model"
+                mock_resp.read.side_effect = [b"fake model", b""]
                 mock_resp.__enter__ = MagicMock(return_value=mock_resp)
                 mock_resp.__exit__ = MagicMock(return_value=False)
                 return mock_resp
@@ -232,7 +233,7 @@ class TestModelDownloader:
             mock_resp = MagicMock()
             if "model.safetensors" in str(url):
                 raise Exception("404")
-            mock_resp.read.return_value = b"fake model"
+            mock_resp.read.side_effect = [b"fake model", b""]
             mock_resp.__enter__ = MagicMock(return_value=mock_resp)
             mock_resp.__exit__ = MagicMock(return_value=False)
             return mock_resp
@@ -257,7 +258,7 @@ class TestModelDownloader:
                 def urlopen_side_effect(url, timeout=None):
                     assert "custom.mirror.com" in str(url)
                     mock_resp = MagicMock()
-                    mock_resp.read.return_value = b"fake"
+                    mock_resp.read.side_effect = [b"fake", b""]
                     mock_resp.__enter__ = MagicMock(return_value=mock_resp)
                     mock_resp.__exit__ = MagicMock(return_value=False)
                     return mock_resp

--- a/tests/unit/test_model_downloader.py
+++ b/tests/unit/test_model_downloader.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from jfox.model_downloader import _HF_MIRROR, ModelDownloader
+from jfox.model_downloader import _DEFAULT_MIRROR, ModelDownloader
 
 
 class TestModelDownloader:
@@ -14,12 +14,25 @@ class TestModelDownloader:
     @pytest.fixture
     def downloader(self, tmp_path):
         """创建带临时缓存的 downloader"""
-        with patch(
-            "jfox.model_downloader.ModelDownloader._get_hf_hub_cache",
-            return_value=tmp_path / "hub",
+        local_path = tmp_path / "local_models" / "sentence-transformers--all-MiniLM-L6-v2"
+        with (
+            patch(
+                "jfox.model_downloader.ModelDownloader._get_hf_hub_cache",
+                return_value=tmp_path / "hub",
+            ),
+            patch.object(
+                ModelDownloader,
+                "_get_local_model_path",
+                return_value=local_path,
+            ),
         ):
             d = ModelDownloader("sentence-transformers/all-MiniLM-L6-v2")
-            return d
+            yield d
+            # 清理本地模型目录，避免影响后续测试
+            if local_path.exists():
+                import shutil
+
+                shutil.rmtree(local_path)
 
     def test_check_cached_when_not_exists(self, downloader):
         """缓存不存在时返回 False"""
@@ -90,7 +103,7 @@ class TestModelDownloader:
 
         with patch("huggingface_hub.hf_hub_download") as mock_download:
             mock_download.side_effect = Exception("network")
-            downloader._try_hf_hub_download(endpoint=_HF_MIRROR)
+            downloader._try_hf_hub_download(endpoint=_DEFAULT_MIRROR)
 
         # 调用后环境变量应被恢复
         assert os.environ.get("HF_ENDPOINT") == env_before
@@ -133,3 +146,17 @@ class TestModelDownloader:
                 result = downloader._try_curl_download()
                 # curl 未实际下载文件，返回 False；TemporaryDirectory 自动清理
                 assert result is False
+
+    def test_check_cached_local_dir_with_weight(self, downloader):
+        """本地目录存在权重文件时返回 True"""
+        local = downloader._get_local_model_path()
+        local.mkdir(parents=True, exist_ok=True)
+        (local / "model.safetensors").write_text("fake")
+        assert downloader._check_cached() is True
+
+    def test_check_cached_local_dir_without_weight(self, downloader):
+        """本地目录存在但无权重文件时返回 False"""
+        local = downloader._get_local_model_path()
+        local.mkdir(parents=True, exist_ok=True)
+        (local / "config.json").write_text("fake")
+        assert downloader._check_cached() is False

--- a/tests/unit/test_model_downloader.py
+++ b/tests/unit/test_model_downloader.py
@@ -1,6 +1,5 @@
 """ModelDownloader 单元测试"""
 
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -65,7 +64,7 @@ class TestModelDownloader:
 
     def test_ensure_cached_step1_succeeds(self, downloader):
         """Step 1 成功，后续步骤不执行"""
-        with patch.object(downloader, "_try_hf_hub_download", side_effect=[True, False]) as mock_hf:
+        with patch.object(downloader, "_try_hf_hub_download", return_value=True) as mock_hf:
             with patch.object(downloader, "_try_curl_download") as mock_curl:
                 result = downloader.ensure_cached()
                 assert result is True
@@ -96,17 +95,6 @@ class TestModelDownloader:
             with patch.object(downloader, "_try_curl_download", return_value=False):
                 result = downloader.ensure_cached()
                 assert result is False
-
-    def test_try_hf_hub_download_sets_env(self, downloader):
-        """验证镜像模式设置了 HF_ENDPOINT 环境变量"""
-        env_before = os.environ.get("HF_ENDPOINT")
-
-        with patch("huggingface_hub.hf_hub_download") as mock_download:
-            mock_download.side_effect = Exception("network")
-            downloader._try_hf_hub_download(endpoint=_DEFAULT_MIRROR)
-
-        # 调用后环境变量应被恢复
-        assert os.environ.get("HF_ENDPOINT") == env_before
 
     def test_try_curl_download_no_curl(self, downloader):
         """curl 不存在时返回 False"""

--- a/tests/unit/test_model_downloader.py
+++ b/tests/unit/test_model_downloader.py
@@ -253,3 +253,16 @@ class TestModelDownloader:
                 mock_retrieve.side_effect = urlretrieve_side_effect
                 result = downloader._try_modelscope_http()
                 assert result is True
+
+    def test_get_manual_instructions(self, downloader):
+        """手动下载指引包含 ModelScope URL 和本地路径"""
+        instructions = downloader.get_manual_instructions()
+        assert "modelscope.cn" in instructions or "JFOX_MODEL_MIRROR" in instructions
+        assert downloader.model_name in instructions
+        assert str(downloader._get_local_model_path()) in instructions
+
+    def test_get_manual_instructions_custom_mirror(self, downloader):
+        """自定义镜像站时指引使用自定义 URL"""
+        with patch.dict(os.environ, {"JFOX_MODEL_MIRROR": "https://custom.mirror.com"}):
+            instructions = downloader.get_manual_instructions()
+            assert "custom.mirror.com" in instructions


### PR DESCRIPTION
## Summary

- Replace `hf-mirror.com` with `modelscope.cn` as the fallback download source
- Add `JFOX_MODEL_MIRROR` env var for custom mirror support
- Download models to `~/.zettelkasten/.models/` instead of faking HF Hub cache structure
- Block daemon startup when model download fails (fixes misleading 300s timeout)
- Upgrade download failure logs from debug to warning
- EmbeddingBackend now prefers loading from local model directory

## Changes

- `jfox/model_downloader.py`: new `_try_modelscope_http()` step, curl downloads to local dir, updated manual instructions
- `jfox/embedding_backend.py`: load from local `~/.zettelkasten/.models/{safe_name}/` first
- `jfox/daemon/process.py`: block startup on download failure, print manual instructions to stderr
- Tests updated for new 3-step retry chain and local directory caching

Fixes #225