### PR TITLE
fix: Issue #224 CR leftovers — atomic write + CAS + interruptible Popen + threading.Event

### DIFF
--- a/docs/superpowers/plans/2026-06-02-todo-note-type.md
+++ b/docs/superpowers/plans/2026-06-02-todo-note-type.md
@@ -1,0 +1,1645 @@
+# Todo 便签笔记类型 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新增 `todo` 笔记类型，提供 `jfox todo` 命令族，支持 open/done 状态管理和批量 review。
+
+**Architecture:** 最小侵入式扩展现有 NoteType 枚举和 Note 模型，新增 `status` 可选字段（遵循 `source`/`topic` 的 type-specific 字段模式）。CLI 使用 Typer sub-app 模式，Agent 优先（默认非交互， `--interactive` 可选）。todo 笔记自动融入 search、graph、backlinks 等现有功能。
+
+**Tech Stack:** Python 3.10+, Typer, Rich, pytest, unittest.mock
+
+---
+
+## File Structure
+
+| 文件 | 职责 | 操作 |
+|------|------|------|
+| `jfox/models.py` | NoteType 枚举、Note 数据模型、序列化/反序列化 | Modify |
+| `jfox/config.py` | KB 目录初始化 | Modify |
+| `jfox/note.py` | 笔记 CRUD、统计 | Modify |
+| `jfox/cli.py` | CLI 入口、type 校验文案 | Modify |
+| `jfox/todo_cli.py` | `jfox todo` 子命令族（新增文件） | Create |
+| `tests/unit/test_todo_crud.py` | models + note CRUD 测试 | Create |
+| `tests/unit/test_todo_cli.py` | todo CLI 命令测试 | Create |
+| `tests/unit/test_todo_review.py` | review 命令测试 | Create |
+| `tests/unit/test_todo_integration.py` | search/graph 集成测试 | Create |
+
+---
+
+### Task 1: 扩展 NoteType 枚举和 Note 模型
+
+**Files:**
+- Modify: `jfox/models.py`
+- Test: `tests/unit/test_todo_crud.py`
+
+- [ ] **Step 1: 写 failing test — todo enum 和 status 字段**
+
+```python
+"""
+测试类型: 单元测试
+目标模块: jfox.models (todo note type)
+预估耗时: < 1秒
+依赖要求: 无外部依赖
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+from datetime import datetime
+
+from jfox.models import Note, NoteType
+
+
+class TestTodoNoteType:
+    """Test todo note type support"""
+
+    def test_todo_enum_value(self):
+        assert NoteType.TODO.value == "todo"
+
+    def test_todo_note_creation_with_status(self):
+        n = Note(
+            id="202605221430001234",
+            title="跟进客户反馈",
+            content="客户提出了三个问题",
+            type=NoteType.TODO,
+            status="open",
+            created=datetime(2026, 5, 22, 14, 30, 0),
+            updated=datetime(2026, 5, 22, 14, 30, 0),
+            tags=["工作"],
+        )
+        assert n.status == "open"
+        assert n.type == NoteType.TODO
+
+    def test_todo_note_defaults_to_none_status(self):
+        n = Note(
+            id="202605221430001234",
+            title="Test",
+            content="content",
+            type=NoteType.PERMANENT,
+            created=datetime(2026, 5, 22, 14, 30, 0),
+            updated=datetime(2026, 5, 22, 14, 30, 0),
+        )
+        assert n.status is None
+
+    def test_todo_filename_uses_slug(self):
+        n = Note(
+            id="202605221430001234",
+            title="跟进客户反馈",
+            content="content",
+            type=NoteType.TODO,
+            created=datetime(2026, 5, 22, 14, 30, 0),
+            updated=datetime(2026, 5, 22, 14, 30, 0),
+        )
+        assert n.filename == "202605221430001234-跟进客户反馈.md"
+
+    def test_todo_status_persisted_to_frontmatter(self):
+        n = Note(
+            id="202605221430001234",
+            title="跟进客户反馈",
+            content="content",
+            type=NoteType.TODO,
+            status="open",
+            created=datetime(2026, 5, 22, 14, 30, 0),
+            updated=datetime(2026, 5, 22, 14, 30, 0),
+        )
+        md = n.to_markdown()
+        assert 'status: "open"' in md
+        assert "type: todo" in md
+
+    def test_todo_status_absent_when_none(self):
+        n = Note(
+            id="202605221430001234",
+            title="跟进客户反馈",
+            content="content",
+            type=NoteType.TODO,
+            status=None,
+            created=datetime(2026, 5, 22, 14, 30, 0),
+            updated=datetime(2026, 5, 22, 14, 30, 0),
+        )
+        md = n.to_markdown()
+        assert "status:" not in md
+
+    def test_todo_roundtrip_from_markdown(self):
+        n = Note(
+            id="202605221430001234",
+            title="跟进客户反馈",
+            content="客户提出了三个问题",
+            type=NoteType.TODO,
+            status="done",
+            tags=["工作", "客户"],
+            created=datetime(2026, 5, 22, 14, 30, 0),
+            updated=datetime(2026, 5, 22, 14, 30, 0),
+        )
+        md = n.to_markdown()
+        loaded = Note.from_markdown(md, n.filepath)
+        assert loaded.status == "done"
+        assert loaded.type == NoteType.TODO
+        assert loaded.title == "跟进客户反馈"
+
+    def test_todo_to_dict_includes_status(self):
+        n = Note(
+            id="202605221430001234",
+            title="跟进客户反馈",
+            content="content",
+            type=NoteType.TODO,
+            status="open",
+            created=datetime(2026, 5, 22, 14, 30, 0),
+            updated=datetime(2026, 5, 22, 14, 30, 0),
+        )
+        d = n.to_dict()
+        assert d["status"] == "open"
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `uv run pytest tests/unit/test_todo_crud.py -v`
+Expected: FAIL (NoteType.TODO 不存在，Note 无 status 字段)
+
+- [ ] **Step 3: 实现 NoteType 和 Note 模型扩展**
+
+修改 `jfox/models.py`：
+
+1. 在 `NoteType` 枚举中新增 `TODO = "todo"`（line 19 后）
+
+```python
+class NoteType(Enum):
+    """笔记类型"""
+
+    FLEETING = "fleeting"
+    LITERATURE = "literature"
+    PERMANENT = "permanent"
+    SESSION = "session"
+    TODO = "todo"  # 新增: 便签待办
+```
+
+2. 在 `Note` dataclass 中新增 `status` 字段（line 36 后，backlinks 之前）
+
+```python
+    source: Optional[str] = None  # 来源（文献笔记）
+    topic: Optional[str] = None  # 会话主题（session 类型）
+    status: Optional[str] = None  # 状态（todo 类型: open | done）
+```
+
+3. 修改 `to_markdown()`（line 86-89 后），在 `topic` 处理之后添加：
+
+```python
+        if self.status:
+            frontmatter["status"] = self.status
+```
+
+4. 修改 `from_markdown()`（line 137-138 后），在 `topic` 参数之后添加：
+
+```python
+            source=fm.get("source"),
+            topic=fm.get("topic"),
+            status=fm.get("status"),
+        )
+```
+
+5. 修改 `to_dict()`（line 155 后），在 `topic` 之后添加：
+
+```python
+            "topic": self.topic,
+            "status": self.status,
+        }
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `uv run pytest tests/unit/test_todo_crud.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add jfox/models.py tests/unit/test_todo_crud.py
+git commit -m "feat(models): add TODO note type with status field
+
+- Add NoteType.TODO enum value
+- Add Note.status field for open/done state
+- Serialize status to frontmatter for todo notes
+- Deserialize status from frontmatter on load
+
+Refs #230"
+```
+
+---
+
+### Task 2: 更新配置层（config.py + note.py）
+
+**Files:**
+- Modify: `jfox/config.py`
+- Modify: `jfox/note.py`
+- Test: `tests/unit/test_todo_crud.py`（追加测试）
+
+- [ ] **Step 1: 写 failing test — todo 目录创建和 CRUD**
+
+在 `tests/unit/test_todo_crud.py` 中追加：
+
+```python
+from unittest.mock import patch
+
+from jfox.config import ZKConfig
+from jfox.note import create_note, load_note_by_id, save_note, get_stats
+
+
+class TestTodoCrud:
+    """Test todo note CRUD operations"""
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_create_todo_note_defaults(self, mock_global_config, mock_note_config, tmp_path):
+        """创建 todo 笔记时 status 默认为 open"""
+        cfg = ZKConfig(base_dir=tmp_path)
+        cfg.ensure_dirs()
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        n = create_note("跟进客户反馈", note_type=NoteType.TODO, tags=["工作"])
+        assert n.type == NoteType.TODO
+        assert n.status == "open"  # 默认值
+        assert n.title == "跟进客户反馈"
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_todo_directory_created(self, mock_global_config, mock_note_config, tmp_path):
+        """KB 初始化时创建 todo 目录"""
+        cfg = ZKConfig(base_dir=tmp_path)
+        cfg.ensure_dirs()
+        assert (tmp_path / "notes" / "todo").exists()
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_save_and_load_todo_note(self, mock_global_config, mock_note_config, tmp_path):
+        """保存并加载 todo 笔记"""
+        cfg = ZKConfig(base_dir=tmp_path)
+        cfg.ensure_dirs()
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        n = create_note("跟进客户反馈", note_type=NoteType.TODO, tags=["工作"])
+        save_note(n, add_to_index=False)
+
+        loaded = load_note_by_id(n.id, cfg=cfg)
+        assert loaded is not None
+        assert loaded.type == NoteType.TODO
+        assert loaded.status == "open"
+        assert loaded.title == "跟进客户反馈"
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_get_stats_includes_todo(self, mock_global_config, mock_note_config, tmp_path):
+        """统计包含 todo 类型"""
+        cfg = ZKConfig(base_dir=tmp_path)
+        cfg.ensure_dirs()
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        n = create_note("跟进客户反馈", note_type=NoteType.TODO)
+        save_note(n, add_to_index=False)
+
+        stats = get_stats(cfg=cfg)
+        assert "todo" in stats["by_type"]
+        assert stats["by_type"]["todo"] == 1
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `uv run pytest tests/unit/test_todo_crud.py::TestTodoCrud -v`
+Expected: FAIL (config.ensure_dirs 不创建 todo 目录，create_note 不设置 status)
+
+- [ ] **Step 3: 实现配置层改动**
+
+修改 `jfox/config.py` line 63，在 `session` 目录后添加 `todo`：
+
+```python
+        dirs = [
+            self.notes_dir / "fleeting",
+            self.notes_dir / "literature",
+            self.notes_dir / "permanent",
+            self.notes_dir / "session",
+            self.notes_dir / "todo",  # 新增
+            self.zk_dir,
+            self.chroma_dir,
+            self.zk_dir / "cache",
+        ]
+```
+
+修改 `jfox/note.py` line 32-63，在 `create_note()` 中设置 todo 默认 status：
+
+```python
+def create_note(
+    content: str,
+    title: Optional[str] = None,
+    note_type: NoteType = NoteType.FLEETING,
+    tags: Optional[List[str]] = None,
+    links: Optional[List[str]] = None,
+    source: Optional[str] = None,
+    topic: Optional[str] = None,
+    status: Optional[str] = None,
+) -> Note:
+    """创建新笔记"""
+    note_id = generate_id()
+    now = datetime.now()
+
+    # 如果没有标题，从内容提取
+    if title is None:
+        title = content[:50] + "..." if len(content) > 50 else content
+
+    # todo 类型默认 status 为 open
+    if note_type == NoteType.TODO and status is None:
+        status = "open"
+
+    note = Note(
+        id=note_id,
+        title=title,
+        content=content,
+        type=note_type,
+        created=now,
+        updated=now,
+        tags=tags or [],
+        links=links or [],
+        backlinks=[],
+        source=source,
+        topic=topic,
+        status=status,
+    )
+
+    return note
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `uv run pytest tests/unit/test_todo_crud.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add jfox/config.py jfox/note.py tests/unit/test_todo_crud.py
+git commit -m "feat(config,note): support todo note type in storage layer
+
+- ZKConfig.ensure_dirs() creates notes/todo/ directory
+- create_note() defaults status='open' for todo type
+- get_stats() auto-counts todo via NoteType iteration
+
+Refs #230"
+```
+
+---
+
+### Task 3: 更新 CLI type 校验文案
+
+**Files:**
+- Modify: `jfox/cli.py`
+
+- [ ] **Step 1: 修改 _add_note_impl 的校验文案**
+
+`jfox/cli.py` line 342：
+
+```python
+        raise ValueError(
+            f"Invalid note type: {note_type}. Use: fleeting, literature, permanent, session, todo"
+        )
+```
+
+- [ ] **Step 2: 修改 _list_impl 的校验文案**
+
+`jfox/cli.py` line 802：
+
+```python
+            raise ValueError(
+                f"Invalid note type: {note_type}. Use: fleeting, literature, permanent, session, todo"
+            )
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add jfox/cli.py
+git commit -m "chore(cli): update type validation messages to include todo
+
+Refs #230"
+```
+
+---
+
+### Task 4: 创建 todo_cli.py — add / list 命令
+
+**Files:**
+- Create: `jfox/todo_cli.py`
+- Modify: `jfox/cli.py`（注册 sub-app）
+- Test: `tests/unit/test_todo_cli.py`
+
+- [ ] **Step 1: 写 failing test — todo add / list CLI**
+
+```python
+"""
+测试类型: 单元测试
+目标模块: jfox.todo_cli
+预估耗时: < 1秒
+依赖要求: 无外部依赖，使用 mock
+"""
+
+import json
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from jfox.models import Note, NoteType
+
+PATCH_USE_KB = "jfox.todo_cli.use_kb"
+PATCH_NOTE_MODULE = "jfox.todo_cli.note"
+
+
+class TestTodoAdd:
+    """测试 todo add 命令"""
+
+    @patch(PATCH_USE_KB)
+    @patch(PATCH_NOTE_MODULE)
+    def test_add_todo_basic(self, mock_note, mock_use_kb):
+        """快速添加 todo"""
+        from jfox.todo_cli import _todo_add_impl
+
+        mock_note.create_note.return_value = Note(
+            id="202605221430001234",
+            title="跟进客户反馈",
+            content="",
+            type=NoteType.TODO,
+            status="open",
+            created=datetime.now(),
+            updated=datetime.now(),
+        )
+        mock_note.save_note.return_value = True
+
+        result = _todo_add_impl(title="跟进客户反馈", content="", tags=None, links=None)
+
+        mock_note.create_note.assert_called_once()
+        call_kwargs = mock_note.create_note.call_args.kwargs
+        assert call_kwargs["note_type"] == NoteType.TODO
+        assert call_kwargs["title"] == "跟进客户反馈"
+        mock_note.save_note.assert_called_once()
+        assert result["success"] is True
+
+    @patch(PATCH_USE_KB)
+    @patch(PATCH_NOTE_MODULE)
+    def test_add_todo_with_content(self, mock_note, mock_use_kb):
+        """添加带内容的 todo"""
+        from jfox.todo_cli import _todo_add_impl
+
+        mock_note.create_note.return_value = Note(
+            id="202605221430001234",
+            title="跟进客户反馈",
+            content="客户提出了三个问题",
+            type=NoteType.TODO,
+            status="open",
+            created=datetime.now(),
+            updated=datetime.now(),
+        )
+        mock_note.save_note.return_value = True
+
+        result = _todo_add_impl(
+            title="跟进客户反馈", content="客户提出了三个问题", tags=["工作"], links=None
+        )
+
+        call_kwargs = mock_note.create_note.call_args.kwargs
+        assert call_kwargs["content"] == "客户提出了三个问题"
+        assert call_kwargs["tags"] == ["工作"]
+
+
+class TestTodoList:
+    """测试 todo list 命令"""
+
+    @patch(PATCH_USE_KB)
+    @patch(PATCH_NOTE_MODULE)
+    def test_list_defaults_to_open_only(self, mock_note, mock_use_kb):
+        """默认只列出 open 状态的 todo"""
+        from jfox.todo_cli import _todo_list_impl
+
+        open_todo = Note(
+            id="202605221430001234",
+            title="Open task",
+            content="",
+            type=NoteType.TODO,
+            status="open",
+            created=datetime.now(),
+            updated=datetime.now(),
+        )
+        done_todo = Note(
+            id="202605221430005678",
+            title="Done task",
+            content="",
+            type=NoteType.TODO,
+            status="done",
+            created=datetime.now(),
+            updated=datetime.now(),
+        )
+        mock_note.list_notes.return_value = [open_todo]
+
+        result = _todo_list_impl(show_all=False, tags=None, output_format="json")
+
+        # 验证 list_notes 被调用时传入了 status 过滤
+        call_kwargs = mock_note.list_notes.call_args.kwargs
+        assert call_kwargs["note_type"] == NoteType.TODO
+        assert result["total"] == 1
+        assert result["notes"][0]["title"] == "Open task"
+
+    @patch(PATCH_USE_KB)
+    @patch(PATCH_NOTE_MODULE)
+    def test_list_all_shows_done(self, mock_note, mock_use_kb):
+        """--all 列出所有 todo"""
+        from jfox.todo_cli import _todo_list_impl
+
+        open_todo = Note(
+            id="202605221430001234",
+            title="Open task",
+            content="",
+            type=NoteType.TODO,
+            status="open",
+            created=datetime.now(),
+            updated=datetime.now(),
+        )
+        done_todo = Note(
+            id="202605221430005678",
+            title="Done task",
+            content="",
+            type=NoteType.TODO,
+            status="done",
+            created=datetime.now(),
+            updated=datetime.now(),
+        )
+        mock_note.list_notes.return_value = [open_todo, done_todo]
+
+        result = _todo_list_impl(show_all=True, tags=None, output_format="json")
+
+        assert result["total"] == 2
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `uv run pytest tests/unit/test_todo_cli.py -v`
+Expected: FAIL (todo_cli.py 不存在)
+
+- [ ] **Step 3: 创建 todo_cli.py**
+
+创建 `jfox/todo_cli.py`：
+
+```python
+"""Todo 便签笔记 CLI 子命令"""
+
+import logging
+from datetime import datetime
+from typing import List, Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from . import note
+from .config import config, use_kb
+from .models import Note, NoteType
+from .cli import find_note_id_by_title_or_id, output_json
+
+logger = logging.getLogger(__name__)
+console = Console(legacy_windows=False)
+
+# 创建 todo 子应用
+todo_app = typer.Typer(name="todo", help="待办便签管理")
+
+
+def _todo_add_impl(
+    title: str,
+    content: str,
+    tags: Optional[List[str]],
+    links: Optional[List[str]],
+) -> dict:
+    """添加 todo 的内部实现"""
+    # 解析链接
+    resolved_links = []
+    unresolved = []
+    if links:
+        for link_text in links:
+            target_id = find_note_id_by_title_or_id(link_text)
+            if target_id:
+                resolved_links.append(target_id)
+            else:
+                unresolved.append(link_text)
+
+    # 创建 todo 笔记
+    new_note = note.create_note(
+        content=content,
+        title=title,
+        note_type=NoteType.TODO,
+        tags=tags or [],
+        links=resolved_links,
+    )
+
+    # 保存
+    if note.save_note(new_note):
+        # 更新反向链接
+        for target_id in resolved_links:
+            target_note = note.load_note_by_id(target_id)
+            if target_note and new_note.id not in target_note.backlinks:
+                target_note.backlinks.append(new_note.id)
+                note.save_note(target_note, add_to_index=False)
+
+        result = {
+            "success": True,
+            "note": {
+                "id": new_note.id,
+                "title": new_note.title,
+                "type": "todo",
+                "status": new_note.status,
+                "filepath": str(new_note.filepath),
+            },
+        }
+        if unresolved:
+            result["warnings"] = f"Unresolved links: {', '.join(unresolved)}"
+        return result
+    else:
+        return {"success": False, "error": "Failed to save note"}
+
+
+def _todo_list_impl(
+    show_all: bool,
+    tags: Optional[List[str]],
+    output_format: str,
+) -> dict:
+    """列出 todo 的内部实现"""
+    from .formatters import OutputFormatter
+
+    # 获取所有 todo 笔记
+    todos = note.list_notes(note_type=NoteType.TODO, tags=tags)
+
+    # 默认只显示 open 状态
+    if not show_all:
+        todos = [t for t in todos if t.status == "open"]
+
+    data = []
+    for t in todos:
+        d = t.to_dict()
+        d["status"] = t.status  # 确保 status 在输出中
+        data.append(d)
+
+    result = {
+        "total": len(todos),
+        "notes": data,
+    }
+
+    if output_format == "json":
+        print(OutputFormatter.to_json(result))
+    elif output_format == "table":
+        table = Table(title=f"Todos ({len(todos)} total)")
+        table.add_column("ID", style="dim")
+        table.add_column("Title", style="cyan")
+        table.add_column("Status", style="green")
+        table.add_column("Tags", style="yellow")
+        table.add_column("Created", style="dim")
+
+        for t in todos:
+            status_style = "green" if t.status == "open" else "dim"
+            created_str = t.created.strftime("%Y-%m-%d") if t.created else ""
+            table.add_row(
+                t.id,
+                t.title[:40],
+                f"[{status_style}]{t.status}[/{status_style}]",
+                ", ".join(t.tags) if t.tags else "",
+                created_str,
+            )
+        console.print(table)
+    elif output_format == "csv":
+        console.print(
+            OutputFormatter.to_csv(
+                data, headers=["id", "title", "status", "tags", "created"]
+            )
+        )
+    elif output_format == "yaml":
+        print(OutputFormatter.to_yaml(result))
+    elif output_format == "paths":
+        paths = [{"filepath": str(t.filepath)} for t in todos]
+        console.print(OutputFormatter.to_paths(paths, key="filepath"))
+    else:
+        raise ValueError(f"Unsupported format: {output_format}")
+
+    return result
+
+
+@todo_app.command()
+def add(
+    title: str = typer.Argument(..., help="待办标题"),
+    content: str = typer.Option("", "--content", "-c", help="待办内容/备注"),
+    tags: Optional[List[str]] = typer.Option(None, "--tag", "-t", help="标签（可多次使用）"),
+    links: Optional[List[str]] = typer.Option(None, "--link", "-l", help="链接到已有笔记（[[标题]] 或 ID）"),
+    output_format: str = typer.Option("table", "--format", "-f", help="输出格式: json, table"),
+    json_output: bool = typer.Option(False, "--json", help="JSON 输出"),
+    kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
+):
+    """添加待办便签"""
+    try:
+        if json_output:
+            output_format = "json"
+
+        with use_kb(kb):
+            result = _todo_add_impl(title, content, tags, links)
+
+        if output_format == "json":
+            print(output_json(result))
+        else:
+            if result.get("success"):
+                console.print(f"[green]✓[/green] Todo created: {result['note']['title']}")
+                console.print(f"[dim]  ID: {result['note']['id']}[/dim]")
+                if result.get("warnings"):
+                    console.print(f"[yellow]⚠ {result['warnings']}[/yellow]")
+            else:
+                console.print(f"[red]✗[/red] {result.get('error', 'Unknown error')}")
+                raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]✗[/red] Error: {e}")
+        raise typer.Exit(1)
+
+
+@todo_app.command()
+def list(
+    show_all: bool = typer.Option(False, "--all", "-a", help="显示所有 todo（包括已完成）"),
+    tags: Optional[List[str]] = typer.Option(None, "--tag", "-t", help="按标签筛选"),
+    output_format: str = typer.Option(
+        "table", "--format", "-f", help="输出格式: json, table, csv, yaml, paths"
+    ),
+    json_output: bool = typer.Option(False, "--json", help="JSON 输出"),
+    kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
+):
+    """列出待办便签（默认只显示未完成的）"""
+    try:
+        if json_output:
+            output_format = "json"
+
+        with use_kb(kb):
+            _todo_list_impl(show_all, tags, output_format)
+    except Exception as e:
+        if output_format == "json":
+            print(output_json({"success": False, "error": str(e)}))
+        else:
+            console.print(f"[red]✗[/red] Error: {e}")
+        raise typer.Exit(1)
+```
+
+- [ ] **Step 4: 在 cli.py 注册 todo_app**
+
+在 `jfox/cli.py` 中，找到 `app.add_typer(auto_summary_app, name="auto-summary")` 后添加：
+
+```python
+# Todo 子命令组
+from .todo_cli import todo_app  # noqa: E402
+
+app.add_typer(todo_app, name="todo")
+```
+
+- [ ] **Step 5: 运行测试确认通过**
+
+Run: `uv run pytest tests/unit/test_todo_cli.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add jfox/todo_cli.py jfox/cli.py tests/unit/test_todo_cli.py
+git commit -m "feat(todo): add todo add and list commands
+
+- jfox/todo_cli.py: new sub-app with add/list commands
+- Agent-friendly: list defaults to open-only, --all for all
+- Supports --content, --tag, --link options on add
+- Supports json/table/csv/yaml/paths output formats
+
+Refs #230"
+```
+
+---
+
+### Task 5: 创建 done / open / delete 命令
+
+**Files:**
+- Modify: `jfox/todo_cli.py`
+- Test: `tests/unit/test_todo_cli.py`（追加测试）
+
+- [ ] **Step 1: 写 failing test — done / open / delete**
+
+在 `tests/unit/test_todo_cli.py` 中追加：
+
+```python
+class TestTodoStatus:
+    """测试 done / open / delete 命令"""
+
+    @patch(PATCH_USE_KB)
+    @patch(PATCH_NOTE_MODULE)
+    def test_done_todo(self, mock_note, mock_use_kb):
+        """标记 todo 为完成"""
+        from jfox.todo_cli import _todo_done_impl
+
+        mock_todo = Note(
+            id="202605221430001234",
+            title="跟进客户反馈",
+            content="",
+            type=NoteType.TODO,
+            status="open",
+            created=datetime.now(),
+            updated=datetime.now(),
+        )
+        mock_note.load_note_by_id.return_value = mock_todo
+        mock_note.update_note.return_value = True
+
+        result = _todo_done_impl("跟进客户反馈")
+
+        assert result["success"] is True
+        assert mock_todo.status == "done"
+        mock_note.update_note.assert_called_once()
+
+    @patch(PATCH_USE_KB)
+    @patch(PATCH_NOTE_MODULE)
+    def test_done_already_done_warns(self, mock_note, mock_use_kb):
+        """done 一个已经是 done 的 todo 发出警告"""
+        from jfox.todo_cli import _todo_done_impl
+
+        mock_todo = Note(
+            id="202605221430001234",
+            title="跟进客户反馈",
+            content="",
+            type=NoteType.TODO,
+            status="done",
+            created=datetime.now(),
+            updated=datetime.now(),
+        )
+        mock_note.load_note_by_id.return_value = mock_todo
+
+        result = _todo_done_impl("跟进客户反馈")
+
+        assert result["success"] is True
+        assert "already" in result.get("message", "").lower()
+
+    @patch(PATCH_USE_KB)
+    @patch(PATCH_NOTE_MODULE)
+    def test_open_todo(self, mock_note, mock_use_kb):
+        """重新打开 todo"""
+        from jfox.todo_cli import _todo_open_impl
+
+        mock_todo = Note(
+            id="202605221430001234",
+            title="跟进客户反馈",
+            content="",
+            type=NoteType.TODO,
+            status="done",
+            created=datetime.now(),
+            updated=datetime.now(),
+        )
+        mock_note.load_note_by_id.return_value = mock_todo
+        mock_note.update_note.return_value = True
+
+        result = _todo_open_impl("跟进客户反馈")
+
+        assert result["success"] is True
+        assert mock_todo.status == "open"
+
+    @patch(PATCH_USE_KB)
+    @patch(PATCH_NOTE_MODULE)
+    def test_delete_todo(self, mock_note, mock_use_kb):
+        """删除 todo"""
+        from jfox.todo_cli import _todo_delete_impl
+
+        mock_todo = Note(
+            id="202605221430001234",
+            title="跟进客户反馈",
+            content="",
+            type=NoteType.TODO,
+            status="open",
+            created=datetime.now(),
+            updated=datetime.now(),
+        )
+        mock_note.load_note_by_id.return_value = mock_todo
+        mock_note.delete_note.return_value = True
+
+        result = _todo_delete_impl("跟进客户反馈")
+
+        assert result["success"] is True
+        mock_note.delete_note.assert_called_once_with("202605221430001234")
+
+    @patch(PATCH_USE_KB)
+    @patch(PATCH_NOTE_MODULE)
+    def test_not_found_returns_error(self, mock_note, mock_use_kb):
+        """找不到 todo 返回错误"""
+        from jfox.todo_cli import _todo_done_impl
+
+        mock_note.load_note_by_id.return_value = None
+
+        result = _todo_done_impl("不存在的待办")
+
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `uv run pytest tests/unit/test_todo_cli.py::TestTodoStatus -v`
+Expected: FAIL (_todo_done_impl 等不存在)
+
+- [ ] **Step 3: 实现 done / open / delete 命令**
+
+在 `jfox/todo_cli.py` 中，在 `_todo_list_impl` 函数后追加：
+
+```python
+def _todo_done_impl(note_ref: str) -> dict:
+    """标记 todo 为完成的内部实现"""
+    note_id = find_note_id_by_title_or_id(note_ref)
+    if not note_id:
+        return {"success": False, "error": f"Todo not found: {note_ref}"}
+
+    target = note.load_note_by_id(note_id)
+    if not target:
+        return {"success": False, "error": f"Todo not found: {note_ref}"}
+
+    if target.status == "done":
+        return {"success": True, "message": "Todo is already done", "note": target.to_dict()}
+
+    target.status = "done"
+    target.updated = datetime.now()
+    if note.update_note(target, add_to_index=False):
+        return {"success": True, "note": target.to_dict()}
+    else:
+        return {"success": False, "error": "Failed to update todo"}
+
+
+def _todo_open_impl(note_ref: str) -> dict:
+    """重新打开 todo 的内部实现"""
+    note_id = find_note_id_by_title_or_id(note_ref)
+    if not note_id:
+        return {"success": False, "error": f"Todo not found: {note_ref}"}
+
+    target = note.load_note_by_id(note_id)
+    if not target:
+        return {"success": False, "error": f"Todo not found: {note_ref}"}
+
+    if target.status == "open":
+        return {"success": True, "message": "Todo is already open", "note": target.to_dict()}
+
+    target.status = "open"
+    target.updated = datetime.now()
+    if note.update_note(target, add_to_index=False):
+        return {"success": True, "note": target.to_dict()}
+    else:
+        return {"success": False, "error": "Failed to update todo"}
+
+
+def _todo_delete_impl(note_ref: str) -> dict:
+    """删除 todo 的内部实现"""
+    note_id = find_note_id_by_title_or_id(note_ref)
+    if not note_id:
+        return {"success": False, "error": f"Todo not found: {note_ref}"}
+
+    target = note.load_note_by_id(note_id)
+    if not target:
+        return {"success": False, "error": f"Todo not found: {note_ref}"}
+
+    if note.delete_note(note_id):
+        return {"success": True, "note": {"id": note_id, "title": target.title}}
+    else:
+        return {"success": False, "error": "Failed to delete todo"}
+```
+
+然后在文件末尾追加 CLI 命令装饰器：
+
+```python
+@todo_app.command()
+def done(
+    note_ref: str = typer.Argument(..., help="待办 ID 或标题"),
+    kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
+):
+    """标记待办为已完成"""
+    try:
+        with use_kb(kb):
+            result = _todo_done_impl(note_ref)
+
+        if result["success"]:
+            msg = result.get("message", "Todo marked as done")
+            console.print(f"[green]✓[/green] {msg}: {result['note']['title']}")
+        else:
+            console.print(f"[red]✗[/red] {result['error']}")
+            raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]✗[/red] Error: {e}")
+        raise typer.Exit(1)
+
+
+@todo_app.command()
+def open(
+    note_ref: str = typer.Argument(..., help="待办 ID 或标题"),
+    kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
+):
+    """重新打开已完成的待办"""
+    try:
+        with use_kb(kb):
+            result = _todo_open_impl(note_ref)
+
+        if result["success"]:
+            msg = result.get("message", "Todo reopened")
+            console.print(f"[green]✓[/green] {msg}: {result['note']['title']}")
+        else:
+            console.print(f"[red]✗[/red] {result['error']}")
+            raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]✗[/red] Error: {e}")
+        raise typer.Exit(1)
+
+
+@todo_app.command()
+def delete(
+    note_ref: str = typer.Argument(..., help="待办 ID 或标题"),
+    kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
+):
+    """删除待办便签"""
+    try:
+        with use_kb(kb):
+            result = _todo_delete_impl(note_ref)
+
+        if result["success"]:
+            console.print(f"[green]✓[/green] Deleted: {result['note']['title']}")
+        else:
+            console.print(f"[red]✗[/red] {result['error']}")
+            raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]✗[/red] Error: {e}")
+        raise typer.Exit(1)
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `uv run pytest tests/unit/test_todo_cli.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add jfox/todo_cli.py tests/unit/test_todo_cli.py
+git commit -m "feat(todo): add done, open, delete commands
+
+- done: mark todo as done with idempotency warning
+- open: reopen a done todo
+- delete: remove todo and its index entries
+- All commands support --kb for multi-kb usage
+
+Refs #230"
+```
+
+---
+
+### Task 6: 创建 review 命令
+
+**Files:**
+- Modify: `jfox/todo_cli.py`
+- Test: `tests/unit/test_todo_review.py`
+
+- [ ] **Step 1: 写 failing test — review 命令**
+
+```python
+"""
+测试类型: 单元测试
+目标模块: jfox.todo_cli (review 命令)
+预估耗时: < 1秒
+依赖要求: 无外部依赖，使用 mock
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+from datetime import datetime
+from unittest.mock import patch
+
+from jfox.models import Note, NoteType
+
+PATCH_USE_KB = "jfox.todo_cli.use_kb"
+PATCH_NOTE_MODULE = "jfox.todo_cli.note"
+
+
+class TestTodoReview:
+    """测试 todo review 命令"""
+
+    @patch(PATCH_USE_KB)
+    @patch(PATCH_NOTE_MODULE)
+    def test_review_default_returns_list(self, mock_note, mock_use_kb):
+        """默认 review 返回 open todo 列表（Agent 友好）"""
+        from jfox.todo_cli import _todo_review_impl
+
+        todos = [
+            Note(
+                id="202605221430001234",
+                title="Task 1",
+                content="",
+                type=NoteType.TODO,
+                status="open",
+                created=datetime(2026, 5, 20, 10, 0, 0),
+                updated=datetime.now(),
+            ),
+            Note(
+                id="202605221430005678",
+                title="Task 2",
+                content="",
+                type=NoteType.TODO,
+                status="done",
+                created=datetime(2026, 5, 21, 10, 0, 0),
+                updated=datetime.now(),
+            ),
+        ]
+        mock_note.list_notes.return_value = [todos[0]]  # 默认过滤后只剩 open
+
+        result = _todo_review_impl(interactive=False, output_format="json")
+
+        assert result["total"] == 1
+        assert result["notes"][0]["title"] == "Task 1"
+        assert result["stats"]["open"] == 1
+
+    @patch(PATCH_USE_KB)
+    @patch(PATCH_NOTE_MODULE)
+    def test_review_stats_include_all_statuses(self, mock_note, mock_use_kb):
+        """review 统计包含所有状态"""
+        from jfox.todo_cli import _todo_review_impl
+
+        todos = [
+            Note(
+                id="202605221430001234",
+                title="Task 1",
+                content="",
+                type=NoteType.TODO,
+                status="open",
+                created=datetime.now(),
+                updated=datetime.now(),
+            ),
+            Note(
+                id="202605221430005678",
+                title="Task 2",
+                content="",
+                type=NoteType.TODO,
+                status="done",
+                created=datetime.now(),
+                updated=datetime.now(),
+            ),
+            Note(
+                id="202605221430009012",
+                title="Task 3",
+                content="",
+                type=NoteType.TODO,
+                status="open",
+                created=datetime.now(),
+                updated=datetime.now(),
+            ),
+        ]
+        mock_note.list_notes.return_value = todos
+
+        result = _todo_review_impl(interactive=False, output_format="json")
+
+        assert result["stats"]["open"] == 2
+        assert result["stats"]["done"] == 1
+        assert result["stats"]["total"] == 3
+
+    @patch(PATCH_USE_KB)
+    @patch("jfox.todo_cli.typer.confirm")
+    @patch(PATCH_NOTE_MODULE)
+    def test_review_interactive_marks_done(self, mock_note, mock_confirm, mock_use_kb):
+        """交互模式下可以标记完成"""
+        from jfox.todo_cli import _todo_review_impl
+
+        todo = Note(
+            id="202605221430001234",
+            title="Task 1",
+            content="Content",
+            type=NoteType.TODO,
+            status="open",
+            created=datetime.now(),
+            updated=datetime.now(),
+        )
+        mock_note.list_notes.return_value = [todo]
+        mock_note.load_note_by_id.return_value = todo
+        mock_note.update_note.return_value = True
+        # 模拟用户输入: d (done), q (quit)
+        mock_confirm.side_effect = [True, False]  # done=True, continue?=False
+
+        result = _todo_review_impl(interactive=True, output_format="json")
+
+        assert result["stats"]["completed"] == 1
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `uv run pytest tests/unit/test_todo_review.py -v`
+Expected: FAIL (_todo_review_impl 不存在)
+
+- [ ] **Step 3: 实现 review 命令**
+
+在 `jfox/todo_cli.py` 中，在 `_todo_delete_impl` 后追加：
+
+```python
+def _todo_review_impl(
+    interactive: bool,
+    output_format: str,
+) -> dict:
+    """review 待办的内部实现"""
+    from .formatters import OutputFormatter
+
+    # 获取所有 todo
+    all_todos = note.list_notes(note_type=NoteType.TODO)
+
+    # 统计
+    open_todos = [t for t in all_todos if t.status == "open"]
+    done_todos = [t for t in all_todos if t.status == "done"]
+
+    stats = {
+        "total": len(all_todos),
+        "open": len(open_todos),
+        "done": len(done_todos),
+    }
+
+    # 非交互模式：返回列表（Agent 友好）
+    if not interactive:
+        data = []
+        for t in open_todos:  # 默认只展示 open
+            d = t.to_dict()
+            d["status"] = t.status
+            data.append(d)
+
+        result = {
+            "total": len(open_todos),
+            "notes": data,
+            "stats": stats,
+        }
+
+        if output_format == "json":
+            print(OutputFormatter.to_json(result))
+        elif output_format == "table":
+            table = Table(title=f"Todo Review ({len(open_todos)} open / {len(all_todos)} total)")
+            table.add_column("ID", style="dim")
+            table.add_column("Title", style="cyan")
+            table.add_column("Created", style="dim")
+            table.add_column("Content Preview", style="white")
+
+            for t in open_todos:
+                created_str = t.created.strftime("%Y-%m-%d") if t.created else ""
+                preview = t.content[:60] + "..." if len(t.content) > 60 else t.content
+                table.add_row(t.id, t.title[:40], created_str, preview)
+            console.print(table)
+
+            console.print(f"\n[dim]Total: {len(all_todos)} | Open: {len(open_todos)} | Done: {len(done_todos)}[/dim]")
+        else:
+            print(OutputFormatter.to_yaml(result))
+
+        return result
+
+    # 交互模式：逐条 review
+    completed_count = 0
+    skipped_count = 0
+    deleted_count = 0
+
+    console.print(f"\n[bold]Todo Review[/bold] ({len(open_todos)} open items)\n")
+
+    for i, t in enumerate(open_todos, 1):
+        console.print(f"[{i}/{len(open_todos)}] [cyan]{t.title}[/cyan] ({t.created.strftime('%Y-%m-%d')})")
+        if t.content:
+            preview = t.content[:200] + "..." if len(t.content) > 200 else t.content
+            console.print(f"  {preview}")
+        console.print()
+
+        action = typer.prompt(
+            "Action: [d]one / [s]kip / [x]delete / [q]uit",
+            default="s",
+        ).lower().strip()
+
+        if action in ("d", "done"):
+            t.status = "done"
+            t.updated = datetime.now()
+            note.update_note(t, add_to_index=False)
+            completed_count += 1
+            console.print("  [green]✓ Marked as done[/green]\n")
+        elif action in ("x", "delete", "del"):
+            note.delete_note(t.id)
+            deleted_count += 1
+            console.print("  [red]✗ Deleted[/red]\n")
+        elif action in ("q", "quit"):
+            console.print("  [dim]Quitting review[/dim]\n")
+            break
+        else:
+            skipped_count += 1
+            console.print("  [dim]Skipped[/dim]\n")
+
+    console.print(f"\n[bold]Review Complete[/bold]")
+    console.print(f"  Done: {completed_count} | Skipped: {skipped_count} | Deleted: {deleted_count}")
+
+    return {
+        "total": len(open_todos),
+        "stats": {
+            **stats,
+            "completed": completed_count,
+            "skipped": skipped_count,
+            "deleted": deleted_count,
+        },
+    }
+```
+
+然后在文件末尾追加 CLI 命令：
+
+```python
+@todo_app.command()
+def review(
+    interactive: bool = typer.Option(False, "--interactive", "-i", help="交互式逐条 review"),
+    output_format: str = typer.Option("table", "--format", "-f", help="输出格式: json, table, yaml"),
+    json_output: bool = typer.Option(False, "--json", help="JSON 输出"),
+    kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
+):
+    """Review 待办便签
+
+    默认输出所有 open todo 的列表（Agent 友好）。
+    加 --interactive 进入交互式逐条 review 模式。
+    """
+    try:
+        if json_output:
+            output_format = "json"
+
+        with use_kb(kb):
+            _todo_review_impl(interactive, output_format)
+    except Exception as e:
+        if output_format == "json":
+            print(output_json({"success": False, "error": str(e)}))
+        else:
+            console.print(f"[red]✗[/red] Error: {e}")
+        raise typer.Exit(1)
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `uv run pytest tests/unit/test_todo_review.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add jfox/todo_cli.py tests/unit/test_todo_review.py
+git commit -m "feat(todo): add review command with interactive mode
+
+- Default: lists open todos with stats (Agent-friendly)
+- --interactive: step-through with [d]one/[s]kip/[x]delete/[q]uit
+- Shows completion stats after review
+
+Refs #230"
+```
+
+---
+
+### Task 7: 集成测试
+
+**Files:**
+- Create: `tests/unit/test_todo_integration.py`
+
+- [ ] **Step 1: 写集成测试**
+
+```python
+"""
+测试类型: 单元测试（集成）
+目标模块: todo 与 search/graph 的集成
+预估耗时: < 1秒
+依赖要求: 无外部依赖，使用 mock
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+from jfox.config import ZKConfig
+from jfox.models import Note, NoteType
+from jfox.note import create_note, save_note
+
+
+class TestTodoIntegration:
+    """测试 todo 与现有功能的集成"""
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_todo_links_to_other_notes(self, mock_global_config, mock_note_config, tmp_path):
+        """todo 可以链接到其他笔记， backlinks 正常更新"""
+        cfg = ZKConfig(base_dir=tmp_path)
+        cfg.ensure_dirs()
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        # 创建一篇永久笔记
+        permanent = create_note(
+            "Python async patterns",
+            title="Python Async",
+            note_type=NoteType.PERMANENT,
+            tags=["python"],
+        )
+        save_note(permanent, add_to_index=False)
+
+        # 创建 todo 链接到永久笔记
+        todo = create_note(
+            "读完这篇文章",
+            title="Read Python Async",
+            note_type=NoteType.TODO,
+            tags=["学习"],
+            links=[permanent.id],
+        )
+        save_note(todo, add_to_index=False)
+
+        # 验证 todo 的前向链接
+        assert permanent.id in todo.links
+
+        # 验证永久笔记的反向链接被更新
+        from jfox.note import load_note_by_id
+
+        reloaded = load_note_by_id(permanent.id, cfg=cfg)
+        assert todo.id in reloaded.backlinks
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_todo_note_index_includes_todo(self, mock_global_config, mock_note_config, tmp_path):
+        """NoteIndex 自动包含 todo 类型"""
+        cfg = ZKConfig(base_dir=tmp_path)
+        cfg.ensure_dirs()
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        todo = create_note("测试 todo", note_type=NoteType.TODO)
+        save_note(todo, add_to_index=False)
+
+        from jfox.note_index import NoteIndex
+
+        idx = NoteIndex(cfg)
+        idx.rebuild()
+
+        # 验证索引中包含 todo
+        all_meta = idx.get_all_meta()
+        todo_meta = [m for m in all_meta if m.type == NoteType.TODO]
+        assert len(todo_meta) == 1
+        assert todo_meta[0].title == "测试 todo"
+
+    @patch("jfox.note.config")
+    @patch("jfox.config.config")
+    def test_todo_filepath_in_todo_dir(self, mock_global_config, mock_note_config, tmp_path):
+        """todo 笔记文件保存在 notes/todo/ 目录"""
+        cfg = ZKConfig(base_dir=tmp_path)
+        cfg.ensure_dirs()
+        mock_global_config.notes_dir = cfg.notes_dir
+        mock_note_config.notes_dir = cfg.notes_dir
+
+        todo = create_note("测试 todo", note_type=NoteType.TODO)
+        save_note(todo, add_to_index=False)
+
+        assert "notes/todo/" in str(todo.filepath).replace("\\", "/")
+        assert todo.filepath.exists()
+```
+
+- [ ] **Step 2: 运行测试确认通过**
+
+Run: `uv run pytest tests/unit/test_todo_integration.py -v`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/test_todo_integration.py
+git commit -m "test(todo): add integration tests for todo type
+
+- Verify backlinks work with todo notes
+- Verify NoteIndex auto-includes todo type
+- Verify todo files are stored in notes/todo/
+
+Refs #230"
+```
+
+---
+
+### Task 8: 验证与手动测试
+
+**Files:**
+- None (manual verification)
+
+- [ ] **Step 1: 运行全部 todo 测试**
+
+Run: `uv run pytest tests/unit/test_todo_*.py -v`
+Expected: 全部 PASS
+
+- [ ] **Step 2: 验证 CLI 注册**
+
+Run: `uv run jfox todo --help`
+Expected: 显示 add, list, done, open, delete, review 命令
+
+- [ ] **Step 3: 端到端手动测试**
+
+```bash
+# 创建测试知识库（或使用现有）
+uv run jfox init --name todo-test
+
+# 添加 todo
+uv run jfox todo add "测试待办" --content "这是内容" --tag "测试" --kb todo-test
+
+# 列出 open todo
+uv run jfox todo list --kb todo-test
+
+# 标记完成
+uv run jfox todo done "测试待办" --kb todo-test
+
+# 验证 list 不再显示
+uv run jfox todo list --kb todo-test
+
+# --all 仍能看到
+uv run jfox todo list --all --kb todo-test
+
+# 删除
+uv run jfox todo delete "测试待办" --kb todo-test
+```
+
+- [ ] **Step 4: 验证 search 包含 todo**
+
+```bash
+uv run jfox todo add "搜索测试" --content "关键词内容" --kb todo-test
+uv run jfox search "关键词" --kb todo-test
+```
+Expected: 搜索结果包含 todo 笔记
+
+- [ ] **Step 5: 验证 graph 包含 todo**
+
+```bash
+uv run jfox graph --kb todo-test
+```
+Expected: 图谱统计中包含 todo 节点
+
+- [ ] **Step 6: 运行完整单元测试套件（快速）**
+
+Run: `uv run pytest tests/unit/ -m "not embedding and not slow" -v`
+Expected: 全部 PASS
+
+- [ ] **Step 7: Final commit**
+
+```bash
+git commit --allow-empty -m "feat(todo): complete todo note type implementation (#230)
+
+- New NoteType.TODO with open/done status
+- jfox todo sub-command: add, list, done, open, delete, review
+- Agent-friendly defaults: list shows open-only, review lists by default
+- --interactive flag for human-friendly step-through review
+- Full integration with search, graph, backlinks, and NoteIndex
+- 4 test files covering CRUD, CLI, review, and integration
+
+Closes #230"
+```
+
+---
+
+## Self-Review
+
+### 1. Spec Coverage
+
+| 设计需求 | 对应 Task |
+|----------|-----------|
+| NoteType.TODO | Task 1 |
+| Note.status 字段 | Task 1 |
+| status 序列化/反序列化 | Task 1 |
+| notes/todo/ 目录 | Task 2 |
+| create_note 默认 status=open | Task 2 |
+| get_stats 自动统计 | Task 2 (无需改动，遍历 NoteType) |
+| CLI type 校验文案更新 | Task 3 |
+| todo add 命令 | Task 4 |
+| todo list（默认 open） | Task 4 |
+| todo done/open/delete | Task 5 |
+| todo review（默认列表） | Task 6 |
+| todo review --interactive | Task 6 |
+| search/graph 集成 | Task 7 (测试验证) |
+| backlinks 集成 | Task 7 |
+
+**无遗漏。**
+
+### 2. Placeholder Scan
+
+- 无 "TBD" / "TODO" / "implement later"
+- 无 "add appropriate error handling"
+- 所有步骤包含实际代码
+- 每个 Task 的测试代码完整，不引用 "Similar to Task N"
+
+### 3. Type Consistency
+
+- `NoteType.TODO` 全计划一致
+- `status` 字段类型始终为 `Optional[str]`
+- `_todo_*_impl` 函数签名在测试和实现中一致
+- `output_format` 参数值在所有命令中一致
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-06-02-todo-note-type.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-06-02-todo-note-type-design.md
+++ b/docs/superpowers/specs/2026-06-02-todo-note-type-design.md
@@ -1,0 +1,169 @@
+# Design: Todo 便签笔记类型
+
+日期: 2026-06-02
+Issue: #230
+
+---
+
+## 背景
+
+当前笔记类型（fleeting/literature/permanent/session）都是知识类。用户想在工作知识库中快速记录待办/备忘，类似黄色便签，定期 review 这些 todo list。
+
+**关键约束**：该 CLI 的主要使用者是 Coding Agent，因此设计以 Agent 友好为优先，人类交互为可选增强。
+
+---
+
+## 目标
+
+1. 新增 `todo` 笔记类型，支持 `open` / `done` 两种状态
+2. 提供独立的 `jfox todo` 命令族，便于 Agent 程序化操作
+3. 与现有功能（search、graph、backlinks）无缝集成
+4. 不破坏现有模型和架构
+
+---
+
+## Section 1: 数据模型与存储层
+
+### 1.1 NoteType 扩展
+
+在 `models.py` 的 `NoteType` 枚举中新增：
+
+```python
+class NoteType(Enum):
+    FLEETING = "fleeting"
+    LITERATURE = "literature"
+    PERMANENT = "permanent"
+    SESSION = "session"
+    TODO = "todo"  # 新增
+```
+
+### 1.2 Note 模型（最小侵入）
+
+采用与现有 `source`（literature 专用）、`topic`（session 专用）相同的模式：
+
+```python
+@dataclass
+class Note:
+    # ... 现有字段 ...
+    status: Optional[str] = None  # 仅 todo 使用: "open" | "done"
+```
+
+- `to_markdown()` 在 `type == "todo"` 时输出 `status` 到 frontmatter
+- `from_markdown()` 解析 frontmatter 中的 `status`（非 todo 类型则为 None）
+- 其他类型完全无感知
+
+### 1.3 存储路径
+
+- 存储路径：`~/.zettelkasten/<kb>/notes/todo/`
+- `config.py` 的 `ensure_dirs()` 新增 `self.notes_dir / "todo"`
+- `note.py` 的 `get_stats()` 自动统计 todo 类型（遍历 `NoteType` 枚举）
+
+### 1.4 文件名规则
+
+采用 `permanent`/`literature` 模式：
+
+```
+{id}-{slug}.md
+# 例如: 20260522143000-跟进客户反馈.md
+```
+
+---
+
+## Section 2: CLI 接口设计
+
+采用 Typer sub-app 模式：
+
+```python
+todo_app = typer.Typer(name="todo", help="待办便签管理")
+app.add_typer(todo_app, name="todo")
+```
+
+### 2.1 命令族
+
+| 命令 | 作用 | 输出格式 |
+|------|------|----------|
+| `jfox todo add "标题" [--content "正文"] [--tag t1] [--link [[笔记]]]` | 快速创建 todo | 成功/失败 + note ID |
+| `jfox todo list [--all] [--tag t1] [--format json]` | 列出 todo（默认只显示 open） | 表格/JSON |
+| `jfox todo done <id_or_title>` | 标记完成 | 成功/失败 |
+| `jfox todo open <id_or_title>` | 重新打开 | 成功/失败 |
+| `jfox todo delete <id_or_title>` | 删除 todo | 成功/失败 |
+| `jfox todo review [--interactive]` | 批量 review | 列表 / 交互式 |
+
+### 2.2 关键设计决策
+
+**`list` 默认过滤 open**：与 `jfox list`（列出所有类型）不同，`jfox todo list` 默认只显示 `status=open` 的 todo，加 `--all` 才显示全部。
+
+**`review` 的行为（Agent 优先）**：
+- 默认（无 `--interactive`）：输出所有 open todo 的结构化列表，等价于 `jfox todo list`，供 Agent 消费
+- `jfox todo review --interactive`：进入交互模式，逐条展示：
+  ```
+  [1/5] 跟进客户反馈 (2026-05-22)
+  客户提出了三个问题需要回复...
+  操作: [d]one / [s]kip / [x]delete / [q]uit >
+  ```
+  交互结束后输出统计。
+
+**`done`/`open` 的实现**：
+- 复用 `note.update_note()`，但只修改 `status` 和 `updated` 字段
+- 为避免重命名文件（标题没变），`update_note()` 在检测到新旧路径相同时跳过 `unlink()`
+
+### 2.3 错误处理
+
+- `done` 一个已经是 done 的 todo → 提示警告，不报错
+- `open` 一个已经是 open 的 todo → 同理
+- 找不到 todo → 使用 `find_note_id_by_title_or_id()` 的模糊匹配，失败时报错
+
+---
+
+## Section 3: 集成与测试
+
+### 3.1 与现有功能的集成
+
+| 功能 | 集成方式 | 是否需要代码改动 |
+|------|----------|------------------|
+| **Search** (`jfox search`) | `note_type="todo"` 自动可用；搜索结果包含 todo | 无需改动 |
+| **Graph** (`jfox graph`) | `rglob("*.md")` 自动包含 todo 目录；`[[links]]` 正常解析 | 无需改动 |
+| **Index** (`note_index.py`) | `NoteIndex.rebuild()` 遍历所有 `NoteType`，自动包含 | 无需改动 |
+| **Backlinks** | `jfox todo add --link [[笔记]]` 正常更新目标笔记的 `backlinks` | 复用现有逻辑 |
+| **Vector Store / BM25** | `save_note()` 自动添加到索引 | 无需改动 |
+| **`jfox show <id>`** | 复用 `find_note_id_by_title_or_id`，可定位 todo | 无需改动 |
+
+**唯一需要的文案更新**：`jfox list` 和 `jfox add` 的 type 参数校验文案，从 `"Use: fleeting, literature, permanent, session"` 改为 `"Use: fleeting, literature, permanent, session, todo"`。
+
+### 3.2 测试策略
+
+| 测试文件 | 覆盖内容 |
+|----------|----------|
+| `tests/unit/test_todo_crud.py` | `create_note(type=TODO)`, `save_note`, `load_note`, `status` 序列化/反序列化 |
+| `tests/unit/test_todo_cli.py` | `todo add`, `todo list`, `todo done`, `todo open`, `todo delete` 命令参数与输出 |
+| `tests/unit/test_todo_review.py` | `review` 默认列表输出、`--interactive` 交互流程（mock 输入） |
+| `tests/unit/test_todo_integration.py` | todo 的 `[[links]]` 能否被 graph/search 正确索引 |
+
+### 3.3 不在范围内（YAGNI）
+
+- todo 不单独建索引，复用现有 BM25 + 向量索引
+- todo 不支持模板（`jfox todo add --template` 暂不支持）
+- todo 不支持 `source`/`topic` 字段
+- 不实现重复检测（如"是否已有同名 open todo"）
+
+---
+
+## 影响范围
+
+| 文件 | 改动内容 |
+|------|----------|
+| `jfox/models.py` | `NoteType` 新增 `TODO`；`Note` 新增 `status` 字段；`to_markdown()`/`from_markdown()` 处理 `status` |
+| `jfox/note.py` | `create_note()` 支持 todo 默认值；`get_stats()` 自动统计 |
+| `jfox/config.py` | `ensure_dirs()` 新增 `todo` 目录 |
+| `jfox/cli.py` | 新增 `todo` sub-app 及 6 个命令 |
+| `tests/unit/test_todo_*.py` | 4 个新测试文件 |
+
+---
+
+## 执行顺序
+
+1. 数据层（models.py + config.py + note.py）
+2. CLI 命令（cli.py：add/list/done/open/delete）
+3. Review 命令（cli.py：review + --interactive）
+4. 测试（4 个测试文件）
+5. 验证（手动运行 todo 命令族）

