### PR TITLE
chore: bump version to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to jfox-cli will be documented in this file.
 
+## [0.10.0] - 2026-06-06
+
+### Features
+- **auto-summary**: progress visibility + remove 7-day scan limit (#235)
+- **daemon**: interactive auto-summary prompt on daemon start (#233)
+- add pi skills and package.json for pi-package support
+- **daemon**: add restart command
+
+### Fixes
+- Issue #224 CR leftovers — atomic write + CAS + interruptible Popen + threading.Event (#236)
+
+### Changes
+- **README**: add auto-summary section with implementation details
+- ignore pr-monitor state and tmp issue body files
+- add superpowers plans and spec for recent work
+
+[0.10.0]: https://github.com/zhuxixi/jfox/compare/v0.9.0...v0.10.0
+
 ## [0.9.0] - 2026-05-22
 
 ### Features

--- a/jfox/__init__.py
+++ b/jfox/__init__.py
@@ -1,5 +1,5 @@
 """JFox - Zettelkasten 知识管理工具"""
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 __author__ = "User"
 __email__ = "user@example.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jfox-cli"
-version = "0.9.0"
+version = "0.10.0"
 description = "JFox - Zettelkasten 知识管理 CLI 工具"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -867,7 +867,7 @@ wheels = [
 
 [[package]]
 name = "jfox-cli"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary
Bump version from 0.9.0 to 0.10.0

## [0.10.0] - 2026-06-06

### Features
- **auto-summary**: progress visibility + remove 7-day scan limit (#235)
- **daemon**: interactive auto-summary prompt on daemon start (#233)
- add pi skills and package.json for pi-package support
- **daemon**: add restart command

### Fixes
- Issue #224 CR leftovers — atomic write + CAS + interruptible Popen + threading.Event (#236)

### Changes
- **README**: add auto-summary section with implementation details
- ignore pr-monitor state and tmp issue body files
- add superpowers plans and spec for recent work

🤖 Generated with [Claude Code](https://claude.com/claude-code)