### PR TITLE
feat(auto-summary): progress visibility + remove 7-day scan limit

### DIFF
--- a/jfox/auto_summary/cli.py
+++ b/jfox/auto_summary/cli.py
@@ -25,6 +25,7 @@ from ..global_config import get_global_config_manager
 from . import ledger as ledger_module
 from .ledger import Ledger
 from .runner import run_once, scan_pending
+from .scanner import list_session_files
 
 
 def _fmt(table: Optional[Table] = None, json_data: Any = None, fmt: str = "table") -> None:
@@ -52,10 +53,42 @@ def _config():
 def status(
     output_format: str = typer.Option("table", "--format", "-f", help="输出格式: table, json"),
 ) -> None:
-    """显示 auto-summary 配置和 ledger 统计"""
+    """显示 auto-summary 配置、ledger 统计和处理进度"""
     cfg = _config()
     led = Ledger()
     stats = led.stats()
+
+    # 交叉对比：scanner vs ledger
+    scannable = list_session_files(
+        idle_threshold_minutes=cfg.idle_threshold_minutes,
+        max_session_size_mb=cfg.max_session_size_mb,
+        min_session_size_kb=cfg.min_session_size_kb,
+        skip_after_days=cfg.skip_after_days,
+    )
+    success = skipped = failed = 0
+    for sf in scannable:
+        entry = led.get(sf.session_id)
+        if entry is None:
+            continue
+        if entry.status == "success":
+            success += 1
+        elif entry.status == "skipped":
+            skipped += 1
+        else:
+            failed += 1
+    total = len(scannable)
+    pending = total - success - skipped - failed
+    done = success + skipped
+    pct = round(done / total * 100, 1) if total > 0 else 100.0
+
+    progress = {
+        "total_scannable": total,
+        "success": success,
+        "skipped": skipped,
+        "pending": pending,
+        "failed": failed,
+        "percentage": pct,
+    }
 
     if output_format == "json":
         _fmt(
@@ -63,10 +96,13 @@ def status(
                 "config": cfg.to_dict(),
                 "ledger_file": str(ledger_module.DEFAULT_LEDGER_PATH),
                 "ledger_stats": stats,
+                "progress": progress,
             },
             fmt="json",
         )
         return
+
+    # --- table output (keep existing two tables, add third) ---
 
     table = Table(title="auto-summary 配置", show_header=False)
     table.add_column("项", style="cyan", no_wrap=True)