--- a/jfox/auto_summary/cli.py
+++ b/jfox/auto_summary/cli.py
@@ -26,6 +26,11 @@ from . import ledger as ledger_module
 from .ledger import Ledger
 from .runner import run_once, scan_pending
 
+# 设计说明：此模块的子命令未采用主 cli.py 的 `@app.command() → _xxx_impl()` 拆分模式。
+# 原因：(1) 每个子命令仅 20-40 行，拆分无复用价值；
+#       (2) 作为独立子模块，不与主 cli.py 共享 _impl 函数；
+#       (3) 保持紧凑可读比形式统一更重要。
+
 
 def _fmt(table: Optional[Table] = None, json_data: Any = None, fmt: str = "table") -> None:
     """统一的输出路由：fmt=json 时输出 JSON 字符串，否则渲染 Table"""

--- a/jfox/auto_summary/ledger.py
+++ b/jfox/auto_summary/ledger.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import tempfile
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -132,28 +131,13 @@ class Ledger:
 
     def _save(self) -> bool:
         try:
-            self.path.parent.mkdir(parents=True, exist_ok=True)
+            from ..utils import atomic_write_json
+
             payload = {
                 "version": self._data.version,
                 "sessions": {sid: e.to_dict() for sid, e in self._data.sessions.items()},
             }
