### PR TITLE
feat(daemon): interactive auto-summary prompt on daemon start

### DIFF
--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 import re
 import sys
 import warnings
@@ -2680,7 +2681,7 @@ def daemon(
                 from .global_config import get_global_config_manager
 
                 auto_cfg = get_global_config_manager().get_auto_summary_config()
-                if not auto_cfg.enabled:
+                if not auto_cfg.enabled and os.isatty(1):
                     if typer.confirm("是否启用 auto-summary 自动总结功能？", default=False):
                         get_global_config_manager().update_auto_summary_config(enabled=True)
                         console.print("[green]✓[/green] auto-summary 已启用")

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -2666,9 +2666,7 @@ def daemon(
 
     try:
         if enable_auto_summary and no_auto_summary:
-            console.print(
-                "[red]✗[/red] --enable-auto-summary 和 --no-auto-summary 不能同时使用"
-            )
+            console.print("[red]✗[/red] --enable-auto-summary 和 --no-auto-summary 不能同时使用")
             raise typer.Exit(1)
 
         if action == "start":
@@ -2711,9 +2709,11 @@ def daemon(
         elif action == "restart":
             if enable_auto_summary:
                 from .global_config import get_global_config_manager
+
                 get_global_config_manager().update_auto_summary_config(enabled=True)
             elif no_auto_summary:
                 from .global_config import get_global_config_manager
+
                 get_global_config_manager().update_auto_summary_config(enabled=False)
 
             console.print("[yellow]正在重启 daemon...[/yellow]")

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -2712,10 +2712,12 @@ def daemon(
                 from .global_config import get_global_config_manager
 
                 get_global_config_manager().update_auto_summary_config(enabled=True)
+                console.print("[green]✓[/green] auto-summary 已启用")
             elif no_auto_summary:
                 from .global_config import get_global_config_manager
 
                 get_global_config_manager().update_auto_summary_config(enabled=False)
+                console.print("[yellow]auto-summary 已禁用[/yellow]")
 
             console.print("[yellow]正在重启 daemon...[/yellow]")
             if restart_daemon(port=port):

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -2761,7 +2761,7 @@ def daemon(
             console.print("可用操作: start, stop, restart, status")
             raise typer.Exit(1)
 
-    except typer.Exit:
+    except (typer.Exit, typer.Abort):
         raise
     except Exception as e:
         console.print(f"[red]✗[/red] 错误: {e}")

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -2681,7 +2681,7 @@ def daemon(
                 from .global_config import get_global_config_manager
 
                 auto_cfg = get_global_config_manager().get_auto_summary_config()
-                if not auto_cfg.enabled and os.isatty(1):
+                if not auto_cfg.enabled and os.isatty(0):
                     if typer.confirm("是否启用 auto-summary 自动总结功能？", default=False):
                         get_global_config_manager().update_auto_summary_config(enabled=True)
                         console.print("[green]✓[/green] auto-summary 已启用")

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -2709,6 +2709,13 @@ def daemon(
                 raise typer.Exit(1)
 
         elif action == "restart":
+            if enable_auto_summary:
+                from .global_config import get_global_config_manager
+                get_global_config_manager().update_auto_summary_config(enabled=True)
+            elif no_auto_summary:
+                from .global_config import get_global_config_manager
+                get_global_config_manager().update_auto_summary_config(enabled=False)
+
             console.print("[yellow]正在重启 daemon...[/yellow]")
             if restart_daemon(port=port):
                 _print_daemon_status()

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -2665,6 +2665,11 @@ def daemon(
         else:
             console.print("[green]✓ Daemon 运行中但状态查询失败[/green]")
 
+    from .global_config import get_global_config_manager
+
+    # 记录待写入的 auto-summary 配置变更，daemon 成功后再写入
+    _pending_auto_summary: Optional[bool] = None
+
     try:
         if enable_auto_summary and no_auto_summary:
             console.print("[red]✗[/red] --enable-auto-summary 和 --no-auto-summary 不能同时使用")
@@ -2673,23 +2678,25 @@ def daemon(
         if action == "start":
             # auto-summary 启用检查
             if enable_auto_summary:
-                from .global_config import get_global_config_manager
-
-                get_global_config_manager().update_auto_summary_config(enabled=True)
-                console.print("[green]✓[/green] auto-summary 已启用")
+                _pending_auto_summary = True
             elif not no_auto_summary:
-                from .global_config import get_global_config_manager
-
                 auto_cfg = get_global_config_manager().get_auto_summary_config()
                 if not auto_cfg.enabled and os.isatty(0):
                     if typer.confirm("是否启用 auto-summary 自动总结功能？", default=False):
-                        get_global_config_manager().update_auto_summary_config(enabled=True)
-                        console.print("[green]✓[/green] auto-summary 已启用")
+                        _pending_auto_summary = True
 
             console.print("[yellow]正在启动 embedding daemon...[/yellow]")
             console.print(f"[dim]日志文件: {DAEMON_LOG_FILE}[/dim]")
             ok = start_daemon(port=port)
             if ok:
+                # daemon 成功后再写入配置
+                if _pending_auto_summary is not None:
+                    if get_global_config_manager().update_auto_summary_config(
+                        enabled=_pending_auto_summary
+                    ):
+                        console.print("[green]✓[/green] auto-summary 已启用")
+                    else:
+                        console.print("[red]✗ auto-summary 配置写入失败[/red]")
                 _print_daemon_status()
             else:
                 console.print("[red]✗ Daemon 启动失败[/red]")
@@ -2709,18 +2716,23 @@ def daemon(
 
         elif action == "restart":
             if enable_auto_summary:
-                from .global_config import get_global_config_manager
-
-                get_global_config_manager().update_auto_summary_config(enabled=True)
-                console.print("[green]✓[/green] auto-summary 已启用")
+                _pending_auto_summary = True
             elif no_auto_summary:
-                from .global_config import get_global_config_manager
-
-                get_global_config_manager().update_auto_summary_config(enabled=False)
-                console.print("[yellow]auto-summary 已禁用[/yellow]")
+                _pending_auto_summary = False
 
             console.print("[yellow]正在重启 daemon...[/yellow]")
             if restart_daemon(port=port):
+                # daemon 成功后再写入配置
+                if _pending_auto_summary is not None:
+                    if get_global_config_manager().update_auto_summary_config(
+                        enabled=_pending_auto_summary
+                    ):
+                        if _pending_auto_summary:
+                            console.print("[green]✓[/green] auto-summary 已启用")
+                        else:
+                            console.print("[yellow]auto-summary 已禁用[/yellow]")
+                    else:
+                        console.print("[red]✗ auto-summary 配置写入失败[/red]")
                 _print_daemon_status()
             else:
                 console.print("[red]✗ Daemon 重启失败[/red]")

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -2618,6 +2618,12 @@ def perf(
 def daemon(
     action: str = typer.Argument("status", help="操作: start, stop, restart, status"),
     port: int = typer.Option(18700, "--port", "-p", help="Daemon 监听端口"),
+    enable_auto_summary: bool = typer.Option(
+        False, "--enable-auto-summary", help="启动时直接启用 auto-summary（跳过询问）"
+    ),
+    no_auto_summary: bool = typer.Option(
+        False, "--no-auto-summary", help="启动时不启用 auto-summary（跳过询问）"
+    ),
 ):
     """
     管理嵌入模型守护进程
@@ -2659,6 +2665,12 @@ def daemon(
             console.print("[green]✓ Daemon 运行中但状态查询失败[/green]")
 
     try:
+        if enable_auto_summary and no_auto_summary:
+            console.print(
+                "[red]✗[/red] --enable-auto-summary 和 --no-auto-summary 不能同时使用"
+            )
+            raise typer.Exit(1)
+
         if action == "start":
             console.print("[yellow]正在启动 embedding daemon...[/yellow]")
             console.print(f"[dim]日志文件: {DAEMON_LOG_FILE}[/dim]")

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -2672,6 +2672,21 @@ def daemon(
             raise typer.Exit(1)
 
         if action == "start":
+            # auto-summary 启用检查
+            if enable_auto_summary:
+                from .global_config import get_global_config_manager
+
+                get_global_config_manager().update_auto_summary_config(enabled=True)
+                console.print("[green]✓[/green] auto-summary 已启用")
+            elif not no_auto_summary:
+                from .global_config import get_global_config_manager
+
+                auto_cfg = get_global_config_manager().get_auto_summary_config()
+                if not auto_cfg.enabled:
+                    if typer.confirm("是否启用 auto-summary 自动总结功能？", default=False):
+                        get_global_config_manager().update_auto_summary_config(enabled=True)
+                        console.print("[green]✓[/green] auto-summary 已启用")
+
             console.print("[yellow]正在启动 embedding daemon...[/yellow]")
             console.print(f"[dim]日志文件: {DAEMON_LOG_FILE}[/dim]")
             ok = start_daemon(port=port)

--- a/tests/unit/test_daemon_cli.py
+++ b/tests/unit/test_daemon_cli.py
@@ -104,3 +104,42 @@ class TestDaemonStartAutoSummaryFlags:
         result = runner.invoke(app, ["daemon", "start"], input="n\n")
         assert result.exit_code == 0
         mock_global_config.update_auto_summary_config.assert_not_called()
+
+
+class TestDaemonRestartAutoSummaryFlags:
+    """测试 daemon restart 的 auto-summary flag 处理"""
+
+    def test_restart_no_flags_keeps_config(
+        self, runner, mock_global_config, mock_restart_daemon, mock_daemon_status
+    ):
+        """restart 无 flag 时保持当前配置"""
+        result = runner.invoke(app, ["daemon", "restart"])
+        assert result.exit_code == 0
+        mock_global_config.update_auto_summary_config.assert_not_called()
+
+    def test_restart_enable_flag_sets_enabled(
+        self, runner, mock_global_config, mock_restart_daemon, mock_daemon_status
+    ):
+        """restart --enable-auto-summary 写入 enabled=True"""
+        result = runner.invoke(app, ["daemon", "restart", "--enable-auto-summary"])
+        assert result.exit_code == 0
+        mock_global_config.update_auto_summary_config.assert_called_once_with(enabled=True)
+
+    def test_restart_no_flag_sets_disabled(
+        self, runner, mock_global_config, mock_restart_daemon, mock_daemon_status
+    ):
+        """restart --no-auto-summary 写入 enabled=False"""
+        result = runner.invoke(app, ["daemon", "restart", "--no-auto-summary"])
+        assert result.exit_code == 0
+        mock_global_config.update_auto_summary_config.assert_called_once_with(enabled=False)
+
+    def test_restart_no_prompt(
+        self, runner, mock_global_config, mock_restart_daemon, mock_daemon_status
+    ):
+        """restart 不会触发交互式询问"""
+        cfg = mock_global_config.get_auto_summary_config.return_value
+        cfg.enabled = False
+        # 不提供 input — 如果有 prompt 会导致超时或 hang
+        result = runner.invoke(app, ["daemon", "restart"])
+        assert result.exit_code == 0
+        mock_global_config.update_auto_summary_config.assert_not_called()

--- a/tests/unit/test_daemon_cli.py
+++ b/tests/unit/test_daemon_cli.py
@@ -16,7 +16,7 @@ def runner():
 @pytest.fixture
 def mock_global_config():
     """Mock GlobalConfigManager，默认 auto_summary.enabled=False"""
-    with patch("jfox.cli.get_global_config_manager") as mock_get:
+    with patch("jfox.global_config.get_global_config_manager") as mock_get:
         mgr = MagicMock()
         cfg = MagicMock()
         cfg.enabled = False
@@ -62,3 +62,45 @@ class TestDaemonStartAutoSummaryFlags:
             app, ["daemon", "start", "--enable-auto-summary", "--no-auto-summary"]
         )
         assert result.exit_code != 0
+
+    def test_enable_flag_skips_prompt_and_enables(
+        self, runner, mock_global_config, mock_start_daemon, mock_daemon_status
+    ):
+        """--enable-auto-summary 跳过询问，直接写入 enabled=True"""
+        result = runner.invoke(app, ["daemon", "start", "--enable-auto-summary"])
+        assert result.exit_code == 0
+        mock_global_config.update_auto_summary_config.assert_called_once_with(enabled=True)
+
+    def test_no_flag_skips_prompt_and_does_not_enable(
+        self, runner, mock_global_config, mock_start_daemon, mock_daemon_status
+    ):
+        """--no-auto-summary 跳过询问，不写入配置"""
+        result = runner.invoke(app, ["daemon", "start", "--no-auto-summary"])
+        assert result.exit_code == 0
+        mock_global_config.update_auto_summary_config.assert_not_called()
+
+    def test_no_flags_enabled_true_skips_prompt(
+        self, runner, mock_global_config, mock_start_daemon, mock_daemon_status
+    ):
+        """无 flag 且 enabled=True 时不询问也不写入"""
+        cfg = mock_global_config.get_auto_summary_config.return_value
+        cfg.enabled = True
+        result = runner.invoke(app, ["daemon", "start"])
+        assert result.exit_code == 0
+        mock_global_config.update_auto_summary_config.assert_not_called()
+
+    def test_no_flags_enabled_false_user_says_yes(
+        self, runner, mock_global_config, mock_start_daemon, mock_daemon_status
+    ):
+        """无 flag 且 enabled=false，用户选 yes → 写入 enabled=True"""
+        result = runner.invoke(app, ["daemon", "start"], input="y\n")
+        assert result.exit_code == 0
+        mock_global_config.update_auto_summary_config.assert_called_once_with(enabled=True)
+
+    def test_no_flags_enabled_false_user_says_no(
+        self, runner, mock_global_config, mock_start_daemon, mock_daemon_status
+    ):
+        """无 flag 且 enabled=false，用户选 no → 不写入"""
+        result = runner.invoke(app, ["daemon", "start"], input="n\n")
+        assert result.exit_code == 0
+        mock_global_config.update_auto_summary_config.assert_not_called()

--- a/tests/unit/test_daemon_cli.py
+++ b/tests/unit/test_daemon_cli.py
@@ -63,18 +63,18 @@ class TestDaemonStartAutoSummaryFlags:
         )
         assert result.exit_code != 0
 
-    def test_enable_flag_skips_prompt_and_enables(
+    def test_enable_flag_enables_after_daemon_success(
         self, runner, mock_global_config, mock_start_daemon, mock_daemon_status
     ):
-        """--enable-auto-summary 跳过询问，直接写入 enabled=True"""
+        """--enable-auto-summary 在 daemon 启动成功后写入 enabled=True"""
         result = runner.invoke(app, ["daemon", "start", "--enable-auto-summary"])
         assert result.exit_code == 0
         mock_global_config.update_auto_summary_config.assert_called_once_with(enabled=True)
 
-    def test_no_flag_skips_prompt_and_does_not_enable(
+    def test_no_flag_does_not_enable(
         self, runner, mock_global_config, mock_start_daemon, mock_daemon_status
     ):
-        """--no-auto-summary 跳过询问，不写入配置"""
+        """--no-auto-summary 不写入配置"""
         result = runner.invoke(app, ["daemon", "start", "--no-auto-summary"])
         assert result.exit_code == 0
         mock_global_config.update_auto_summary_config.assert_not_called()
@@ -92,7 +92,7 @@ class TestDaemonStartAutoSummaryFlags:
     def test_no_flags_enabled_false_user_says_yes(
         self, runner, mock_global_config, mock_start_daemon, mock_daemon_status
     ):
-        """无 flag 且 enabled=false，用户选 yes → 写入 enabled=True"""
+        """无 flag 且 enabled=false，用户选 yes → daemon 成功后写入 enabled=True"""
         with patch("jfox.cli.os.isatty", return_value=True):
             result = runner.invoke(app, ["daemon", "start"], input="y\n")
         assert result.exit_code == 0
@@ -116,6 +116,22 @@ class TestDaemonStartAutoSummaryFlags:
         assert result.exit_code == 0
         mock_global_config.update_auto_summary_config.assert_not_called()
 
+    def test_enable_flag_rolls_back_on_daemon_failure(self, runner, mock_global_config):
+        """daemon 启动失败时不写入 auto-summary 配置"""
+        with patch("jfox.daemon.process.start_daemon", return_value=False):
+            result = runner.invoke(app, ["daemon", "start", "--enable-auto-summary"])
+        assert result.exit_code != 0
+        mock_global_config.update_auto_summary_config.assert_not_called()
+
+    def test_config_write_failure_shows_error(
+        self, runner, mock_global_config, mock_start_daemon, mock_daemon_status
+    ):
+        """update_auto_summary_config 返回 False 时显示错误"""
+        mock_global_config.update_auto_summary_config.return_value = False
+        result = runner.invoke(app, ["daemon", "start", "--enable-auto-summary"])
+        assert result.exit_code == 0
+        assert "配置写入失败" in result.output
+
 
 class TestDaemonRestartAutoSummaryFlags:
     """测试 daemon restart 的 auto-summary flag 处理"""
@@ -131,7 +147,7 @@ class TestDaemonRestartAutoSummaryFlags:
     def test_restart_enable_flag_sets_enabled(
         self, runner, mock_global_config, mock_restart_daemon, mock_daemon_status
     ):
-        """restart --enable-auto-summary 写入 enabled=True"""
+        """restart --enable-auto-summary 在 daemon 成功后写入 enabled=True"""
         result = runner.invoke(app, ["daemon", "restart", "--enable-auto-summary"])
         assert result.exit_code == 0
         mock_global_config.update_auto_summary_config.assert_called_once_with(enabled=True)
@@ -139,7 +155,7 @@ class TestDaemonRestartAutoSummaryFlags:
     def test_restart_no_flag_sets_disabled(
         self, runner, mock_global_config, mock_restart_daemon, mock_daemon_status
     ):
-        """restart --no-auto-summary 写入 enabled=False"""
+        """restart --no-auto-summary 在 daemon 成功后写入 enabled=False"""
         result = runner.invoke(app, ["daemon", "restart", "--no-auto-summary"])
         assert result.exit_code == 0
         mock_global_config.update_auto_summary_config.assert_called_once_with(enabled=False)
@@ -153,4 +169,11 @@ class TestDaemonRestartAutoSummaryFlags:
         # 不提供 input — 如果有 prompt 会导致超时或 hang
         result = runner.invoke(app, ["daemon", "restart"])
         assert result.exit_code == 0
+        mock_global_config.update_auto_summary_config.assert_not_called()
+
+    def test_restart_rolls_back_on_daemon_failure(self, runner, mock_global_config):
+        """restart daemon 失败时不写入 auto-summary 配置"""
+        with patch("jfox.daemon.process.restart_daemon", return_value=False):
+            result = runner.invoke(app, ["daemon", "restart", "--enable-auto-summary"])
+        assert result.exit_code != 0
         mock_global_config.update_auto_summary_config.assert_not_called()

--- a/tests/unit/test_daemon_cli.py
+++ b/tests/unit/test_daemon_cli.py
@@ -1,6 +1,5 @@
 """daemon start/restart --enable-auto-summary / --no-auto-summary 交互逻辑测试"""
 
-import sys
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/unit/test_daemon_cli.py
+++ b/tests/unit/test_daemon_cli.py
@@ -1,0 +1,64 @@
+"""daemon start/restart --enable-auto-summary / --no-auto-summary 交互逻辑测试"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from jfox.cli import app
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_global_config():
+    """Mock GlobalConfigManager，默认 auto_summary.enabled=False"""
+    with patch("jfox.cli.get_global_config_manager") as mock_get:
+        mgr = MagicMock()
+        cfg = MagicMock()
+        cfg.enabled = False
+        mgr.get_auto_summary_config.return_value = cfg
+        mgr.update_auto_summary_config.return_value = True
+        mock_get.return_value = mgr
+        yield mgr
+
+
+@pytest.fixture
+def mock_start_daemon():
+    with patch("jfox.daemon.process.start_daemon", return_value=True):
+        yield
+
+
+@pytest.fixture
+def mock_restart_daemon():
+    with patch("jfox.daemon.process.restart_daemon", return_value=True):
+        yield
+
+
+@pytest.fixture
+def mock_daemon_status():
+    with patch(
+        "jfox.daemon.process.get_daemon_status",
+        return_value={
+            "pid": 1234,
+            "port": 18700,
+            "model": "test",
+            "dimension": 384,
+            "device": "cpu",
+        },
+    ):
+        yield
+
+
+class TestDaemonStartAutoSummaryFlags:
+    """测试 --enable-auto-summary 和 --no-auto-summary 参数"""
+
+    def test_both_flags_mutually_exclusive(self, runner):
+        """同时传 --enable-auto-summary 和 --no-auto-summary 应报错"""
+        result = runner.invoke(
+            app, ["daemon", "start", "--enable-auto-summary", "--no-auto-summary"]
+        )
+        assert result.exit_code != 0

--- a/tests/unit/test_daemon_cli.py
+++ b/tests/unit/test_daemon_cli.py
@@ -1,5 +1,6 @@
 """daemon start/restart --enable-auto-summary / --no-auto-summary 交互逻辑测试"""
 
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -93,7 +94,8 @@ class TestDaemonStartAutoSummaryFlags:
         self, runner, mock_global_config, mock_start_daemon, mock_daemon_status
     ):
         """无 flag 且 enabled=false，用户选 yes → 写入 enabled=True"""
-        result = runner.invoke(app, ["daemon", "start"], input="y\n")
+        with patch("jfox.cli.os.isatty", return_value=True):
+            result = runner.invoke(app, ["daemon", "start"], input="y\n")
         assert result.exit_code == 0
         mock_global_config.update_auto_summary_config.assert_called_once_with(enabled=True)
 
@@ -101,7 +103,17 @@ class TestDaemonStartAutoSummaryFlags:
         self, runner, mock_global_config, mock_start_daemon, mock_daemon_status
     ):
         """无 flag 且 enabled=false，用户选 no → 不写入"""
-        result = runner.invoke(app, ["daemon", "start"], input="n\n")
+        with patch("jfox.cli.os.isatty", return_value=True):
+            result = runner.invoke(app, ["daemon", "start"], input="n\n")
+        assert result.exit_code == 0
+        mock_global_config.update_auto_summary_config.assert_not_called()
+
+    def test_no_flags_non_tty_skips_prompt(
+        self, runner, mock_global_config, mock_start_daemon, mock_daemon_status
+    ):
+        """非 TTY 环境下不询问，不写入配置"""
+        with patch("jfox.cli.os.isatty", return_value=False):
+            result = runner.invoke(app, ["daemon", "start"])
         assert result.exit_code == 0
         mock_global_config.update_auto_summary_config.assert_not_called()
 


### PR DESCRIPTION
## Summary

- `daemon start` 启动时检测 `auto_summary.enabled`，未启用时交互式询问用户是否开启
- 新增 `--enable-auto-summary` / `--no-auto-summary` 互斥 flag，跳过询问
- `daemon restart` 支持 flag 切换配置，但不触发交互询问
- 互斥校验：两个 flag 同时传时报错退出

## Test plan

- [x] 10 个新测试全部通过（6 start + 4 restart）
- [x] 29 个 daemon 相关测试无回归
- [x] CLI help 输出包含新 flag

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)