@@ -90,6 +126,18 @@ def status(
     for k, v in stats.items():
         stat_table.add_row(k, str(v))
     console.print(stat_table)
+
+    # 进度表
+    prog_table = Table(title="auto-summary 进度", show_header=False)
+    prog_table.add_column("项", style="cyan", no_wrap=True)
+    prog_table.add_column("值", style="green", justify="right")
+    prog_table.add_row("可扫描 session 总数", str(total))
+    prog_table.add_row("已处理 (success)", str(success))
+    prog_table.add_row("已跳过 (skipped)", str(skipped))
+    prog_table.add_row("待处理 (pending)", str(pending))
+    prog_table.add_row("处理失败", str(failed))
+    prog_table.add_row("进度", f"{pct}%")
+    console.print(prog_table)
 
 
 @auto_summary_app.command("enable")

--- a/jfox/auto_summary/cli.py
+++ b/jfox/auto_summary/cli.py
@@ -102,7 +102,7 @@ def status(
         )
         return
 
-    # --- table output (keep existing two tables, add third) ---
+    # --- 表格输出（保留原有两张表，新增第三张进度表） ---
 
     table = Table(title="auto-summary 配置", show_header=False)
     table.add_column("项", style="cyan", no_wrap=True)

--- a/jfox/auto_summary/cli.py
+++ b/jfox/auto_summary/cli.py
@@ -65,7 +65,10 @@ def status(
         min_session_size_kb=cfg.min_session_size_kb,
         skip_after_days=cfg.skip_after_days,
     )
-    success = skipped = failed = 0
+    # 与 runner 调度逻辑对齐：
+    # runner 的 is_done() 对 success/skipped/failed_permanent 返回 True（不再处理）
+    # failed_transient 不在 _TERMINAL_STATUSES 中，会被 runner 重试
+    success = skipped = failed_transient = failed_permanent = 0
     for sf in scannable:
         entry = led.get(sf.session_id)
         if entry is None:
@@ -74,9 +77,13 @@ def status(
             success += 1
         elif entry.status == "skipped":
             skipped += 1
-        else:
-            failed += 1
+        elif entry.status == "failed_transient":
+            failed_transient += 1
+        else:  # failed_permanent 或其他 → 视为永久失败
+            failed_permanent += 1
     total = len(scannable)
+    # pending 包含：无 ledger 记录的 + failed_transient（runner 下轮会重试）
+    failed = failed_permanent
     pending = total - success - skipped - failed
     done = success + skipped
     pct = round(done / total * 100, 1) if total > 0 else 100.0
@@ -87,6 +94,7 @@ def status(
         "skipped": skipped,
         "pending": pending,
         "failed": failed,
+        "retryable": failed_transient,
         "percentage": pct,
     }
 
@@ -135,7 +143,9 @@ def status(
     prog_table.add_row("已处理 (success)", str(success))
     prog_table.add_row("已跳过 (skipped)", str(skipped))
     prog_table.add_row("待处理 (pending)", str(pending))
-    prog_table.add_row("处理失败", str(failed))
+    if failed_transient > 0:
+        prog_table.add_row("可重试 (retryable)", str(failed_transient))
+    prog_table.add_row("永久失败 (failed)", str(failed))
     prog_table.add_row("进度", f"{pct}%")
     console.print(prog_table)
 

--- a/jfox/auto_summary/scanner.py
+++ b/jfox/auto_summary/scanner.py
@@ -159,3 +159,27 @@ def is_running_inside_isolated_dir() -> bool:
         return True
     except ValueError:
         return False
+
+
+def list_session_files(
+    claude_projects_dir: Path | None = None,
+    idle_threshold_minutes: int = 30,
+    max_session_size_mb: int = 10,
+    min_session_size_kb: int = 5,
+    skip_after_days: int = 0,
+    project_blocklist: Sequence[str] = DEFAULT_PROJECT_BLOCKLIST_SUBSTRINGS,
+    now: float | None = None,
+) -> list[SessionFile]:
+    """返回所有可扫描的 session 文件列表（materialized）。
+
+    供 status 命令等需要完整列表的场景使用。
+    """
+    return list(iter_session_files(
+        claude_projects_dir=claude_projects_dir,
+        idle_threshold_minutes=idle_threshold_minutes,
+        max_session_size_mb=max_session_size_mb,
+        min_session_size_kb=min_session_size_kb,
+        skip_after_days=skip_after_days,
+        project_blocklist=project_blocklist,
+        now=now,
+    ))

--- a/jfox/auto_summary/scanner.py
+++ b/jfox/auto_summary/scanner.py
@@ -57,7 +57,7 @@ def iter_session_files(
     idle_threshold_minutes: int = 30,
     max_session_size_mb: int = 10,
     min_session_size_kb: int = 5,
-    skip_after_days: int = 7,
+    skip_after_days: int = 0,
     project_blocklist: Sequence[str] = DEFAULT_PROJECT_BLOCKLIST_SUBSTRINGS,
     now: float | None = None,
 ) -> Iterator[SessionFile]:

--- a/jfox/auto_summary/scanner.py
+++ b/jfox/auto_summary/scanner.py
@@ -174,12 +174,14 @@ def list_session_files(
 
     供 status 命令等需要完整列表的场景使用。
     """
-    return list(iter_session_files(
-        claude_projects_dir=claude_projects_dir,
-        idle_threshold_minutes=idle_threshold_minutes,
-        max_session_size_mb=max_session_size_mb,
-        min_session_size_kb=min_session_size_kb,
-        skip_after_days=skip_after_days,
-        project_blocklist=project_blocklist,
-        now=now,
-    ))
+    return list(
+        iter_session_files(
+            claude_projects_dir=claude_projects_dir,
+            idle_threshold_minutes=idle_threshold_minutes,
+            max_session_size_mb=max_session_size_mb,
+            min_session_size_kb=min_session_size_kb,
+            skip_after_days=skip_after_days,
+            project_blocklist=project_blocklist,
+            now=now,
+        )
+    )

--- a/jfox/global_config.py
+++ b/jfox/global_config.py
@@ -55,7 +55,7 @@ class AutoSummaryConfig:
     max_session_size_mb: int = 10  # 超过此大小的 session 跳过（避免 token 爆炸）
     min_session_size_kb: int = 5  # 太小的 session 跳过（无实质内容）
     max_per_tick: int = 5  # 每轮最多处理几个 session
-    skip_after_days: int = 7  # 超过此天数的旧 session 不再补做
+    skip_after_days: int = 0  # 0 表示不跳过任何 session；可自行设置上限
     claude_timeout_seconds: int = 120  # claude -p 调用超时
     claude_binary: Optional[str] = None  # claude 命令路径；None 表示从 PATH 解析
 
@@ -96,7 +96,7 @@ class AutoSummaryConfig:
             max_session_size_mb=int(data.get("max_session_size_mb", 10)),
             min_session_size_kb=int(data.get("min_session_size_kb", 5)),
             max_per_tick=int(data.get("max_per_tick", 5)),
-            skip_after_days=int(data.get("skip_after_days", 7)),
+            skip_after_days=int(data.get("skip_after_days", 0)),
             claude_timeout_seconds=int(data.get("claude_timeout_seconds", 120)),
             claude_binary=data.get("claude_binary"),
         )

--- a/tests/unit/test_auto_summary_defaults.py
+++ b/tests/unit/test_auto_summary_defaults.py
@@ -1,4 +1,5 @@
 """验证 auto-summary 默认配置：skip_after_days=0"""
+
 from jfox.global_config import AutoSummaryConfig
 
 

--- a/tests/unit/test_auto_summary_defaults.py
+++ b/tests/unit/test_auto_summary_defaults.py
@@ -1,0 +1,26 @@
+"""验证 auto-summary 默认配置：skip_after_days=0"""
+from jfox.global_config import AutoSummaryConfig
+
+
+def test_skip_after_days_default_is_zero():
+    """默认值应为 0（不跳过任何 session）"""
+    cfg = AutoSummaryConfig()
+    assert cfg.skip_after_days == 0
+
+
+def test_skip_after_days_from_dict_empty():
+    """from_dict 空输入也应得到 0"""
+    cfg = AutoSummaryConfig.from_dict({})
+    assert cfg.skip_after_days == 0
+
+
+def test_skip_after_days_from_dict_explicit():
+    """显式传入仍生效"""
+    cfg = AutoSummaryConfig.from_dict({"skip_after_days": 14})
+    assert cfg.skip_after_days == 14
+
+
+def test_skip_after_days_negative_clamped():
+    """负值被 clamp 为 0"""
+    cfg = AutoSummaryConfig(skip_after_days=-1)
+    assert cfg.skip_after_days == 0

--- a/tests/unit/test_auto_summary_status.py
+++ b/tests/unit/test_auto_summary_status.py
@@ -1,0 +1,161 @@
+"""验证 status 命令的进度显示和 JSON 输出"""
+import json
+import re
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from jfox.auto_summary import ledger as ledger_module
+from jfox.auto_summary.ledger import Ledger, LedgerEntry, SessionStatus
+from jfox.global_config import AutoSummaryConfig
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _make_config(**overrides):
+    defaults = {
+        "enabled": True,
+        "interval_minutes": 30,
+        "idle_threshold_minutes": 30,
+        "target_kb": None,
+        "max_per_tick": 5,
+        "max_session_size_mb": 10,
+        "min_session_size_kb": 5,
+        "skip_after_days": 0,
+        "claude_timeout_seconds": 120,
+        "claude_binary": None,
+    }
+    defaults.update(overrides)
+    return AutoSummaryConfig(**defaults)
+
+
+def _mock_session_file(session_id: str):
+    from jfox.auto_summary.scanner import SessionFile
+
+    return SessionFile(
+        session_id=session_id,
+        project_dir_name="test-project",
+        path=Path(f"/fake/{session_id}.jsonl"),
+        mtime=time.time() - 3600,
+        size_bytes=5000,
+    )
+
+
+def _make_mock_ledger(sessions: dict | None = None):
+    """构造不触发文件 I/O 的 Ledger 实例"""
+    led = Ledger.__new__(Ledger)
+    led._data = ledger_module._LedgerData(version=1, sessions=sessions or {})
+    return led
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+class TestProgressJsonOutput:
+    """验证 --format json 包含 progress 字段"""
+
+    @patch("jfox.auto_summary.cli.list_session_files")
+    @patch("jfox.auto_summary.cli._config")
+    def test_progress_field_present(self, mock_config, mock_list):
+        """JSON 输出应包含 progress 字段"""
+        mock_config.return_value = _make_config()
+        mock_list.return_value = [
+            _mock_session_file("s1"),
+            _mock_session_file("s2"),
+            _mock_session_file("s3"),
+        ]
+        led = _make_mock_ledger()
+        with (
+            patch("jfox.auto_summary.cli.Ledger", return_value=led),
+        ):
+            from typer.testing import CliRunner
+
+            from jfox.auto_summary.cli import auto_summary_app
+
+            runner = CliRunner()
+            result = runner.invoke(auto_summary_app, ["status", "--format", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(_strip_ansi(result.output))
+        assert "progress" in data
+        assert data["progress"]["total_scannable"] == 3
+        assert data["progress"]["pending"] == 3
+        assert data["progress"]["success"] == 0
+
+    @patch("jfox.auto_summary.cli.list_session_files")
+    @patch("jfox.auto_summary.cli._config")
+    def test_progress_counts_match_ledger(self, mock_config, mock_list):
+        """progress 中的 success/skipped/failed 应与 ledger 匹配"""
+        mock_config.return_value = _make_config()
+        mock_list.return_value = [
+            _mock_session_file("s1"),  # success
+            _mock_session_file("s2"),  # skipped
+            _mock_session_file("s3"),  # failed_transient
+            _mock_session_file("s4"),  # pending (not in ledger)
+        ]
+        sessions = {
+            "s1": LedgerEntry(
+                project="p",
+                processed_at="2026-01-01",
+                status=SessionStatus.SUCCESS.value,
+            ),
+            "s2": LedgerEntry(
+                project="p",
+                processed_at="2026-01-01",
+                status=SessionStatus.SKIPPED.value,
+            ),
+            "s3": LedgerEntry(
+                project="p",
+                processed_at="2026-01-01",
+                status=SessionStatus.FAILED_TRANSIENT.value,
+            ),
+        }
+        led = _make_mock_ledger(sessions)
+        with (
+            patch("jfox.auto_summary.cli.Ledger", return_value=led),
+        ):
+            from typer.testing import CliRunner
+
+            from jfox.auto_summary.cli import auto_summary_app
+
+            runner = CliRunner()
+            result = runner.invoke(auto_summary_app, ["status", "--format", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(_strip_ansi(result.output))
+        p = data["progress"]
+        assert p["total_scannable"] == 4
+        assert p["success"] == 1
+        assert p["skipped"] == 1
+        assert p["failed"] == 1
+        assert p["pending"] == 1
+        assert p["percentage"] == 50.0  # (success+skipped)/total = 2/4 = 50%
+
+
+class TestProgressTableOutput:
+    """验证 table 模式输出包含进度表"""
+
+    @patch("jfox.auto_summary.cli.list_session_files")
+    @patch("jfox.auto_summary.cli._config")
+    def test_table_contains_progress(self, mock_config, mock_list):
+        """table 输出应包含进度百分比"""
+        mock_config.return_value = _make_config()
+        mock_list.return_value = [_mock_session_file("s1")]
+
+        led = _make_mock_ledger()
+        with (
+            patch("jfox.auto_summary.cli.Ledger", return_value=led),
+        ):
+            from typer.testing import CliRunner
+
+            from jfox.auto_summary.cli import auto_summary_app
+
+            runner = CliRunner()
+            result = runner.invoke(auto_summary_app, ["status"])
+
+        assert result.exit_code == 0
+        assert "进度" in result.output
+        assert "待处理" in result.output or "pending" in result.output.lower()

--- a/tests/unit/test_auto_summary_status.py
+++ b/tests/unit/test_auto_summary_status.py
@@ -1,4 +1,5 @@
 """验证 status 命令的进度显示和 JSON 输出"""
+
 import json
 import re
 import time
@@ -66,9 +67,7 @@ class TestProgressJsonOutput:
             _mock_session_file("s3"),
         ]
         led = _make_mock_ledger()
-        with (
-            patch("jfox.auto_summary.cli.Ledger", return_value=led),
-        ):
+        with (patch("jfox.auto_summary.cli.Ledger", return_value=led),):
             from typer.testing import CliRunner
 
             from jfox.auto_summary.cli import auto_summary_app
@@ -112,9 +111,7 @@ class TestProgressJsonOutput:
             ),
         }
         led = _make_mock_ledger(sessions)
-        with (
-            patch("jfox.auto_summary.cli.Ledger", return_value=led),
-        ):
+        with (patch("jfox.auto_summary.cli.Ledger", return_value=led),):
             from typer.testing import CliRunner
 
             from jfox.auto_summary.cli import auto_summary_app
@@ -144,9 +141,7 @@ class TestProgressTableOutput:
         mock_list.return_value = [_mock_session_file("s1")]
 
         led = _make_mock_ledger()
-        with (
-            patch("jfox.auto_summary.cli.Ledger", return_value=led),
-        ):
+        with (patch("jfox.auto_summary.cli.Ledger", return_value=led),):
             from typer.testing import CliRunner
 
             from jfox.auto_summary.cli import auto_summary_app

--- a/tests/unit/test_auto_summary_status.py
+++ b/tests/unit/test_auto_summary_status.py
@@ -5,8 +5,6 @@ import time
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 from jfox.auto_summary import ledger as ledger_module
 from jfox.auto_summary.ledger import Ledger, LedgerEntry, SessionStatus
 from jfox.global_config import AutoSummaryConfig

--- a/tests/unit/test_auto_summary_status.py
+++ b/tests/unit/test_auto_summary_status.py
@@ -81,16 +81,64 @@ class TestProgressJsonOutput:
         assert data["progress"]["total_scannable"] == 3
         assert data["progress"]["pending"] == 3
         assert data["progress"]["success"] == 0
+        assert "retryable" in data["progress"]  # 新增字段
+
+    @patch("jfox.auto_summary.cli.list_session_files")
+    @patch("jfox.auto_summary.cli._config")
+    def test_failed_permanent_counted_as_failed(self, mock_config, mock_list):
+        """failed_permanent 应计入 failed，不计入 pending"""
+        mock_config.return_value = _make_config()
+        mock_list.return_value = [
+            _mock_session_file("s1"),  # success
+            _mock_session_file("s2"),  # failed_permanent → 永久失败
+            _mock_session_file("s3"),  # failed_transient → 可重试
+            _mock_session_file("s4"),  # pending (not in ledger)
+        ]
+        sessions = {
+            "s1": LedgerEntry(
+                project="p",
+                processed_at="2026-01-01",
+                status=SessionStatus.SUCCESS.value,
+            ),
+            "s2": LedgerEntry(
+                project="p",
+                processed_at="2026-01-01",
+                status=SessionStatus.FAILED_PERMANENT.value,
+            ),
+            "s3": LedgerEntry(
+                project="p",
+                processed_at="2026-01-01",
+                status=SessionStatus.FAILED_TRANSIENT.value,
+            ),
+        }
+        led = _make_mock_ledger(sessions)
+        with (patch("jfox.auto_summary.cli.Ledger", return_value=led),):
+            from typer.testing import CliRunner
+
+            from jfox.auto_summary.cli import auto_summary_app
+
+            runner = CliRunner()
+            result = runner.invoke(auto_summary_app, ["status", "--format", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(_strip_ansi(result.output))
+        p = data["progress"]
+        assert p["total_scannable"] == 4
+        assert p["success"] == 1
+        assert p["failed"] == 1  # s2: failed_permanent
+        assert p["retryable"] == 1  # s3: failed_transient
+        assert p["pending"] == 2  # s3 (retryable) + s4 (无记录)
+        assert p["percentage"] == 25.0  # success/total = 1/4 = 25%
 
     @patch("jfox.auto_summary.cli.list_session_files")
     @patch("jfox.auto_summary.cli._config")
     def test_progress_counts_match_ledger(self, mock_config, mock_list):
-        """progress 中的 success/skipped/failed 应与 ledger 匹配"""
+        """progress 中的 success/skipped/failed 应与 ledger 匹配，failed_transient 归入 pending"""
         mock_config.return_value = _make_config()
         mock_list.return_value = [
             _mock_session_file("s1"),  # success
             _mock_session_file("s2"),  # skipped
-            _mock_session_file("s3"),  # failed_transient
+            _mock_session_file("s3"),  # failed_transient → runner 会重试，归入 pending
             _mock_session_file("s4"),  # pending (not in ledger)
         ]
         sessions = {
@@ -125,8 +173,10 @@ class TestProgressJsonOutput:
         assert p["total_scannable"] == 4
         assert p["success"] == 1
         assert p["skipped"] == 1
-        assert p["failed"] == 1
-        assert p["pending"] == 1
+        # failed_transient 归入 pending（runner 会重试），failed 仅计永久失败
+        assert p["failed"] == 0
+        assert p["pending"] == 2  # s3 (retryable) + s4 (无记录)
+        assert p["retryable"] == 1  # s3
         assert p["percentage"] == 50.0  # (success+skipped)/total = 2/4 = 50%
 
 

--- a/tests/unit/test_scanner_list.py
+++ b/tests/unit/test_scanner_list.py
@@ -3,7 +3,7 @@ import os
 import time
 from pathlib import Path
 
-from jfox.auto_summary.scanner import SessionFile, list_session_files
+from jfox.auto_summary.scanner import list_session_files
 
 
 def _make_session(tmp_path: Path, name: str, size: int = 5000, age_minutes: int = 60) -> Path:

--- a/tests/unit/test_scanner_list.py
+++ b/tests/unit/test_scanner_list.py
@@ -1,0 +1,57 @@
+"""验证 list_session_files 返回完整列表"""
+import os
+import time
+from pathlib import Path
+
+from jfox.auto_summary.scanner import SessionFile, list_session_files
+
+
+def _make_session(tmp_path: Path, name: str, size: int = 5000, age_minutes: int = 60) -> Path:
+    """在 tmp_path 下创建一个 .jsonl 文件，size 字节，mtime 为 age_minutes 前"""
+    p = tmp_path / name
+    p.write_bytes(b"x" * size)
+    mtime = time.time() - age_minutes * 60
+    os.utime(p, (mtime, mtime))
+    return p
+
+
+def test_list_returns_list_type(tmp_path):
+    """返回类型应为 list"""
+    _make_session(tmp_path, "abc.jsonl")
+    result = list_session_files(
+        claude_projects_dir=tmp_path,
+        idle_threshold_minutes=1,
+        min_session_size_kb=1,
+        skip_after_days=0,
+        now=time.time(),
+    )
+    assert isinstance(result, list)
+
+
+def test_list_matches_iter(tmp_path):
+    """list_session_files 应与 list(iter_session_files(...)) 结果一致"""
+    _make_session(tmp_path, "s1.jsonl", size=3000, age_minutes=120)
+    _make_session(tmp_path, "s2.jsonl", size=2000, age_minutes=30)
+    kwargs = dict(
+        claude_projects_dir=tmp_path,
+        idle_threshold_minutes=1,
+        min_session_size_kb=1,
+        skip_after_days=0,
+        now=time.time(),
+    )
+    from jfox.auto_summary.scanner import iter_session_files
+    from_iter = list(iter_session_files(**kwargs))
+    from_list = list_session_files(**kwargs)
+    assert len(from_iter) == len(from_list)
+    assert {s.session_id for s in from_iter} == {s.session_id for s in from_list}
+
+
+def test_list_empty_dir(tmp_path):
+    """空目录返回空列表"""
+    result = list_session_files(
+        claude_projects_dir=tmp_path,
+        idle_threshold_minutes=1,
+        skip_after_days=0,
+        now=time.time(),
+    )
+    assert result == []

--- a/tests/unit/test_scanner_list.py
+++ b/tests/unit/test_scanner_list.py
@@ -1,4 +1,5 @@
 """验证 list_session_files 返回完整列表"""
+
 import os
 import time
 from pathlib import Path
@@ -40,6 +41,7 @@ def test_list_matches_iter(tmp_path):
         now=time.time(),
     )
     from jfox.auto_summary.scanner import iter_session_files
+
     from_iter = list(iter_session_files(**kwargs))
     from_list = list_session_files(**kwargs)
     assert len(from_iter) == len(from_list)


### PR DESCRIPTION
## Changes

Closes #229

### 1. 移除 7 天硬限制
- `skip_after_days` 默认值从 `7` 改为 `0`（不跳过任何 session）
- 保留配置项，用户可自行设置上限

### 2. scanner 新增 `list_session_files()`
- 返回 `list[SessionFile]` 而非 generator，供 status 命令使用

### 3. status 命令增强
- 新增进度表：可扫描总数 / 已处理 / 已跳过 / 待处理 / 失败 / 进度百分比
- `--format json` 输出包含 `progress` 字段
- 进度 = (success + skipped) / total（skipped 算已完成，failed 算未完成）

## Files Changed
- `jfox/global_config.py` — 2 处默认值 `7` → `0`
- `jfox/auto_summary/scanner.py` — 默认参数 + 新增 `list_session_files()`
- `jfox/auto_summary/cli.py` — status 命令增加进度表 + JSON 输出
- 3 个新测试文件（10 个测试，101 个相关测试全部通过）

## Test Results
```
101 passed, 341 deselected in 34.86s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)