-            # 原子写：tempfile + os.replace；避免半截写入导致下次 _load 失败、清空所有历史
-            fd, tmp_path = tempfile.mkstemp(
-                prefix=self.path.name + ".",
-                suffix=".tmp",
-                dir=str(self.path.parent),
-            )
-            try:
-                with os.fdopen(fd, "w", encoding="utf-8") as f:
-                    json.dump(payload, f, ensure_ascii=False, indent=2)
-                os.replace(tmp_path, self.path)
-            except Exception:
-                # 清理半成品 tmp 文件，再抛
-                try:
-                    os.unlink(tmp_path)
-                except OSError:
-                    pass
-                raise
+            atomic_write_json(self.path, payload)
             return True
         except OSError as e:
             logger.error("保存 ledger 失败: %s", e)

--- a/jfox/auto_summary/ledger.py
+++ b/jfox/auto_summary/ledger.py
@@ -208,7 +208,7 @@ class Ledger:
     # 写入 -----------------------------------------------------------------
 
     def record_success(self, session_id: str, project: str, note_id: str) -> bool:
-        for attempt in range(3):
+        for attempt in range(self.max_retries):
             data = self._load()
             data.sessions[session_id] = LedgerEntry(
                 project=project,
@@ -221,11 +221,13 @@ class Ledger:
             if self._save_cas(data):
                 self._data = data
                 return True
-            logger.debug("CAS conflict on record_success, retry %d/3", attempt + 1)
-        raise RuntimeError(f"Ledger CAS conflict after 3 retries: {session_id}")
+            logger.debug(
+                "CAS conflict on record_success, retry %d/%d", attempt + 1, self.max_retries
+            )
+        raise RuntimeError(f"Ledger CAS conflict after {self.max_retries} retries: {session_id}")
 
     def record_skip(self, session_id: str, project: str, reason: str) -> bool:
-        for attempt in range(3):
+        for attempt in range(self.max_retries):
             data = self._load()
             data.sessions[session_id] = LedgerEntry(
                 project=project,
@@ -238,11 +240,11 @@ class Ledger:
             if self._save_cas(data):
                 self._data = data
                 return True
-            logger.debug("CAS conflict on record_skip, retry %d/3", attempt + 1)
-        raise RuntimeError(f"Ledger CAS conflict after 3 retries: {session_id}")
+            logger.debug("CAS conflict on record_skip, retry %d/%d", attempt + 1, self.max_retries)
+        raise RuntimeError(f"Ledger CAS conflict after {self.max_retries} retries: {session_id}")
 
     def record_failure(self, session_id: str, project: str, error: str) -> bool:
-        for attempt in range(3):
+        for attempt in range(self.max_retries):
             data = self._load()
             prev = data.sessions.get(session_id)
             retries = (prev.retry_count if prev else 0) + 1
@@ -259,12 +261,14 @@ class Ledger:
             if self._save_cas(data):
                 self._data = data
                 return True
-            logger.debug("CAS conflict on record_failure, retry %d/3", attempt + 1)
-        raise RuntimeError(f"Ledger CAS conflict after 3 retries: {session_id}")
+            logger.debug(
+                "CAS conflict on record_failure, retry %d/%d", attempt + 1, self.max_retries
+            )
+        raise RuntimeError(f"Ledger CAS conflict after {self.max_retries} retries: {session_id}")
 
     def forget(self, session_id: str) -> bool:
         """从 ledger 中移除某条，使其下次扫描时被重新处理"""
-        for attempt in range(3):
+        for attempt in range(self.max_retries):
             data = self._load()
             if session_id not in data.sessions:
                 return False
@@ -272,15 +276,15 @@ class Ledger:
             if self._save_cas(data):
                 self._data = data
                 return True
-            logger.debug("CAS conflict on forget, retry %d/3", attempt + 1)
-        raise RuntimeError(f"Ledger CAS conflict after 3 retries: {session_id}")
+            logger.debug("CAS conflict on forget, retry %d/%d", attempt + 1, self.max_retries)
+        raise RuntimeError(f"Ledger CAS conflict after {self.max_retries} retries: {session_id}")
 
     def prune_older_than(self, days: int) -> int:
         """删除 processed_at 早于 N 天的条目，返回删除数量"""
         if days <= 0:
             return 0
         cutoff = datetime.now().timestamp() - days * 86400
-        for attempt in range(3):
+        for attempt in range(self.max_retries):
             data = self._load()
             to_delete = []
             for sid, entry in data.sessions.items():
@@ -297,5 +301,5 @@ class Ledger:
             if self._save_cas(data):
                 self._data = data
                 return len(to_delete)
-            logger.debug("CAS conflict on prune, retry %d/3", attempt + 1)
-        raise RuntimeError("Ledger CAS conflict after 3 retries during prune")
+            logger.debug("CAS conflict on prune, retry %d/%d", attempt + 1, self.max_retries)
+        raise RuntimeError(f"Ledger CAS conflict after {self.max_retries} retries during prune")

--- a/jfox/auto_summary/ledger.py
+++ b/jfox/auto_summary/ledger.py
@@ -69,17 +69,20 @@ class _LedgerData:
 
 class Ledger:
     """
-    线程安全性说明：本实现非线程安全。daemon 后台循环和 CLI 手动 run 不会
-    并发修改同一份 ledger（CLI 命令本身会去 daemon 之外独立跑），单点写入足够。
+    并发安全性说明：写方法使用 CAS（compare-and-swap）保护，daemon 后台循环
+    和 CLI 手动 run 并发写入同一份 ledger 时，会自动重试（最多 3 次）。
+    不适用于高频并发场景（每秒多次写入）。
     """
 
     def __init__(self, path: Optional[Path] = None, max_retries: int = DEFAULT_MAX_RETRIES):
         self.path = path or DEFAULT_LEDGER_PATH
         self.max_retries = max_retries
+        self._last_mtime: Optional[float] = None
         self._data = self._load()
 
     def _load(self) -> _LedgerData:
         if not self.path.exists():
+            self._last_mtime = None
             return _LedgerData()
         try:
             with open(self.path, "r", encoding="utf-8") as f:
@@ -91,6 +94,7 @@ class Ledger:
                 e,
                 backup_path or "(备份失败)",
             )
+            self._last_mtime = None
             return _LedgerData()
 
         # 合法 JSON 但非 dict → 视为损坏，同样备份
@@ -101,6 +105,7 @@ class Ledger:
                 type(raw).__name__,
                 backup_path or "(备份失败)",
             )
+            self._last_mtime = None
             return _LedgerData()
 
         version = raw.get("version", SCHEMA_VERSION)
@@ -114,6 +119,10 @@ class Ledger:
         sessions = {
             sid: LedgerEntry.from_dict(d) for sid, d in sessions_raw.items() if isinstance(d, dict)
         }
+        try:
+            self._last_mtime = os.path.getmtime(self.path)
+        except OSError:
+            self._last_mtime = None
         return _LedgerData(version=SCHEMA_VERSION, sessions=sessions)
 
     def _backup_corrupted_file(self) -> Optional[Path]:
@@ -143,6 +152,35 @@ class Ledger:
             logger.error("保存 ledger 失败: %s", e)
             return False
 
+    def _save_cas(self, data: _LedgerData) -> bool:
+        """CAS 写入：mtime 变化则返回 False（调用方应重新 load 再试）。"""
+        try:
+            current_mtime = None
+            if self.path.exists():
+                current_mtime = os.path.getmtime(self.path)
+        except OSError:
+            current_mtime = None
+
+        if current_mtime != self._last_mtime:
+            return False
+
+        from ..utils import atomic_write_json
+
+        payload = {
+            "version": data.version,
+            "sessions": {sid: e.to_dict() for sid, e in data.sessions.items()},
+        }
+        atomic_write_json(self.path, payload)
+        try:
+            self._last_mtime = os.path.getmtime(self.path)
+        except OSError:
+            self._last_mtime = None
+        return True
+
+    def _retry_count_from(self, data: _LedgerData, session_id: str) -> int:
+        prev = data.sessions.get(session_id)
+        return prev.retry_count if prev else 0
+
     # 查询 -----------------------------------------------------------------
 
     def get(self, session_id: str) -> Optional[LedgerEntry]:
@@ -170,68 +208,94 @@ class Ledger:
     # 写入 -----------------------------------------------------------------
 
     def record_success(self, session_id: str, project: str, note_id: str) -> bool:
-        self._data.sessions[session_id] = LedgerEntry(
-            project=project,
-            processed_at=datetime.now().isoformat(),
-            status=SessionStatus.SUCCESS.value,
-            note_id=note_id,
-            retry_count=self._existing_retry_count(session_id),
-            last_error=None,
-        )
-        return self._save()
+        for attempt in range(3):
+            data = self._load()
+            data.sessions[session_id] = LedgerEntry(
+                project=project,
+                processed_at=datetime.now().isoformat(),
+                status=SessionStatus.SUCCESS.value,
+                note_id=note_id,
+                retry_count=self._retry_count_from(data, session_id),
+                last_error=None,
+            )
+            if self._save_cas(data):
+                self._data = data
+                return True
+            logger.debug("CAS conflict on record_success, retry %d/3", attempt + 1)
+        raise RuntimeError(f"Ledger CAS conflict after 3 retries: {session_id}")
 
     def record_skip(self, session_id: str, project: str, reason: str) -> bool:
-        self._data.sessions[session_id] = LedgerEntry(
-            project=project,
-            processed_at=datetime.now().isoformat(),
-            status=SessionStatus.SKIPPED.value,
-            note_id=None,
-            retry_count=self._existing_retry_count(session_id),
-            last_error=reason,
-        )
-        return self._save()
+        for attempt in range(3):
+            data = self._load()
+            data.sessions[session_id] = LedgerEntry(
+                project=project,
+                processed_at=datetime.now().isoformat(),
+                status=SessionStatus.SKIPPED.value,
+                note_id=None,
+                retry_count=self._retry_count_from(data, session_id),
+                last_error=reason,
+            )
+            if self._save_cas(data):
+                self._data = data
+                return True
+            logger.debug("CAS conflict on record_skip, retry %d/3", attempt + 1)
+        raise RuntimeError(f"Ledger CAS conflict after 3 retries: {session_id}")
 
     def record_failure(self, session_id: str, project: str, error: str) -> bool:
-        prev = self.get(session_id)
-        retries = (prev.retry_count if prev else 0) + 1
-        permanent = retries >= self.max_retries
-        status = SessionStatus.FAILED_PERMANENT if permanent else SessionStatus.FAILED_TRANSIENT
-        self._data.sessions[session_id] = LedgerEntry(
-            project=project,
-            processed_at=datetime.now().isoformat(),
-            status=status.value,
-            note_id=prev.note_id if prev else None,
-            retry_count=retries,
-            last_error=error[:500],  # 截断防膨胀
-        )
-        return self._save()
+        for attempt in range(3):
+            data = self._load()
+            prev = data.sessions.get(session_id)
+            retries = (prev.retry_count if prev else 0) + 1
+            permanent = retries >= self.max_retries
+            status = SessionStatus.FAILED_PERMANENT if permanent else SessionStatus.FAILED_TRANSIENT
+            data.sessions[session_id] = LedgerEntry(
+                project=project,
+                processed_at=datetime.now().isoformat(),
+                status=status.value,
+                note_id=prev.note_id if prev else None,
+                retry_count=retries,
+                last_error=error[:500],
+            )
+            if self._save_cas(data):
+                self._data = data
+                return True
+            logger.debug("CAS conflict on record_failure, retry %d/3", attempt + 1)
+        raise RuntimeError(f"Ledger CAS conflict after 3 retries: {session_id}")
 
     def forget(self, session_id: str) -> bool:
         """从 ledger 中移除某条，使其下次扫描时被重新处理"""
-        if session_id not in self._data.sessions:
-            return False
-        del self._data.sessions[session_id]
-        return self._save()
+        for attempt in range(3):
+            data = self._load()
+            if session_id not in data.sessions:
+                return False
+            del data.sessions[session_id]
+            if self._save_cas(data):
+                self._data = data
+                return True
+            logger.debug("CAS conflict on forget, retry %d/3", attempt + 1)
+        raise RuntimeError(f"Ledger CAS conflict after 3 retries: {session_id}")
 
     def prune_older_than(self, days: int) -> int:
         """删除 processed_at 早于 N 天的条目，返回删除数量"""
         if days <= 0:
             return 0
         cutoff = datetime.now().timestamp() - days * 86400
-        to_delete = []
-        for sid, entry in self._data.sessions.items():
-            try:
-                ts = datetime.fromisoformat(entry.processed_at).timestamp()
-            except ValueError:
-                continue
-            if ts < cutoff:
-                to_delete.append(sid)
-        for sid in to_delete:
-            del self._data.sessions[sid]
-        if to_delete:
-            self._save()
-        return len(to_delete)
-
-    def _existing_retry_count(self, session_id: str) -> int:
-        prev = self.get(session_id)
-        return prev.retry_count if prev else 0
+        for attempt in range(3):
+            data = self._load()
+            to_delete = []
+            for sid, entry in data.sessions.items():
+                try:
+                    ts = datetime.fromisoformat(entry.processed_at).timestamp()
+                except ValueError:
+                    continue
+                if ts < cutoff:
+                    to_delete.append(sid)
+            for sid in to_delete:
+                del data.sessions[sid]
+            if not to_delete:
+                return 0
+            if self._save_cas(data):
+                self._data = data
+                return len(to_delete)
+            logger.debug("CAS conflict on prune, retry %d/3", attempt + 1)
+        raise RuntimeError("Ledger CAS conflict after 3 retries during prune")

--- a/jfox/auto_summary/loop.py
+++ b/jfox/auto_summary/loop.py
@@ -31,7 +31,7 @@ def _tick_once(stop_event: threading.Event) -> str:
         return "auto-summary 已禁用，跳过本轮"
 
     # 将 stop_event 注入 config，让 _invoke_claude → _run_claude 能检查
-    cfg._stop_event = stop_event  # type: ignore[attr-defined]
+    cfg._stop_event = stop_event
 
     try:
         report = run_once(cfg=cfg)

--- a/jfox/auto_summary/loop.py
+++ b/jfox/auto_summary/loop.py
@@ -2,14 +2,15 @@
 daemon 后台循环：每 interval_minutes 调用一次 run_once。
 
 提供：
-- auto_summary_loop(stop_event): asyncio task body
-- _tick_once(): 同步 wrapper（在 executor 中执行 run_once，避免阻塞事件循环）
+- auto_summary_loop(stop_event): async task body（接受 threading.Event）
+- _tick_once(stop_event): 同步 wrapper（在 executor 中执行 run_once）
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 
 from ..global_config import get_global_config_manager
 from .runner import run_once
@@ -17,20 +18,24 @@ from .runner import run_once
 logger = logging.getLogger(__name__)
 
 
-def _tick_once() -> str:
-    """在 executor 中执行的同步函数。返回简短日志行供 await 后打印。
+def _tick_once(stop_event: threading.Event) -> str:
+    """在 executor 中执行的同步函数。返回简短日志行。
 
-    每轮先 reload 全局配置：daemon 进程可能持有旧缓存，CLI `enable` / `disable`
-    已写入新值到磁盘。
+    每轮先 reload 全局配置，然后通过 setattr 把 stop_event 传给 runner，
+    使 claude -p 子进程可被外部中断。
     """
     gm = get_global_config_manager()
     gm.reload()
     cfg = gm.get_auto_summary_config()
     if not cfg.enabled:
         return "auto-summary 已禁用，跳过本轮"
+
+    # 将 stop_event 注入 config，让 _invoke_claude → _run_claude 能检查
+    cfg._stop_event = stop_event  # type: ignore[attr-defined]
+
     try:
         report = run_once(cfg=cfg)
-    except Exception as e:  # 兜底，避免循环退出
+    except Exception as e:
         logger.exception("auto-summary run_once 异常: %s", e)
         return f"run_once 异常: {e}"
 
@@ -43,33 +48,33 @@ def _tick_once() -> str:
     )
 
 
-async def auto_summary_loop(stop_event: asyncio.Event) -> None:
+async def auto_summary_loop(stop_event: threading.Event) -> None:
     """
-    后台循环主体。stop_event.set() 后立即退出。
+    后台循环主体。stop_event.set() 后在 ~1s 内退出（包括终止 claude 子进程）。
 
-    每轮：
-    - 重新读取 GlobalConfig（用户可能在运行期改了 interval / enable）
-    - 通过 run_in_executor 跑 run_once，避免阻塞 daemon 的 HTTP 请求
-    - sleep interval（可被 stop_event 提前中断）
+    使用 threading.Event 而非 asyncio.Event，因为 run_in_executor 中的同步函数
+    需要检查 stop 状态。
     """
     logger.info("auto-summary 后台循环已启动")
     loop = asyncio.get_running_loop()
 
     # 启动后短暂延迟，让 daemon 完成模型加载
     try:
-        await asyncio.wait_for(stop_event.wait(), timeout=10)
-        logger.info("auto-summary 后台循环：启动延迟期间收到停止信号，退出")
-        return
-    except asyncio.TimeoutError:
+        await loop.run_in_executor(None, lambda: stop_event.wait(timeout=10))
+        if stop_event.is_set():
+            logger.info("auto-summary 后台循环：启动延迟期间收到停止信号，退出")
+            return
+    except Exception:
         pass
 
     while not stop_event.is_set():
-        cfg = get_global_config_manager().get_auto_summary_config()
+        gm = get_global_config_manager()
+        cfg = gm.get_auto_summary_config()
         interval_sec = max(60, cfg.interval_minutes * 60)
 
         if cfg.enabled:
             try:
-                summary = await loop.run_in_executor(None, _tick_once)
+                summary = await loop.run_in_executor(None, _tick_once, stop_event)
                 logger.info("auto-summary tick: %s", summary)
             except Exception as e:
                 logger.exception("auto-summary tick 异常: %s", e)
@@ -77,9 +82,12 @@ async def auto_summary_loop(stop_event: asyncio.Event) -> None:
             logger.debug("auto-summary 处于禁用状态，等待下一轮")
 
         try:
-            await asyncio.wait_for(stop_event.wait(), timeout=interval_sec)
-            break  # stop_event 已 set
-        except asyncio.TimeoutError:
+            await loop.run_in_executor(
+                None, lambda: stop_event.wait(timeout=interval_sec)
+            )
+            # wait 返回 True → stop_event 已 set
+            break
+        except Exception:
             continue
 
     logger.info("auto-summary 后台循环已退出")

--- a/jfox/auto_summary/loop.py
+++ b/jfox/auto_summary/loop.py
@@ -61,11 +61,11 @@ async def auto_summary_loop(stop_event: threading.Event) -> None:
     # 启动后短暂延迟，让 daemon 完成模型加载
     try:
         await loop.run_in_executor(None, lambda: stop_event.wait(timeout=10))
-        if stop_event.is_set():
-            logger.info("auto-summary 后台循环：启动延迟期间收到停止信号，退出")
-            return
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("auto-summary 启动延迟等待异常: %s", e)
+    if stop_event.is_set():
+        logger.info("auto-summary 后台循环：启动延迟期间收到停止信号，退出")
+        return
 
     while not stop_event.is_set():
         gm = get_global_config_manager()
@@ -82,12 +82,14 @@ async def auto_summary_loop(stop_event: threading.Event) -> None:
             logger.debug("auto-summary 处于禁用状态，等待下一轮")
 
         try:
-            await loop.run_in_executor(
+            was_set = await loop.run_in_executor(
                 None, lambda: stop_event.wait(timeout=interval_sec)
             )
-            # wait 返回 True → stop_event 已 set
-            break
-        except Exception:
+            if was_set:
+                break  # stop_event 已 set，退出循环
+            # timeout 到期，继续下一轮
+        except Exception as e:
+            logger.warning("auto-summary 等待间隔异常: %s", e)
             continue
 
     logger.info("auto-summary 后台循环已退出")

--- a/jfox/auto_summary/loop.py
+++ b/jfox/auto_summary/loop.py
@@ -61,7 +61,9 @@ async def auto_summary_loop(stop_event: threading.Event) -> None:
     # 启动后短暂延迟，让 daemon 完成模型加载
     try:
         await loop.run_in_executor(None, lambda: stop_event.wait(timeout=10))
-    except Exception as e:
+    except RuntimeError as e:
+        # run_in_executor 在 event loop 关闭时抛 RuntimeError；
+        # 延迟失败不应导致 daemon 崩溃
         logger.warning("auto-summary 启动延迟等待异常: %s", e)
     if stop_event.is_set():
         logger.info("auto-summary 后台循环：启动延迟期间收到停止信号，退出")
@@ -77,6 +79,7 @@ async def auto_summary_loop(stop_event: threading.Event) -> None:
                 summary = await loop.run_in_executor(None, _tick_once, stop_event)
                 logger.info("auto-summary tick: %s", summary)
             except Exception as e:
+                # daemon 后台循环的顶层 catch-all：任何 tick 内部异常都不应导致 daemon 崩溃
                 logger.exception("auto-summary tick 异常: %s", e)
         else:
             logger.debug("auto-summary 处于禁用状态，等待下一轮")
@@ -88,7 +91,8 @@ async def auto_summary_loop(stop_event: threading.Event) -> None:
             if was_set:
                 break  # stop_event 已 set，退出循环
             # timeout 到期，继续下一轮
-        except Exception as e:
+        except RuntimeError as e:
+            # run_in_executor 在 event loop 关闭时可能抛 RuntimeError
             logger.warning("auto-summary 等待间隔异常: %s", e)
             continue
 

--- a/jfox/auto_summary/runner.py
+++ b/jfox/auto_summary/runner.py
@@ -14,6 +14,7 @@ import os
 import re
 import shutil
 import subprocess
+import threading
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -352,7 +353,7 @@ def _run_claude(
     cwd: str,
     env: dict[str, str],
     shell: bool = False,
-    stop_event: Optional[object] = None,
+    stop_event: Optional[threading.Event] = None,
 ) -> str:
     """执行子命令，支持 stop_event 中断。
 
@@ -373,6 +374,15 @@ def _run_claude(
         env=env,
         shell=shell,
     )
+
+    # 后台线程读取 stderr，防止管道缓冲区满导致死锁
+    stderr_chunks: list[str] = []
+    stderr_thread = threading.Thread(
+        target=lambda: stderr_chunks.append(proc.stderr.read()),
+        daemon=True,
+    )
+    stderr_thread.start()
+
     try:
         if input_text:
             proc.stdin.write(input_text)
@@ -389,6 +399,7 @@ def _run_claude(
                     proc.wait(timeout=5)
                 except subprocess.TimeoutExpired:
                     proc.kill()
+                    proc.wait()
                 raise RuntimeError("Claude subprocess interrupted by stop signal")
 
             if proc.poll() is not None:
@@ -401,19 +412,25 @@ def _run_claude(
                 proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 proc.kill()
+                proc.wait()
             raise TimeoutError(f"Subprocess timed out after {timeout}s")
 
+        stderr_thread.join(timeout=5)
+        stderr_text = "".join(stderr_chunks)
+
         if proc.returncode != 0:
-            stderr = (proc.stderr.read() or "").strip()[:500]
+            stderr = stderr_text.strip()[:500]
             raise RuntimeError(f"Subprocess exited {proc.returncode}: {stderr or '(no stderr)'}")
 
         out = (proc.stdout.read() or "").strip()
         if not out:
-            stderr_hint = (proc.stderr.read() or "").strip()[:200]
+            stderr_hint = stderr_text.strip()[:200]
             raise RuntimeError(f"Empty stdout (stderr: {stderr_hint or '(none)'})")
         return out
     except Exception:
-        proc.kill()
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
         raise
 
 

--- a/jfox/auto_summary/runner.py
+++ b/jfox/auto_summary/runner.py
@@ -377,8 +377,8 @@ def _run_claude(
         if input_text:
             proc.stdin.write(input_text)
         proc.stdin.close()
-    except (BrokenPipeError, OSError):
-        pass
+    except (BrokenPipeError, OSError) as e:
+        logger.warning("子进程 stdin 写入失败（进程可能已提前退出）: %s", e)
 
     try:
         deadline = _time.monotonic() + timeout

--- a/jfox/auto_summary/runner.py
+++ b/jfox/auto_summary/runner.py
@@ -352,14 +352,13 @@ def _run_claude(
     cwd: str,
     env: dict[str, str],
     shell: bool = False,
-    stop_event: Optional["threading.Event"] = None,
+    stop_event: Optional[object] = None,
 ) -> str:
     """执行子命令，支持 stop_event 中断。
 
     使用 Popen + 轮询代替 subprocess.run，使 stop_event.set() 能在 ~1s 内
     终止子进程，而非等待整个 timeout。
     """
-    import threading
     import time as _time
 
     proc = subprocess.Popen(
@@ -420,8 +419,6 @@ def _run_claude(
 
 def _invoke_claude(extracted_dialog_text: str, cfg: AutoSummaryConfig) -> str:
     """调用 claude -p，返回原始 stdout（非空字符串）"""
-    import threading
-
     binary = _resolve_claude_binary(cfg)
     cwd = isolated_runs_dir()
 

--- a/jfox/auto_summary/runner.py
+++ b/jfox/auto_summary/runner.py
@@ -345,8 +345,83 @@ def _build_user_prompt(session_file: SessionFile, extracted) -> str:
     return "\n".join(lines)
 
 
+def _run_claude(
+    cmd: list[str],
+    input_text: str,
+    timeout: int,
+    cwd: str,
+    env: dict[str, str],
+    shell: bool = False,
+    stop_event: Optional["threading.Event"] = None,
+) -> str:
+    """执行子命令，支持 stop_event 中断。
+
+    使用 Popen + 轮询代替 subprocess.run，使 stop_event.set() 能在 ~1s 内
+    终止子进程，而非等待整个 timeout。
+    """
+    import threading
+    import time as _time
+
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        cwd=cwd,
+        env=env,
+        shell=shell,
+    )
+    try:
+        if input_text:
+            proc.stdin.write(input_text)
+        proc.stdin.close()
+    except (BrokenPipeError, OSError):
+        pass
+
+    try:
+        deadline = _time.monotonic() + timeout
+        while _time.monotonic() < deadline:
+            if stop_event and stop_event.is_set():
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                raise RuntimeError("Claude subprocess interrupted by stop signal")
+
+            if proc.poll() is not None:
+                break
+            _time.sleep(1)
+
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            raise TimeoutError(f"Subprocess timed out after {timeout}s")
+
+        if proc.returncode != 0:
+            stderr = (proc.stderr.read() or "").strip()[:500]
+            raise RuntimeError(f"Subprocess exited {proc.returncode}: {stderr or '(no stderr)'}")
+
+        out = (proc.stdout.read() or "").strip()
+        if not out:
+            stderr_hint = (proc.stderr.read() or "").strip()[:200]
+            raise RuntimeError(f"Empty stdout (stderr: {stderr_hint or '(none)'})")
+        return out
+    except Exception:
+        proc.kill()
+        raise
+
+
 def _invoke_claude(extracted_dialog_text: str, cfg: AutoSummaryConfig) -> str:
     """调用 claude -p，返回原始 stdout（非空字符串）"""
+    import threading
+
     binary = _resolve_claude_binary(cfg)
     cwd = isolated_runs_dir()
 
@@ -369,35 +444,29 @@ def _invoke_claude(extracted_dialog_text: str, cfg: AutoSummaryConfig) -> str:
     for noisy in ("JFOX_KB", "JFOX_DAEMON_PROCESS"):
         env.pop(noisy, None)
 
+    stop_event = getattr(cfg, "_stop_event", None)
+
     try:
-        proc = subprocess.run(
-            cmd,
-            input=extracted_dialog_text,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            cwd=str(cwd),
+        return _run_claude(
+            cmd=cmd,
+            input_text=extracted_dialog_text,
             timeout=max(30, cfg.claude_timeout_seconds),
+            cwd=str(cwd),
             env=env,
             shell=use_shell,
+            stop_event=stop_event,
         )
-    except subprocess.TimeoutExpired as e:
+    except TimeoutError as e:
         raise _ClaudeInvocationError(f"claude -p 超时（{cfg.claude_timeout_seconds}s）") from e
+    except RuntimeError as e:
+        msg = str(e)
+        if "interrupted" in msg.lower():
+            raise
+        if "exited" in msg or "Empty stdout" in msg:
+            raise _ClaudeInvocationError(msg) from e
+        raise
     except OSError as e:
         raise _ClaudeInvocationError(f"启动 claude 失败: {e}") from e
-
-    if proc.returncode != 0:
-        stderr = (proc.stderr or "").strip()[:500]
-        raise _ClaudeInvocationError(
-            f"claude -p 退出码 {proc.returncode}: {stderr or '(no stderr)'}"
-        )
-
-    out = (proc.stdout or "").strip()
-    if not out:
-        stderr_hint = (proc.stderr or "").strip()[:200]
-        raise _ClaudeInvocationError(f"claude -p 返回空 stdout (stderr: {stderr_hint or '(none)'})")
-    return out
 
 
 def _parse_claude_json(stdout: str) -> dict[str, Any]:

--- a/jfox/daemon/server.py
+++ b/jfox/daemon/server.py
@@ -9,6 +9,7 @@ import argparse
 import asyncio
 import logging
 import os
+import threading
 from contextlib import asynccontextmanager
 from typing import List, Optional
 
@@ -25,7 +26,7 @@ _server = None
 
 # auto-summary 后台 task 与停止信号
 _auto_summary_task: Optional[asyncio.Task] = None
-_auto_summary_stop_event: Optional[asyncio.Event] = None
+_auto_summary_stop_event: Optional[threading.Event] = None
 
 
 def _load_model():
@@ -60,7 +61,7 @@ def _maybe_start_auto_summary() -> None:
             logger.info("Daemon: auto-summary 未启用（config.auto_summary.enabled=false）")
             return
 
-        _auto_summary_stop_event = asyncio.Event()
+        _auto_summary_stop_event = threading.Event()
         _auto_summary_task = asyncio.create_task(auto_summary_loop(_auto_summary_stop_event))
         logger.info(
             "Daemon: auto-summary 后台循环已启动 (interval=%dm, idle_threshold=%dm)",
@@ -78,19 +79,17 @@ async def _maybe_stop_auto_summary() -> None:
         _auto_summary_stop_event.set()
     if _auto_summary_task is not None:
         try:
-            await asyncio.wait_for(_auto_summary_task, timeout=5)
+            # stop_event 已 set，_run_claude 会在 ~1s 内终止子进程
+            await asyncio.wait_for(_auto_summary_task, timeout=10)
         except asyncio.TimeoutError:
-            logger.warning("Daemon: auto-summary task 5s 内未退出，取消之")
+            logger.warning("Daemon: auto-summary task 10s 内未退出，取消之")
             _auto_summary_task.cancel()
-            # 等待 cancel 实际生效；如果 task 阻塞在 executor 的 claude -p 上，
-            # task.cancel() 不会终止 subprocess，仍会阻塞，但等到子进程超时（cfg.claude_timeout_seconds）后会返回
             try:
                 await asyncio.gather(_auto_summary_task, return_exceptions=True)
             except Exception as inner:
                 logger.warning("Daemon: 等待 auto-summary 取消时异常: %s", inner)
         except Exception as e:
             logger.warning("Daemon: 等待 auto-summary 退出时异常: %s", e)
-            _auto_summary_task.cancel()
     _auto_summary_task = None
     _auto_summary_stop_event = None
 

--- a/jfox/daemon/server.py
+++ b/jfox/daemon/server.py
@@ -90,6 +90,11 @@ async def _maybe_stop_auto_summary() -> None:
                 logger.warning("Daemon: 等待 auto-summary 取消时异常: %s", inner)
         except Exception as e:
             logger.warning("Daemon: 等待 auto-summary 退出时异常: %s", e)
+            _auto_summary_task.cancel()
+            try:
+                await asyncio.gather(_auto_summary_task, return_exceptions=True)
+            except Exception:
+                pass
     _auto_summary_task = None
     _auto_summary_stop_event = None
 

--- a/jfox/global_config.py
+++ b/jfox/global_config.py
@@ -232,11 +232,11 @@ class GlobalConfigManager:
             )
 
     def _save(self) -> bool:
-        """保存配置到文件"""
+        """原子保存配置到文件（tempfile + os.replace）"""
         try:
-            self.config_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(self.config_path, "w", encoding="utf-8") as f:
-                json.dump(self._config.to_dict(), f, ensure_ascii=False, indent=2)
+            from jfox.utils import atomic_write_json
+
+            atomic_write_json(self.config_path, self._config.to_dict())
             logger.debug(f"Saved global config to {self.config_path}")
             return True
         except Exception as e:

--- a/jfox/global_config.py
+++ b/jfox/global_config.py
@@ -80,6 +80,8 @@ class AutoSummaryConfig:
             self.min_session_size_kb = max(0, self.max_session_size_mb * 1024 - 1)
         if isinstance(self.target_kb, str) and not self.target_kb.strip():
             self.target_kb = None
+        # 运行时 stop_event，由 daemon loop 注入，不序列化
+        object.__setattr__(self, "_stop_event", None)
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)

--- a/jfox/utils.py
+++ b/jfox/utils.py
@@ -1,0 +1,29 @@
+"""共享工具函数。"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write_json(path: Path, data: dict, *, indent: int = 2) -> None:
+    """原子写入 JSON 文件：写临时文件 → os.replace 覆盖。
+
+    异常时自动清理临时文件。os.replace 在所有主流 OS 上是原子的。
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=indent)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise

--- a/jfox/utils.py
+++ b/jfox/utils.py
@@ -14,9 +14,7 @@ def atomic_write_json(path: Path, data: dict, *, indent: int = 2) -> None:
     异常时自动清理临时文件。os.replace 在所有主流 OS 上是原子的。
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_path = tempfile.mkstemp(
-        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent)
-    )
+    fd, tmp_path = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(data, f, ensure_ascii=False, indent=indent)

--- a/tests/unit/test_auto_summary_ledger.py
+++ b/tests/unit/test_auto_summary_ledger.py
@@ -124,3 +124,64 @@ class TestLedger:
         assert led.all_entries() == {}
         # 写入仍然能工作
         assert led.record_success("sid", "p", "n")
+
+
+from jfox.utils import atomic_write_json as _atomic_write_json
+
+
+class TestLedgerCAS:
+    """测试 ledger 的 compare-and-swap 并发保护"""
+
+    def test_cas_writes_succeed_when_no_conflict(self, tmp_path):
+        """无并发时正常写入"""
+        path = tmp_path / "cas.json"
+        led = Ledger(path=path)
+        led.record_success("sid1", "proj", "n1")
+        assert led.get("sid1") is not None
+        assert led.get("sid1").status == SessionStatus.SUCCESS.value
+
+    def test_cas_retries_on_mtime_conflict(self, tmp_path):
+        """mtime 被外部修改后，CAS 应重试成功"""
+        import json as _json
+        import time
+
+        path = tmp_path / "cas2.json"
+        led = Ledger(path=path)
+        led.record_success("sid1", "proj", "n1")
+
+        time.sleep(0.05)
+        raw = _json.loads(path.read_text(encoding="utf-8"))
+        raw["sessions"]["ext_sid"] = {
+            "project": "ext",
+            "processed_at": "2026-01-01T00:00:00",
+            "status": "success",
+            "note_id": "ext_note",
+            "retry_count": 0,
+            "last_error": None,
+        }
+        _atomic_write_json(path, raw)
+
+        led.record_success("sid2", "proj", "n2")
+
+        led2 = Ledger(path=path)
+        assert led2.get("ext_sid") is not None
+        assert led2.get("sid2") is not None
+
+    def test_cas_raises_after_max_retries(self, tmp_path):
+        """持续冲突 3 次后应抛 RuntimeError"""
+        from unittest.mock import patch
+
+        path = tmp_path / "cas3.json"
+        led = Ledger(path=path)
+        led.record_success("sid1", "proj", "n1")
+
+        with patch.object(led, "_save_cas", return_value=False):
+            with pytest.raises(RuntimeError, match="CAS conflict"):
+                led.record_success("sid2", "proj", "n2")
+
+    def test_cas_handles_missing_file(self, tmp_path):
+        """文件不存在时 mtime 比较应跳过，直接写入"""
+        path = tmp_path / "new.json"
+        led = Ledger(path=path)
+        led.record_success("sid1", "proj", "n1")
+        assert led.get("sid1") is not None

--- a/tests/unit/test_auto_summary_runner.py
+++ b/tests/unit/test_auto_summary_runner.py
@@ -7,7 +7,9 @@
 
 import json
 import subprocess
-from unittest.mock import patch
+import threading
+import time
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -123,10 +125,17 @@ def ledger(tmp_path):
     return Ledger(path=tmp_path / "state.json", max_retries=3)
 
 
-def _make_completed_proc(stdout, returncode=0, stderr=""):
-    return subprocess.CompletedProcess(
-        args=["claude", "-p"], returncode=returncode, stdout=stdout, stderr=stderr
-    )
+def _make_popen_mock(stdout="", returncode=0, stderr=""):
+    """创建 mock Popen 实例，模拟子进程立即完成（首次 poll 即返回 returncode）。"""
+    mock_proc = MagicMock()
+    mock_proc.poll.return_value = returncode
+    mock_proc.returncode = returncode
+    mock_proc.stdout.read.return_value = stdout
+    mock_proc.stderr.read.return_value = stderr
+    mock_proc.wait.return_value = returncode
+    mock_proc.terminate.return_value = None
+    mock_proc.kill.return_value = None
+    return mock_proc
 
 
 def test_summarize_one_success(tmp_path, ledger, fake_cfg):
@@ -142,7 +151,7 @@ def test_summarize_one_success(tmp_path, ledger, fake_cfg):
 
     with (
         patch.object(runner_module, "_resolve_claude_binary", return_value="claude"),
-        patch.object(subprocess, "run", return_value=_make_completed_proc(fake_stdout)),
+        patch("subprocess.Popen", return_value=_make_popen_mock(stdout=fake_stdout)),
         patch.object(runner_module, "_save_session_note", return_value="20260519T100000"),
     ):
         result = summarize_one(sf, cfg=fake_cfg, ledger=ledger)
@@ -169,7 +178,7 @@ def test_summarize_one_claude_marks_skip(tmp_path, ledger, fake_cfg):
 
     with (
         patch.object(runner_module, "_resolve_claude_binary", return_value="claude"),
-        patch.object(subprocess, "run", return_value=_make_completed_proc(fake_stdout)),
+        patch("subprocess.Popen", return_value=_make_popen_mock(stdout=fake_stdout)),
         patch.object(runner_module, "_save_session_note") as save_mock,
     ):
         result = summarize_one(sf, cfg=fake_cfg, ledger=ledger)
@@ -183,11 +192,10 @@ def test_summarize_one_claude_marks_skip(tmp_path, ledger, fake_cfg):
 
 def test_summarize_one_claude_nonzero_exit_marks_failure(tmp_path, ledger, fake_cfg):
     sf = _make_session_jsonl(tmp_path, sid="fail0001")
-    proc = _make_completed_proc("", returncode=2, stderr="boom")
 
     with (
         patch.object(runner_module, "_resolve_claude_binary", return_value="claude"),
-        patch.object(subprocess, "run", return_value=proc),
+        patch("subprocess.Popen", return_value=_make_popen_mock(returncode=2, stderr="boom")),
     ):
         result = summarize_one(sf, cfg=fake_cfg, ledger=ledger)
 
@@ -199,11 +207,13 @@ def test_summarize_one_claude_nonzero_exit_marks_failure(tmp_path, ledger, fake_
 
 def test_summarize_one_invalid_json_marks_failure(tmp_path, ledger, fake_cfg):
     sf = _make_session_jsonl(tmp_path, sid="parse001")
-    proc = _make_completed_proc('{"result": "not a json object at all"}')
 
     with (
         patch.object(runner_module, "_resolve_claude_binary", return_value="claude"),
-        patch.object(subprocess, "run", return_value=proc),
+        patch(
+            "subprocess.Popen",
+            return_value=_make_popen_mock(stdout='{"result": "not a json object at all"}'),
+        ),
     ):
         result = summarize_one(sf, cfg=fake_cfg, ledger=ledger)
 
@@ -228,11 +238,11 @@ def test_summarize_one_empty_dialog_skips_without_calling_claude(tmp_path, ledge
         size_bytes=p.stat().st_size,
     )
 
-    with patch.object(subprocess, "run") as run_mock:
+    with patch("subprocess.Popen") as popen_mock:
         result = summarize_one(sf, cfg=fake_cfg, ledger=ledger)
 
     assert result.outcome == SummaryOutcome.SKIPPED
-    run_mock.assert_not_called()
+    popen_mock.assert_not_called()
 
 
 def test_summarize_one_empty_summary_md_marks_failure(tmp_path, ledger, fake_cfg):
@@ -249,7 +259,7 @@ def test_summarize_one_empty_summary_md_marks_failure(tmp_path, ledger, fake_cfg
 
     with (
         patch.object(runner_module, "_resolve_claude_binary", return_value="claude"),
-        patch.object(subprocess, "run", return_value=_make_completed_proc(fake_stdout)),
+        patch("subprocess.Popen", return_value=_make_popen_mock(stdout=fake_stdout)),
         patch.object(runner_module, "_save_session_note") as save_mock,
     ):
         result = summarize_one(sf, cfg=fake_cfg, ledger=ledger)
@@ -263,12 +273,18 @@ def test_summarize_one_empty_summary_md_marks_failure(tmp_path, ledger, fake_cfg
 def test_summarize_one_timeout_marks_failure(tmp_path, ledger, fake_cfg):
     sf = _make_session_jsonl(tmp_path, sid="timeout1")
 
-    def raise_timeout(*args, **kwargs):
-        raise subprocess.TimeoutExpired(cmd=args[0], timeout=10)
+    # _run_claude 超时后会 raise TimeoutError，_invoke_claude 捕获后包装为
+    # _ClaudeInvocationError（包含"超时"字样），summarize_one 再记录为 FAILED
+    mock_proc = MagicMock()
+    mock_proc.poll.return_value = None  # 永远不退出
+    mock_proc.wait.return_value = 0
+    mock_proc.terminate.return_value = None
+    mock_proc.kill.return_value = None
 
     with (
         patch.object(runner_module, "_resolve_claude_binary", return_value="claude"),
-        patch.object(subprocess, "run", side_effect=raise_timeout),
+        patch("subprocess.Popen", return_value=mock_proc),
+        patch("time.monotonic", side_effect=[0.0, 1.0, 999.0]),  # deadline 超过
     ):
         result = summarize_one(sf, cfg=fake_cfg, ledger=ledger)
 
@@ -362,3 +378,101 @@ def test_run_once_dry_run_skips_summarize(tmp_path, fake_cfg):
     assert report.scanned == 1
     assert report.processed == 0
     summarize_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _run_claude interruptibility tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunClaudeInterruptible:
+    """测试 _run_claude 的 stop_event 可中断性"""
+
+    def _default_kwargs(self, tmp_path):
+        return dict(
+            cmd=["claude", "-p"],
+            input_text="test prompt",
+            timeout=30,
+            cwd=str(tmp_path),
+            env={"PATH": "/usr/bin"},
+            shell=False,
+        )
+
+    def test_normal_completion(self, tmp_path):
+        """正常完成：stop_event 未设置，返回 stdout"""
+        from jfox.auto_summary.runner import _run_claude
+
+        with patch("subprocess.Popen") as mock_popen, patch("time.sleep"):
+            proc = mock_popen.return_value
+            # 第一次 poll 返回 None（sleep），第二次返回 0（break），第三次被循环后检查调用
+            proc.poll.side_effect = [None, 0, 0]
+            proc.returncode = 0
+            proc.stdout.read.return_value = '{"result": "ok"}'
+            proc.stderr.read.return_value = ""
+
+            result = _run_claude(**self._default_kwargs(tmp_path))
+            assert result == '{"result": "ok"}'
+
+    def test_stop_event_terminates_subprocess(self, tmp_path):
+        """stop_event.set() 后子进程应被 terminate"""
+        from jfox.auto_summary.runner import _run_claude
+
+        stop = threading.Event()
+
+        with patch("subprocess.Popen") as mock_popen, patch("time.sleep"):
+            proc = mock_popen.return_value
+
+            poll_count = {"n": 0}
+
+            def poll_side_effect():
+                poll_count["n"] += 1
+                if poll_count["n"] > 10:
+                    return 0
+                return None
+
+            proc.poll.side_effect = poll_side_effect
+            proc.wait.return_value = 0
+            proc.returncode = 0
+            proc.stdout.read.return_value = ""
+
+            def set_stop_later():
+                time.sleep(0.01)
+                stop.set()
+
+            t = threading.Thread(target=set_stop_later)
+            t.start()
+
+            with pytest.raises(RuntimeError, match="interrupted"):
+                _run_claude(**self._default_kwargs(tmp_path), stop_event=stop)
+
+            t.join()
+            proc.terminate.assert_called()
+
+    def test_timeout_terminates_subprocess(self, tmp_path):
+        """超时后子进程应被 terminate"""
+        from jfox.auto_summary.runner import _run_claude
+
+        with patch("subprocess.Popen") as mock_popen, patch("time.sleep"):
+            proc = mock_popen.return_value
+            proc.poll.return_value = None
+            proc.wait.return_value = 0
+
+            with patch("time.monotonic", side_effect=[0, 0.5, 1.5]):
+                with pytest.raises(TimeoutError, match="timed out"):
+                    _run_claude(**{**self._default_kwargs(tmp_path), "timeout": 1})
+
+            proc.terminate.assert_called()
+
+    def test_nonzero_exit_raises(self, tmp_path):
+        """非零退出码应抛异常"""
+        from jfox.auto_summary.runner import _run_claude
+
+        with patch("subprocess.Popen") as mock_popen, patch("time.sleep"):
+            proc = mock_popen.return_value
+            # 第一次 poll 返回 None（sleep），第二次返回 0（break），第三次循环后检查
+            proc.poll.side_effect = [None, 0, 0]
+            proc.returncode = 1
+            proc.stderr.read.return_value = "error msg"
+
+            with pytest.raises(RuntimeError, match="exited 1"):
+                _run_claude(**self._default_kwargs(tmp_path))

--- a/tests/unit/test_auto_summary_runner.py
+++ b/tests/unit/test_auto_summary_runner.py
@@ -468,8 +468,8 @@ class TestRunClaudeInterruptible:
 
         with patch("subprocess.Popen") as mock_popen, patch("time.sleep"):
             proc = mock_popen.return_value
-            # 第一次 poll 返回 None（sleep），第二次返回 0（break），第三次循环后检查
-            proc.poll.side_effect = [None, 0, 0]
+            # poll 调用链：loop sleep → break → timeout check → except 存活检查
+            proc.poll.side_effect = [None, 0, 0, 0]
             proc.returncode = 1
             proc.stderr.read.return_value = "error msg"
 

--- a/tests/unit/test_auto_summary_runner.py
+++ b/tests/unit/test_auto_summary_runner.py
@@ -6,7 +6,6 @@
 """
 
 import json
-import subprocess
 import threading
 import time
 from unittest.mock import MagicMock, patch


### PR DESCRIPTION
## Summary

闭环 PR #223 (auto-summary daemon) 的 4 个 CR 遗留问题。

### §1+2+3: 原子写入
- 提取 `jfox/utils.py` 中的 `atomic_write_json()` 共享工具函数
- `global_config._save()` 改用原子写入（修复进程崩溃可丢配置的 bug）
- `ledger._save()` 改为复用同一函数，消除重复代码

### §2: Ledger CAS 并发保护
- 所有写方法加入 compare-and-swap 重试循环（最多 3 次）
- 基于 `os.path.getmtime()` 检测文件是否被外部进程改过
- daemon + CLI 并发写入时自动重试，不丢数据

### §3: 可控子进程关闭
- `subprocess.run()` 替换为 `Popen` + 轮询循环
- `stop_event` 每秒检查一次，daemon shutdown 时 ~1s 内 terminate 子进程（而非等 120s）
- 切换到 `threading.Event`（executor 线程可检查）
- `_maybe_stop_auto_summary` 恢复 generic except 中的 `cancel()`

### §4: CLI 惯例说明
- 在 `auto_summary/cli.py` 添加设计决策注释

## CR 修复

三个 review agent 一致发现关键 Bug 并已修复：
- `auto_summary_loop` 无条件 break → 检查 `stop_event.wait()` 返回值
- stdin 写失败被 pass 吞掉 → 加日志
- bare except 无日志 → 加 warning

## Test Plan

- 新增 8 个测试（4 CAS + 4 interruptible Popen）
- 全部 432 个快速单元测试通过
- ruff lint 通过

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)