### PR TITLE
feat: add Kimi Code plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,30 @@ A session is considered "finished" when its file has not been modified for `idle
 
 ---
 
+## Agent Plugins
+
+JFox 提供主流 AI Agent 的插件/技能集成：
+
+### Claude Code
+
+- 插件目录：`packages/cc-plugin/`
+- 安装（marketplace 上架后）：`/plugin marketplace add zhuxixi/jfox`
+- 包含 5 个 skill：manage、search、ingest、organize、session-summary
+
+### Kimi Code CLI
+
+- 插件目录：`packages/kimi-plugin/`
+- 安装：在 Kimi Code CLI TUI 中执行 `/plugins install github:zhuxixi/jfox?path=packages/kimi-plugin`，或使用本地 zip
+- 包含 6 个 skill：`using-jfox`（会话启动自动加载）、`jfox-manage`、`jfox-search`、`jfox-ingest`、`jfox-organize`、`jfox-session-summary`
+- 详见：`packages/kimi-plugin/README.md`
+
+### 其他 Agent
+
+- `skills-recommend/pi/` 提供 pi coding agent 的技能包
+- `skills-recommend/kimi-cli/` 保留旧版 Kimi CLI 手动复制 skill（已弃用）
+
+---
+
 ## Note Format
 
 ### Directory Structure

--- a/packages/kimi-plugin/README.md
+++ b/packages/kimi-plugin/README.md
@@ -1,0 +1,107 @@
+# JFox Kimi Code Plugin
+
+JFox 知识管理 CLI 的 [Kimi Code CLI](https://www.kimi.com/code) 插件。
+
+## 功能
+
+提供与 Claude Code 插件 `packages/cc-plugin/` 对齐的 5 个核心 skill：
+
+| Skill | 用途 | 触发示例 |
+|-------|------|----------|
+| `jfox-manage` | 知识库管理、笔记 CRUD、健康检查 | “创建知识库”、“知识库体检” |
+| `jfox-search` | 搜索笔记、图谱查询、链接推荐 | “搜索 jfox 笔记”、“推荐链接” |
+| `jfox-ingest` | 从 Git 仓库导入 git log / PR / Issues | “导入这个仓库” |
+| `jfox-organize` | 整理知识库、提炼 permanent 笔记 | “整理知识库”、“清理 inbox” |
+| `jfox-session-summary` | 把当前会话总结写入知识库 | “保存这次会话”、“总结到知识库” |
+
+此外，`using-jfox` skill 会在每次新会话/恢复会话时自动加载，提供环境检查和命令速查。
+
+## 前置条件
+
+- Kimi Code CLI >= 0.2.0（本插件使用 `~/.kimi-code/skills/` 迁移后的插件机制）
+- jfox CLI 已安装：
+  ```bash
+  uv tool install jfox-cli
+  ```
+
+## 安装
+
+### 方式一：本地 zip 安装（开发测试）
+
+```bash
+cd packages/kimi-plugin
+zip -r /tmp/jfox-kimi-plugin.zip .
+```
+
+在 Kimi Code CLI 中：
+
+```bash
+/plugins install /tmp/jfox-kimi-plugin.zip
+/new
+```
+
+### 方式二：从 GitHub 安装（推荐）
+
+等待 marketplace 上架后：
+
+```bash
+/plugins install github:zhuxixi/jfox?path=packages/kimi-plugin
+/new
+```
+
+> 具体 git URL 格式以 Kimi Code CLI 当时支持的为准。
+
+### 方式三：本地目录（热更新开发）
+
+```bash
+/plugins install /path/to/jfox/packages/kimi-plugin
+/new
+```
+
+修改 skill 文件后，使用 `/reload` 或重启会话生效。
+
+## 验证
+
+```bash
+/plugins info jfox
+/skill:jfox-manage
+```
+
+## 与 Claude Code 插件的差异
+
+| 项目 | Claude Code (`packages/cc-plugin`) | Kimi Code (`packages/kimi-plugin`) |
+|------|------------------------------------|------------------------------------|
+| 插件 manifest | `.claude-plugin/plugin.json` | `kimi.plugin.json` |
+| Skill 引用语法 | `/jfox:manage` | `/skill:jfox-manage` |
+| 自动加载 | 无（marketplace 机制不同） | `sessionStart.skill` 自动加载 `using-jfox` |
+| 核心技能 | manage / search / ingest / organize / session-summary | jfox-manage / jfox-search / jfox-ingest / jfox-organize / jfox-session-summary |
+
+## 文件结构
+
+```text
+packages/kimi-plugin/
+├── kimi.plugin.json
+├── README.md
+└── skills/
+    ├── using-jfox/
+    │   └── SKILL.md
+    ├── jfox-manage/
+    │   └── SKILL.md
+    ├── jfox-search/
+    │   └── SKILL.md
+    ├── jfox-ingest/
+    │   └── SKILL.md
+    ├── jfox-organize/
+    │   └── SKILL.md
+    └── jfox-session-summary/
+        └── SKILL.md
+```
+
+## 已知限制
+
+- 本插件通过 `Bash` 调用本地 `jfox` CLI，因此依赖用户已安装 `jfox-cli` 并正确配置 PATH。
+- 当前未提供 MCP server；后续可能通过 MCP 封装高频命令以提升稳定性。
+
+## 许可证
+
+MIT

--- a/packages/kimi-plugin/kimi.plugin.json
+++ b/packages/kimi-plugin/kimi.plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "jfox",
+  "version": "0.10.0",
+  "description": "JFox 知识管理 CLI 的 Kimi Code 集成——搜索、写入工作流（导入/整理/会话总结）与知识库管理",
+  "skills": "./skills/",
+  "sessionStart": {
+    "skill": "using-jfox"
+  },
+  "interface": {
+    "displayName": "JFox",
+    "shortDescription": "JFox Zettelkasten 知识管理集成",
+    "longDescription": "为 Kimi Code CLI 提供 JFox 知识库管理、笔记搜索、仓库导入、知识整理和会话总结保存能力。需要本地已安装 jfox-cli。",
+    "developerName": "zhuxixi",
+    "websiteURL": "https://github.com/zhuxixi/jfox"
+  },
+  "keywords": ["zettelkasten", "knowledge-management", "jfox", "notes"],
+  "author": { "name": "zhuxixi" },
+  "homepage": "https://github.com/zhuxixi/jfox",
+  "repository": "https://github.com/zhuxixi/jfox",
+  "license": "MIT"
+}

--- a/packages/kimi-plugin/skills/jfox-ingest/SKILL.md
+++ b/packages/kimi-plugin/skills/jfox-ingest/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: jfox-ingest
+description: Use when user wants to import data from a local git repository into their Zettelkasten as fleeting notes. Triggers on "导入仓库", "导入 git log", "导入 PR", "导入 issues", "读一下这个仓库", "抓取仓库信息", "ingest repo", "import notes from repository", "bulk import from git", "导入项目信息".
+---
+
+# JFox 仓库数据导入
+
+将本地 Git 仓库的 git log、GitHub PRs、GitHub Issues 批量导入为 Zettelkasten 知识库中的 fleeting 笔记。
+
+## 概述
+
+本技能从本地 Git 仓库采集数据，转化为 fleeting 笔记批量导入知识库。支持三种数据源：git log（本地提交记录）、GitHub Pull Requests、GitHub Issues。
+
+## 前置条件
+
+1. 知识库已存在：
+   ```bash
+   jfox kb list --format json
+   ```
+   如果没有知识库，提示用户先调用 manage 技能（`/skill:jfox-manage`）创建。
+
+2. `git` 命令可用。
+
+3. 如需导入 GitHub PR/Issues，`gh` CLI 必须已认证：
+   ```bash
+   gh auth status
+   ```
+
+## 工作流
+
+### Step 1: 确定仓库信息
+
+用户提供本地仓库路径（如 `/home/user/projects/my-app` 或 `C:\Users\me\code\project`）。
+
+检测是否为 GitHub 仓库：
+```bash
+git -C <path> remote get-url origin
+```
+
+检查输出是否包含 `github.com`。如果是，从 URL 中提取 `owner/repo`：
+- `git@github.com:owner/repo.git` → `owner/repo`
+- `https://github.com/owner/repo.git` → `owner/repo`
+
+同时提取仓库名称（`repo` 部分）用于标签，如 `source:my-app`。
+
+### Step 2: 选择数据源
+
+根据用户指令确定导入的数据源：
+
+| 数据源 | 适用场景 | 需要 GitHub |
+|--------|---------|-------------|
+| git-log | 导入提交记录 | 否 |
+| github-pr | 导入 Pull Requests | 是 |
+| github-issue | 导入 Issues | 是 |
+
+如果用户说"导入这个仓库"但未指定数据源，默认导入所有可用数据源（GitHub 仓库导入全部三种，非 GitHub 仓库仅导入 git-log）。
+
+### Step 3: 采集 git log
+
+使用 `jfox ingest-log` 命令（基于 `jfox/git_extractor.py` 模块），一行完成提取 + 转换 + 导入：
+
+```bash
+jfox ingest-log path/to/repo --limit 50 --kb name --type fleeting
+```
+
+该命令会：
+- 调用 `git log` 提取 commit 历史
+- 自动解析为结构化数据（hash, subject, author, date, body）
+- 转换为 fleeting 笔记并批量导入知识库
+- 自动添加标签：`source:repo-name`, `source:git-log`
+
+生成笔记示例：
+```
+Commit: a1b2c3d
+Author: 张三
+Date: 2026-04-10
+
+feat: add user authentication module
+
+实现了 JWT 认证，支持 refresh token 机制。
+```
+
+> **约定**：`jfox ingest-log` 支持 `--format json` 输出 JSON，也可使用快捷方式 `--json`（两者等价）。下文示例统一使用 `--json`。
+
+### Step 4: 采集 GitHub PRs
+
+仅当 Step 1 检测到 GitHub 仓库时执行。
+
+```bash
+gh pr list --repo <owner/repo> --state all --limit 20 --json number,title,body,state,author,createdAt,updatedAt,labels
+```
+
+对于每个 PR，可选获取评论详情：
+```bash
+gh pr view <number> --repo <owner/repo> --json comments
+```
+
+转化为笔记结构：
+
+- **title**: PR 标题
+- **content**: 包含 PR 编号、状态、描述、关键评论、元数据（作者、创建/更新时间、标签）
+- **tags**: `source:<repo-name>`, `source:pr`
+
+示例笔记内容：
+```
+PR #42: Add user authentication
+State: merged
+Author: zhangsan
+Created: 2026-04-01
+Labels: feature, backend
+
+实现了 JWT 认证模块...
+
+Key Comments:
+- @lisi: 建议增加 refresh token 机制
+```
+
+### Step 5: 采集 GitHub Issues
+
+仅当 Step 1 检测到 GitHub 仓库时执行。
+
+```bash
+gh issue list --repo <owner/repo> --state all --limit 30 --json number,title,body,state,author,createdAt,labels,comments
+```
+
+转化为笔记结构：
+
+- **title**: Issue 标题
+- **content**: 包含 Issue 编号、状态、描述、评论、元数据
+- **tags**: `source:<repo-name>`, `source:issue`
+
+示例笔记内容：
+```
+Issue #15: Login page crashes on mobile
+State: closed
+Author: wangwu
+Created: 2026-03-20
+Labels: bug, mobile
+
+在移动端访问登录页面时出现白屏...
+
+Comments:
+- @zhangsan: 已修复，请验证
+```
+
+### Step 6: 导入 GitHub 数据（git-log 已在 Step 3 完成）
+
+git-log 数据已通过 `jfox ingest-log` 完成导入，此步骤仅处理 GitHub PR/Issues 数据。
+
+**去重检查**：导入前检查知识库中是否已有该仓库的数据：
+```bash
+jfox search "repo-name" --format json
+```
+
+如果已有记录，只导入新增的条目（通过 PR 编号、Issue 编号判断）。
+
+**生成临时 JSON 文件**：将 PR/Issues 数据组装为 JSON 数组（仅 GitHub 数据）：
+
+```json
+[
+  {
+    "title": "Add user authentication",
+    "content": "PR #42: Add user authentication\nState: merged\nAuthor: zhangsan\n...",
+    "tags": ["source:my-app", "source:pr"]
+  },
+  {
+    "title": "Login page crashes on mobile",
+    "content": "Issue #15: Login page crashes on mobile\nState: closed\n...",
+    "tags": ["source:my-app", "source:issue"]
+  }
+]
+```
+
+保存到临时文件（使用跨平台路径），然后执行导入：
+```bash
+jfox bulk-import temp-file.json --type fleeting --kb name
+```
+
+> **约定**：`jfox bulk-import` 默认输出 JSON。使用 `--no-json` 切换为 table 格式，或 `--format table` 显式指定。
+
+### Step 7: 确认报告
+
+导入完成后，向用户报告结果：
+
+```
+导入完成！
+  - git log: 50 条
+  - GitHub PRs: 15 条
+  - GitHub Issues: 10 条
+  - 总计: 75 条 fleeting 笔记已导入到 <知识库名称>
+```
+
+## 手动输入支持
+
+如果用户直接粘贴文本（未提供仓库路径），将文本整理为单条 fleeting 笔记并导入。导入仍遵循下文「笔记格式规范」中的 `source:*` 标签约定；`jfox add` 完整语法与 `--kb` / `--json` / `--content-file` 共享约定详见 `/skill:jfox-manage` §4。
+
+## 笔记格式规范
+
+> git-log 格式由 `jfox ingest-log` 自动处理，以下规范主要供理解输出结构参考，以及手动处理 GitHub PR/Issues 数据时使用。
+
+| 数据源 | title 来源 | content 内容 | 额外标签 |
+|--------|-----------|-------------|---------|
+| git-log | commit subject | hash, author, date, body | `source:<repo-name>`, `source:git-log` |
+| PR | PR 标题 | PR 编号, state, 描述, 关键评论 | `source:<repo-name>`, `source:pr` |
+| Issue | Issue 标题 | Issue 编号, state, 描述, 评论 | `source:<repo-name>`, `source:issue` |
+
+- 所有笔记都带有 `source:<repo-name>` 标签用于后续按仓库检索
+- **Fleeting 笔记不含 `[[wiki links]]`** — 它们是原始数据捕获，链接在后续整理/精炼阶段添加（调用 organize 技能，`/skill:jfox-organize`）
+
+## GitLab 预留
+
+对于非 GitHub 仓库（remote URL 中不包含 `github.com`），仅导入 git log。GitLab CLI 支持是未来的扩展方向。
+
+## 命令参考
+
+```bash
+# 检测仓库类型
+git -C path/to/repo remote get-url origin
+gh auth status
+
+# 采集 git log（一行完成提取+导入）
+jfox ingest-log path/to/repo --limit 50 --kb name --type fleeting
+
+# 采集 GitHub 数据
+gh pr list --repo owner/repo --state all --limit 20 --json number,title,body,state,author,createdAt,updatedAt,labels
+gh pr view number --repo owner/repo --json comments
+gh issue list --repo owner/repo --state all --limit 30 --json number,title,body,state,author,createdAt,labels,comments
+
+# 去重检查
+jfox search "repo-name" --format json
+
+# 导入 GitHub 数据
+jfox bulk-import file.json --type fleeting --kb name
+
+# 批量导入加速（可选）
+jfox daemon start                                # 启动 embedding 守护进程
+jfox daemon stop                                 # 完成后停止
+```
+
+> 单条笔记命令（`jfox add` / `edit` / `delete` / `show` 等）的完整语法详见 `/skill:jfox-manage` §4，共享约定见 §4.1。
+
+## 错误处理
+
+- **"Not a git repository"**: `jfox ingest-log` 会报错，提示用户提供正确的仓库路径
+- **`gh: not found`** 或 `gh auth status` 失败: 跳过 GitHub PR/Issues 导入，仅用 `jfox ingest-log` 导入 git log
+- **"Knowledge base not found"**: 提示用户先调用 manage 技能（`/skill:jfox-manage`）创建知识库
+- **Bulk import 部分失败**: 报告成功/失败数量，失败记录不重试

--- a/packages/kimi-plugin/skills/jfox-manage/SKILL.md
+++ b/packages/kimi-plugin/skills/jfox-manage/SKILL.md
@@ -1,0 +1,377 @@
+---
+name: jfox-manage
+description: |
+  Use when user wants to create, manage, or check the health of a Zettelkasten knowledge
+  base, look up the canonical reference for any jfox note command (add/edit/delete/
+  list/show/refs/daily), or start/stop the embedding daemon. Triggers on "创建知识库",
+  "初始化", "知识库管理", "切换知识库", "重命名知识库", "删除知识库", "检查知识库",
+  "知识库健康", "知识库体检", "知识库诊断", "守护进程", "启动 daemon", "停止 daemon",
+  "kb status", "create knowledge base", "init", "kb management", "health check",
+  "knowledge base decay", "jfox 命令参考", "jfox CRUD", "embedding daemon".
+---
+
+# JFox 知识库管理、命令参考与健康检查
+
+管理知识库的完整生命周期；作为 jfox 笔记命令（add/edit/delete/list/show/refs/daily）的权威参考；提供定期健康检查与衰减信号检测。
+
+## 1. 前置条件
+
+确认 jfox 已安装：
+```bash
+jfox --version
+```
+未安装时：`uv tool install jfox-cli`
+
+## 2. 知识库路径约定
+
+所有知识库存储在 `~/.zettelkasten/` 下：
+
+| 命令 | 知识库名称 | 路径 |
+|------|-----------|------|
+| `jfox init` | default | `~/.zettelkasten/default/` |
+| `jfox init --name work` | work | `~/.zettelkasten/work/` |
+| `jfox init --name research` | research | `~/.zettelkasten/research/` |
+
+自定义路径须在 `~/.zettelkasten/` 下（CLI 强制限制）。
+
+## 3. 知识库生命周期
+
+### 3.1 检查现有知识库
+
+```bash
+jfox kb list --json
+```
+
+如果已有知识库，告知用户并询问是使用现有知识库还是创建新知识库。
+
+### 3.2 创建知识库
+
+**默认知识库（首次使用）：**
+```bash
+jfox init
+```
+
+**命名知识库：**
+```bash
+jfox init --name <name> --desc "<description>"
+```
+
+示例：
+```bash
+jfox init --name work --desc "工作笔记"
+jfox init --name research --desc "研究笔记"
+jfox init --name personal --desc "个人知识库"
+```
+
+**自定义路径（必须在 ~/.zettelkasten/ 下）：**
+```bash
+jfox init --name <name> --path ~/.zettelkasten/<custom-path>
+```
+
+### 3.3 创建后验证
+
+```bash
+jfox kb current --json
+jfox status --json
+```
+
+确认知识库已注册、目录结构已创建、状态显示 0 条笔记。
+
+### 3.4 切换与重命名
+
+```bash
+jfox kb switch <name>               # 切换知识库
+jfox kb info <name> --json          # 查看详情
+jfox kb current --json              # 当前知识库
+jfox kb rename <old> <new>          # 重命名
+```
+
+### 3.5 删除知识库
+
+```bash
+jfox kb remove <name>               # 仅注销，保留笔记文件
+jfox kb remove <name> --force       # 删除知识库（含笔记文件，不可恢复）
+```
+
+### 3.6 查看状态
+
+```bash
+jfox status --json                  # 当前知识库状态
+```
+
+## 4. Canonical 笔记 CRUD 参考
+
+> **本节是 jfox 笔记命令的权威参考；ingest、organize、session-summary 技能直接引用此处，仅在文档中记录自身工作流相关的差异（如标签命名、特殊参数）。**
+
+### 4.1 共享约定
+
+- 所有命令均支持 `--kb <name>` 指定目标知识库，省略时使用当前默认知识库
+- 大部分命令支持 `--format json` 输出 JSON，也可使用快捷方式 `--json`（两者等价）。下文示例统一使用 `--json`。**例外**：`jfox show` 仅输出原始 Markdown，无 JSON 模式
+- 长内容或含特殊字符时，使用 `--content-file <path>` 从文件读取；`--content-file -` 表示从 stdin 读取，可避免 shell 转义问题
+
+### 4.2 添加笔记
+
+```bash
+# 快速添加（内容直接作为参数）
+jfox add "笔记内容，支持 [[其他笔记标题]] 链接" --title "笔记标题"
+
+# 指定类型和标签
+jfox add "内容" --title "标题" --type permanent --tag design --tag backend
+
+# 从文件读取内容（v0.2.1+，适合长文本）
+jfox add --content-file notes/draft.md --title "标题" --type literature
+
+# 从 stdin 读取
+cat notes.txt | jfox add --content-file - --title "标题"
+
+# 使用模板
+jfox add --template meeting --title "周会记录"
+```
+
+笔记类型：
+- `fleeting`（默认）— 快速捕获，稍后提炼
+- `literature` — 阅读笔记
+- `permanent` — 已提炼的知识
+- `session` — AI Agent 会话记录（用法及 `--topic` 必填参数详见 `/skill:jfox-session-summary`）
+
+### 4.3 编辑笔记
+
+```bash
+# 编辑内容和标题
+jfox edit <note_id> --content "新内容" --title "新标题"
+
+# 从文件读取内容（v0.2.1+，适合长文本）
+jfox edit <note_id> --content-file updated.md
+
+# 修改标签和类型
+jfox edit <note_id> --tag new-tag1 --tag new-tag2 --type permanent
+
+# 在指定知识库中编辑
+jfox edit <note_id> --kb work --content "新内容"
+```
+
+编辑会保留原始笔记 ID 和创建时间。
+
+### 4.4 删除笔记
+
+```bash
+jfox delete <note_id>               # 需确认
+jfox delete <note_id> --force       # 跳过确认
+```
+
+### 4.5 查看笔记
+
+```bash
+jfox show <id_or_title>                         # 查看笔记完整内容（输出 Markdown，不支持 --json）
+jfox list --json --limit 50                     # 列出笔记
+jfox list --type permanent --json               # 按类型筛选
+jfox daily --json                               # 今天的笔记
+jfox daily --date 2026-04-01 --json             # 指定日期
+jfox refs --search "<标题>" --json              # 查看反向链接
+```
+
+## 5. 健康检查
+
+通过组合多个 jfox 命令采集指标，综合评估知识库健康状况。没有单独的 "health" 命令，需要从多个数据源收集并综合分析。
+
+> 如果用户指定了目标知识库名称，在以下所有命令中追加 `--kb <name>` 参数。未指定时省略，使用当前默认知识库。
+
+### 5.1 6 项指标采集
+
+```bash
+# 1. 知识库总体状态
+jfox status --json [--kb <name>]
+
+# 2. 图谱指标（--stats 和 --orphans 互斥，分开运行）
+jfox graph --stats --json [--kb <name>]
+
+# 3. 孤立笔记列表
+jfox graph --orphans --json [--kb <name>]
+
+# 4. 索引完整性
+jfox index verify [--kb <name>]
+
+# 5. 笔记清单（用于类型分布和日期分析）
+jfox list --json --limit 500 [--kb <name>]
+
+# 6. 未处理收件箱（fleeting + session 笔记）
+jfox inbox --json --limit 100 [--kb <name>]
+```
+
+### 5.2 健康指标表
+
+从采集数据中计算以下指标：
+
+| 指标 | 数据来源 | 健康 | 警告 | 危险 |
+|------|---------|------|------|------|
+| **孤立比例** | `isolated_nodes / total_nodes` | < 20% | 20-40% | > 40% |
+| **平均连接度** | `avg_degree` (图谱统计) | > 2.0 | 1.0-2.0 | < 1.0 |
+| **收件箱积压** | `jfox inbox` 返回的 fleeting + session 笔记数 | < 10 | 10-30 | > 30 |
+| **索引完整性** | `jfox index verify` 结果 | 全部通过 | -- | 任何异常 |
+| **连通率** | `(total_nodes - isolated_nodes) / total_nodes` | > 0.8 | 0.6-0.8 | < 0.6 |
+| **类型平衡** | fleeting 占 total 比例 | fleeting < 30% | 30-50% | > 50% |
+
+### 5.3 衰减信号检测
+
+分析指标，检测以下 5 种衰减模式：
+
+#### 1. 知识孤岛（孤立比例过高）
+- **信号**：> 40% 的笔记没有任何链接
+- **原因**：笔记已记录但未与现有知识建立关联
+- **修复**：调用 organize 技能（`/skill:jfox-organize`）查找并为孤立笔记添加链接
+
+#### 2. Inbox 积压（未处理笔记过多）
+- **信号**：> 30 条未处理的 fleeting 笔记
+- **原因**：持续捕获想法，但未进行反思和提炼
+- **修复**：调用 organize 技能（`/skill:jfox-organize`）处理收件箱
+
+#### 3. 低连接度（平均连接度不足）
+- **信号**：笔记平均链接数 < 1.0
+- **原因**：添加笔记时未使用 `[[links]]` 语法
+- **修复**：使用 `jfox suggest-links` 为现有笔记查找连接
+
+#### 4. 索引失效（索引不同步）
+- **信号**：`jfox index verify` 报告不匹配
+- **原因**：文件在 jfox CLI 之外被添加或修改
+- **修复**：`jfox index rebuild` 重建搜索索引
+
+#### 5. Hub 依赖（图谱结构脆弱）
+- **信号**：Top 3 中心节点拥有 > 50% 的所有边
+- **原因**：过度依赖少数"枢纽"笔记
+- **修复**：创建中间笔记以分散连接
+
+### 5.4 评分系统
+
+计算总体评分（0-100）：
+
+```
+Score = 100
+- min(orphan_ratio * 100, 40)                        # 最多扣 40 分
+- min(max(0, 2.0 - avg_degree) * 10, 20)             # 最多扣 20 分
+- min(max(0, inbox_count - 10), 20)                   # 最多扣 20 分
+- (0 if verify_result["healthy"] else 20)             # 索引异常扣 20 分
+```
+
+评分对应等级：
+
+| 分数 | 等级 | 状态 |
+|------|------|------|
+| 90-100 | A | 优秀 -- 健康，连接良好 |
+| 75-89 | B | 良好 -- 存在少量问题 |
+| 60-74 | C | 一般 -- 检测到衰减迹象 |
+| 40-59 | D | 较差 -- 明显衰减 |
+| 0-39 | F | 危险 -- 需要立即处理 |
+
+### 5.5 报告格式
+
+按以下格式呈现健康报告：
+
+```
+📊 知识库健康报告[KB: {kb_name}]
+
+总体评分: {grade} ({score}/100)
+
+✅ 索引完整性: {通过/未通过}
+✅ 笔记总数: {N} (permanent: {X}, fleeting: {Y})
+⚠️ 孤立笔记: {orphans}/{total} ({ratio}%) -- {建议}
+⚠️ 平均连接度: {degree} -- {建议}
+⚠️ 收件箱: {inbox_count} 条未处理 -- {建议}
+
+详细指标:
+- 集群数: {clusters}
+- Top hubs: {hub_list}
+- 连通率: {connectivity_ratio}
+
+建议操作:
+1. {最优先的操作}
+2. {次要操作}
+3. {可选优化}
+```
+
+使用默认知识库时显示 `[KB: default]`。
+
+使用 emoji 指示器：
+- ✅ 健康 / 通过
+- ⚠️ 警告 / 需关注
+- ❌ 危险 / 异常
+
+### 5.6 运行时机建议
+
+- **每周一次**：作为定期知识管理流程的快速健康检查
+- **批量导入后**：验证索引和连接是否健康
+- **整理前**：识别需要优先关注的区域
+- **感觉知识库停滞时**：检测具体的衰减模式以对症下药
+
+## 6. Daemon
+
+```bash
+jfox daemon start                               # 启动 embedding 守护进程
+jfox daemon stop                                # 停止守护进程
+jfox daemon status                              # 查看 PID、端口、模型信息
+```
+
+注意：daemon 依赖（fastapi、uvicorn）已作为必选依赖安装，`jfox daemon start` 可直接使用。批量整理 / 导入前启动 daemon 可加速 embedding 计算。
+
+## 7. 命令参考速查
+
+> 完整语法详见 §3–§6；本节按主题分组提供速查。
+
+### 知识库生命周期
+
+```bash
+jfox init --name <name> --desc "<desc>"     # 创建知识库
+jfox kb list --json                         # 列出所有知识库
+jfox kb switch <name>                       # 切换知识库
+jfox kb info <name> --json                  # 查看知识库详情
+jfox kb current --json                      # 当前知识库
+jfox kb rename <old> <new>                  # 重命名
+jfox kb remove <name>                       # 注销（保留文件）
+jfox kb remove <name> --force               # 删除（含文件，不可恢复）
+jfox status --json                          # 知识库状态
+```
+
+### 笔记 CRUD
+
+```bash
+jfox add "<content>" --title "<title>" --type <type> --tag <tags>  # 添加笔记
+jfox add --content-file <path> --title "<title>"                   # 从文件添加
+jfox edit <id> --content "<new>" --title "<title>"                 # 编辑笔记
+jfox edit <id> --content-file <path>                               # 从文件编辑
+jfox delete <id> --force                                           # 删除笔记
+jfox show <id_or_title>                                            # 查看笔记完整内容（无 --json）
+jfox list --json --limit <N>                                       # 列出笔记
+jfox daily --json                                                  # 今天的笔记
+jfox daily --date YYYY-MM-DD --json                                # 指定日期
+jfox refs --search "<title>" --json                                # 反向链接
+```
+
+### 健康检查
+
+```bash
+jfox graph --stats --json                    # 图谱指标（与 --orphans 互斥，分开运行）
+jfox graph --orphans --json                  # 孤立笔记列表
+jfox index verify                            # 索引完整性验证
+jfox index rebuild                           # 重建索引
+jfox inbox --json --limit <N>                # 未处理笔记
+```
+
+### Daemon
+
+```bash
+jfox daemon start                            # 启动 embedding 守护进程
+jfox daemon stop                             # 停止守护进程
+jfox daemon status                           # 查看状态
+```
+
+> 搜索（search）、导入（ingest）、整理（organize）、会话总结（session-summary）等高频操作命令见对应技能文档。
+
+## 8. 错误处理
+
+| 场景 | 处理方式 |
+|------|---------|
+| "Knowledge base already exists" | 使用 `jfox kb switch <name>` 切换到已有知识库，或使用不同名称创建 |
+| "Knowledge base not found" | 调用本技能（`/skill:jfox-manage`）创建知识库 |
+| "Path is outside managed directory" | 所有知识库必须在 `~/.zettelkasten/` 下 |
+| `jfox: command not found` | 安装：`uv tool install jfox-cli` |
+| 索引过时或 `jfox index verify` 异常 | 运行 `jfox index rebuild` 重建搜索索引 |
+| `ingest-log` 报 "Not a git repository" | 提供正确的 Git 仓库路径（详见 `/skill:jfox-ingest`） |

--- a/packages/kimi-plugin/skills/jfox-organize/SKILL.md
+++ b/packages/kimi-plugin/skills/jfox-organize/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: jfox-organize
+description: Use when user wants to organize their Zettelkasten, refine fleeting notes into permanent notes, add wiki links, or optimize the knowledge graph. Triggers on "整理知识库", "清理 inbox", "提炼笔记", "组织笔记", "看看有什么可以整理的", "合并笔记", "生成链接", "organize", "process inbox", "refine notes", "knowledge graph optimization".
+---
+
+# JFox 知识库整理与提炼
+
+JFox 的核心提炼技能。将原始 fleeting 笔记转化为结构良好、互相链接的 permanent 知识。
+
+三步流程：收件箱分析 → 提炼（fleeting → permanent，自动生成 `[[wiki links]]`）→ 图谱优化。
+
+此外支持在整理过程中直接创建和编辑笔记。
+
+## 前置条件
+
+知识库中已有笔记。如果知识库为空，建议先调用 ingest 技能（`/skill:jfox-ingest`）导入内容。
+
+> 本技能复用 `/skill:jfox-manage` §4.1 的共享约定（`--kb` / `--json` / `--content-file`），下文示例统一使用 `--json` 简写。
+
+## Step 1: Inbox 分析
+
+```bash
+jfox inbox --json --limit 50
+```
+
+列出所有 fleeting / session 未处理笔记（`jfox inbox` 涵盖两种类型）。对结果进行分组分析：
+
+1. **按 `source:*` 标签分组**：例如所有 `source:git-log` 的笔记归为一组
+2. **组内识别可合并子组**：主题相近、相关的 commits/issues 归入同一子组
+3. 向用户展示提炼建议：
+
+```
+收件箱: N 条 fleeting 笔记
+
+提炼建议:
+1. [合并] 15 条 jfox git-log commits → "JFox 近期开发总结" (permanent)
+2. [合并] 5 条 jfox PR → "JFox PR 技术决策汇总" (permanent)
+3. [逐条] 3 条手动输入笔记 → 逐条处理
+4. [删除] 2 条过时笔记 → 清理
+```
+
+等待用户确认要执行哪些建议。
+
+## Step 2: 提炼（fleeting → permanent）
+
+这是本技能的核心能力。对用户确认的每条建议执行提炼：
+
+### 提炼流程
+
+1. **分析**：阅读分组内的 fleeting 笔记，提取核心知识点
+2. **查找关联**：
+   ```bash
+   jfox suggest-links "<提炼后的内容摘要>" --format json
+   ```
+   筛选 score >= 0.6 的关联笔记
+3. **生成 permanent 笔记**：将核心知识点整理为结构化内容，嵌入 `[[wiki links]]` 关联到已有笔记
+4. **批量交叉链接**：如果同一批正在创建多条 permanent 笔记，在它们之间也添加 `[[links]]`
+5. **插入**：
+   ```bash
+   jfox add "<包含 [[links]] 的内容>" --title "<标题>" --type permanent --tag <tag1> --tag <tag2> [--kb <name>]
+   ```
+6. **删除源 fleeting**：
+   ```bash
+   jfox delete <原始-id> --force
+   ```
+
+### 提炼策略表
+
+| 来源 | 策略 | permanent 示例 |
+|------|------|---------------|
+| git-log（多个 commits） | 按时间段/主题合并，提取技术决策和变更摘要 | "JFox v0.1.4 技术变更总结" |
+| github-pr（多个 PRs） | 提取核心设计决策、争议点、最终方案 | "JFox PR#94 编辑命令的设计讨论" |
+| github-issue（多个 issues） | 提取问题本质、解决方案、经验教训 | "JFox BM25 索引问题及修复方案" |
+| 手动输入 | 根据内容判断是否值得提炼，内容足够成熟则转为 permanent | — |
+
+## Step 3: 图谱优化
+
+### 查找孤立笔记
+
+```bash
+jfox graph --orphans --json
+```
+
+对每条孤立的 permanent 笔记：
+
+1. 获取笔记内容
+2. 查找关联：
+   ```bash
+   jfox suggest-links "<内容>" --format json
+   ```
+3. 如果有匹配度 >= 0.6 的结果，建议添加链接：
+   ```bash
+   jfox edit <孤立笔记_id> --content "原内容... [[相关笔记标题]]"
+
+   # 使用文件内容编辑（适合长文本）
+   jfox edit <孤立笔记_id> --content-file updated.md
+   ```
+
+### 确认改善
+
+```bash
+jfox graph --stats --json
+```
+
+向用户报告前后对比：
+
+| 指标 | 含义 | 健康目标 |
+|------|------|---------|
+| `avg_degree` | 平均每条笔记的链接数 | > 2.0 |
+| `isolated_nodes` | 无链接的孤立笔记数 | < 总数的 20% |
+
+展示整理前后的指标变化。
+
+## 直接创建笔记
+
+在整理过程中，用户可能想直接创建或编辑一条笔记。命令完整语法详见 `/skill:jfox-manage` §4。本技能的工作流约束：
+
+- **对 permanent 笔记**：先运行 `jfox suggest-links "<内容摘要>" --json` 取匹配度 ≥ 0.6 的结果作为 `[[wiki links]]` 候选，再以含链接的内容调用 `jfox add --type permanent`
+- **对 fleeting 笔记**：直接 `jfox add`（默认即 fleeting），链接留到后续提炼阶段
+- **默认类型**：`fleeting`（快速记录，后续用本技能提炼）；只有当内容已是成熟知识时才用 `permanent`
+
+## 命令参考
+
+整理工作流专属命令：
+
+```bash
+jfox inbox --json --limit <N>                 # 查看收件箱（fleeting + session 笔记）
+jfox suggest-links "<content>" --json         # 推荐 [[wiki links]] 候选（按相似度排序）
+jfox graph --orphans --json                   # 查找孤立笔记
+jfox graph --stats --json                     # 图谱统计指标（avg_degree、isolated_nodes 等）
+```
+
+> `jfox add` / `edit` / `delete` / `list` / `show` / `daily` 等通用命令以及 daemon 用法详见 `/skill:jfox-manage` §4 与 §6–§7。
+
+## 错误处理
+
+- **收件箱为空** → 告知用户 "收件箱为空，无需整理"，可跳到 Step 3 图谱优化
+- **`jfox suggest-links` 返回低匹配度**（score < 0.6）→ 跳过链接推荐，不强制添加
+- **`jfox delete` 目标 ID 不存在** → 报告错误，跳过继续处理其他笔记
+
+## 使用建议
+
+- **定期整理**：建议每周处理一次收件箱，避免 fleeting 笔记堆积超过 30 条
+- **大胆链接**：Zettelkasten 的价值在于连接，而非数量。多使用 `[[links]]` 连接相关概念
+- **用标签分组，用链接表达思想**：`--tag` 按主题归类，`[[links]]` 按思维关联

--- a/packages/kimi-plugin/skills/jfox-search/SKILL.md
+++ b/packages/kimi-plugin/skills/jfox-search/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: jfox-search
+description: Use when user wants to search notes, find information, look up knowledge in their Zettelkasten. Triggers on "搜索", "查找", "找一下", "查一下", "搜一下", "帮我找", "有没有关于", "search notes", "look up", "find", "find related notes", "search knowledge base", "notes about".
+---
+
+# JFox Knowledge Base Search
+
+Search and retrieve notes from the Zettelkasten knowledge base.
+
+## Prerequisites
+
+Knowledge base must be initialized (`jfox init`). If search index is stale, run `jfox index rebuild` first.
+
+## Search Strategy Selection
+
+Choose the right search approach based on user intent:
+
+| User Intent | Strategy | Command |
+|-------------|----------|---------|
+| Exact keyword or term | Keyword (BM25) | `jfox search "<keyword>" --mode keyword --format json` |
+| Concept or idea (fuzzy) | Hybrid (BM25+semantic) | `jfox search "<concept>" --mode hybrid --format json` |
+| Pure semantic similarity | Semantic | `jfox search "<idea>" --mode semantic --format json` |
+| Explore related topics | Graph traversal | `jfox query "<topic>" --depth 2 --json` |
+| What links to note X | Backlinks | `jfox refs --search "<title>" --format json` |
+| What should I link to | Link suggestions | `jfox suggest-links "<content>" --format json` |
+
+**Default strategy**: `--mode hybrid` (best balance of precision and recall).
+
+## Workflow
+
+### Single Search
+
+```bash
+jfox search "<query>" --mode hybrid --top 10 --format json
+```
+
+Parse the JSON output and present results as:
+
+```
+找到 N 条相关笔记：
+
+1. [标题] (score: 0.85)
+   类型: permanent | 标签: tag1, tag2
+   摘要: 前100字...
+
+2. [标题] (score: 0.72)
+   ...
+```
+
+提示：使用 `jfox show <note_id>` 查看笔记完整内容。
+
+### Graph-Aware Search
+
+For exploring connections around a topic:
+```bash
+jfox query "<topic>" --top 10 --depth 2 --json
+```
+
+This returns both search results AND their graph neighbors, giving a broader view of the knowledge landscape.
+
+### Backlink Discovery
+
+To find what references a specific note:
+```bash
+jfox refs --search "<title>" --format json
+```
+
+### Link Recommendations
+
+To find notes that should be linked from given content:
+```bash
+jfox suggest-links "<content>" --top 10 --threshold 0.6 --format json
+```
+
+Default threshold is `0.6`. Lower to `0.3-0.5` for broader suggestions, raise to `0.7-0.8` for stricter matching.
+
+## All Search Commands Reference
+
+```bash
+# Basic search
+jfox search "<query>" --mode <hybrid|keyword|semantic> --top <N> --format json
+
+# Filter by note type (fleeting|permanent)
+jfox search "<query>" --type permanent --format json
+
+# Graph query with traversal
+jfox query "<query>" --top <N> --depth <D> --json
+
+# Link suggestions
+jfox suggest-links "<content>" --top <N> --threshold <T> --format json
+
+# Backlinks/references
+jfox refs --search "<title>" --format json
+jfox refs --note "<note-id>" --format json
+```
+
+## Multi-KB Search
+
+All search commands support `--kb <name>` to target a specific knowledge base:
+```bash
+jfox search "<query>" --kb work --format json
+```
+
+## Error Handling
+
+- **"Index not found"**: Run `jfox index rebuild` to build the search index.
+- **Empty results**: Try broader query, switch mode to `hybrid`, or lower `--threshold`.
+- **Slow search**: First search loads embedding model (30-60s). Subsequent searches are fast. 可通过 `jfox daemon start` 启动守护进程避免重复加载。

--- a/packages/kimi-plugin/skills/jfox-session-summary/SKILL.md
+++ b/packages/kimi-plugin/skills/jfox-session-summary/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: jfox-session-summary
+description: |
+  Use when user wants to save the current conversation/session summary into their Zettelkasten. Triggers on "保存会话", "总结到知识库", "记录这次对话", "写入知识库", "save session", "summarize to knowledge base", "log this conversation".
+---
+
+# JFox Session Summary
+
+将当前 Kimi Code 会话的总结写入 jfox 知识库（支持用户确认和笔记类型选择）。
+
+## 前置条件
+
+- 知识库已初始化（`jfox init`）
+- 确认目标知识库（通过 `--kb` 或当前默认）
+
+> 本技能复用 `/skill:jfox-manage` §4.1 的共享约定（`--kb` / `--json` / `--content-file`）。`jfox add` 通用参数语法详见 `/skill:jfox-manage` §4.2；下文记录的是 session 类型专属约束。
+
+## 工作流程
+
+### Step 1: 生成会话总结
+
+回顾当前会话内容，生成结构化总结：
+
+```
+## 会话总结
+
+### 主题
+[一句话描述会话主要话题]
+
+### 完成的工作
+- [具体完成的任务 1]
+- [具体完成的任务 2]
+- ...
+
+### 关键决策
+- [决策 1 及其理由]
+- [决策 2 及其理由]
+
+### 待办 / 后续
+- [未完成的事项]
+- [后续步骤]
+```
+
+### Step 2: 用户确认
+
+将生成的总结用普通文本输出，供用户阅读。然后使用 `AskUserQuestion` 询问：
+
+- 问题：`笔记内容是否 OK？`
+- 选项：
+  - `内容没问题` → 继续 Step 3
+  - `需要修改` → 用户在 "Other" 中输入修改意见，根据意见调整总结后回到 Step 2 重新展示和确认
+
+循环直到用户满意为止。
+
+### Step 3: 选择笔记类型
+
+用户确认内容后，使用 `AskUserQuestion` 询问笔记类型：
+
+- 问题：`选择笔记类型`
+- 选项：
+  - `session`（推荐）— AI Agent 会话记录，专为此场景设计
+  - `fleeting` — 如果只是快速记录，后续可提炼
+  - `literature` — 如果会话有明确的参考资料来源
+  - `permanent` — 如果总结已经是成熟的知识
+
+### Step 4: 写入知识库
+
+使用 Step 3 选定的笔记类型执行写入：
+
+```bash
+jfox add "<markdown-escaped-summary>" \
+  --title "Session: <topic>" \
+  --type <Step 3 选定的类型> \
+  --topic <short-topic> \
+  --tag session \
+  --kb <kb-name> \
+  --format json
+```
+
+**注意**：
+- 当类型为 `session` 时，`--topic` 参数必填
+- `--topic` 的值应该是简短的英文标识（如 `atomic-write`、`daemon-stop-fix`）
+- 标题格式统一为 `Session: <简短主题>`
+- 标签统一使用 `session`
+- 内容中的双引号需要转义，或使用 `--content-file` 从临时文件读取
+
+### Step 5: 处理长内容
+
+如果总结超过 500 字或包含特殊字符，优先使用 `--content-file`：
+
+```bash
+# 写入临时文件
+cat > /tmp/session-summary.md << 'EOF'
+<总结内容>
+EOF
+
+# 从文件导入
+jfox add --content-file /tmp/session-summary.md \
+  --title "Session: <topic>" \
+  --type <Step 3 选定的类型> \
+  --topic <short-topic> \
+  --tag session \
+  --kb <kb-name> \
+  --format json
+```
+
+## 命令参考
+
+```bash
+# 直接添加（短内容）
+jfox add "<summary>" --title "Session: <topic>" --type <type> --topic <short-topic> --tag session --kb <name>
+
+# 从文件添加（长内容或含特殊字符）
+jfox add --content-file <path> --title "Session: <topic>" --type <type> --topic <short-topic> --tag session --kb <name>
+```
+
+> 写入后的验证（`jfox show` / `jfox refs` 等）详见 `/skill:jfox-manage` §4.5。
+
+## 错误处理
+
+- **"Knowledge base not found"**: 提示用户先调用 manage 技能（`/skill:jfox-manage`）创建知识库
+- **内容过长导致 shell 解析失败**: 切换到 `--content-file` 方式
+- **特殊字符转义问题**: 使用单引号包裹内容，或写入临时文件

--- a/packages/kimi-plugin/skills/using-jfox/SKILL.md
+++ b/packages/kimi-plugin/skills/using-jfox/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: using-jfox
+description: |
+  JFox 插件的入口引导。在新会话开始时自动加载，用于确认 jfox CLI 环境、映射常用术语到 Kimi Code 命令，并提供快速参考。不要单独触发此 skill，它通过插件的 sessionStart 自动注入。
+---
+
+# JFox for Kimi Code
+
+你是 JFox（Zettelkasten 知识管理 CLI）与 Kimi Code 之间的集成助手。你的职责是帮助用户通过自然语言管理他们的知识库。
+
+## 环境检查
+
+会话开始时，确认 `jfox` 已安装：
+
+```bash
+jfox --version
+```
+
+如果未安装，提示用户：
+
+```bash
+uv tool install jfox-cli
+```
+
+## 术语映射
+
+| 用户说的 | 对应操作 / Skill |
+|----------|------------------|
+| 创建知识库、初始化 | `/skill:jfox-manage` §3 |
+| 搜索笔记、查找知识 | `/skill:jfox-search` |
+| 导入仓库、git log、PR、Issues | `/skill:jfox-ingest` |
+| 整理知识库、提炼笔记、清理 inbox | `/skill:jfox-organize` |
+| 保存会话、总结到知识库 | `/skill:jfox-session-summary` |
+| 健康检查、知识库体检 | `/skill:jfox-manage` §5 |
+
+## 通用约定
+
+- 所有 `jfox` 命令都支持 `--kb <name>` 指定目标知识库；省略时使用当前默认知识库
+- 大部分命令支持 `--format json` 或 `--json` 输出 JSON，方便解析
+- 长内容或含特殊字符时，使用 `--content-file <path>` 从文件读取；`--content-file -` 表示从 stdin 读取
+- `jfox show <id_or_title>` 只输出原始 Markdown，不支持 `--json`
+
+## 常用命令速查
+
+```bash
+# 知识库
+jfox init --name <name> --desc "<描述>"
+jfox kb list --json
+jfox kb switch <name>
+jfox status --json
+
+# 笔记 CRUD
+jfox add "内容" --title "标题" --type permanent --tag <tag>
+jfox add --content-file <path> --title "标题"
+jfox edit <id> --content "新内容" --title "新标题"
+jfox delete <id> --force
+jfox show <id_or_title>
+jfox list --json --limit 50
+
+# 搜索与图谱
+jfox search "<query>" --mode hybrid --format json
+jfox query "<topic>" --depth 2 --json
+jfox suggest-links "<内容>" --format json
+jfox refs --search "<标题>" --format json
+jfox graph --stats --json
+jfox graph --orphans --json
+
+# 导入与整理
+jfox ingest-log <repo-path> --limit 50 --type fleeting
+jfox inbox --json --limit 50
+jfox index verify
+jfox index rebuild
+
+# Daemon
+jfox daemon start
+jfox daemon stop
+jfox daemon status
+```
+
+## 跨 Skill 引用语法
+
+在 Kimi Code 中，引用本插件的其他 skill 时使用：
+
+```text
+/skill:jfox-manage
+/skill:jfox-search
+/skill:jfox-ingest
+/skill:jfox-organize
+/skill:jfox-session-summary
+```
+
+## 错误处理速查
+
+| 错误 | 处理 |
+|------|------|
+| `jfox: command not found` | `uv tool install jfox-cli` |
+| `Knowledge base not found` | 调用 `/skill:jfox-manage` 创建知识库 |
+| `Knowledge base already exists` | `jfox kb switch <name>` 或换名称 |
+| `Index not found` / 索引异常 | `jfox index rebuild` |
+| 内容过长导致 shell 解析失败 | 改用 `--content-file` |

--- a/skills-recommend/README.md
+++ b/skills-recommend/README.md
@@ -4,6 +4,8 @@
 
 > **Claude Code 用户请通过 marketplace 安装**（`/plugin marketplace add zhuxixi/jfox`），不要从此目录拷贝。
 > Claude Code 的官方插件源在 `packages/cc-plugin/`，使用 auto-discovery 加载 `packages/cc-plugin/skills/` 下的 5 个 skill。
+>
+> **Kimi Code 用户请使用新版插件**（`packages/kimi-plugin/`），通过 `/plugins install` 安装，支持 `sessionStart` 自动加载。
 
 ## 目录结构
 
@@ -27,27 +29,42 @@ skills-recommend/
 
 ## 使用方法
 
-### Kimi CLI
+### Kimi Code CLI（推荐新版插件）
 
-Kimi CLI 使用与 Claude Code 相同的 SKILL.md 格式，通过 `description` 中的关键词自然语言触发：
+Kimi Code CLI 已支持正式插件机制。新版插件位于 `packages/kimi-plugin/`，包含 manifest 和 `sessionStart` 自动加载：
 
 ```bash
-# 复制全部 skills
-mkdir -p ~/.config/agents/skills/
-cp -r skills-recommend/kimi-cli/* ~/.config/agents/skills/
+# 方式一：本地 zip 安装（开发测试）
+cd packages/kimi-plugin
+zip -r /tmp/jfox-kimi-plugin.zip .
 
-# 或复制单个 skill
-cp -r skills-recommend/kimi-cli/jfox-search ~/.config/agents/skills/
+# 在 Kimi Code CLI TUI 中执行
+/plugins install /tmp/jfox-kimi-plugin.zip
+/new
+
+# 方式二：从 GitHub 安装（marketplace 上架后）
+/plugins install github:zhuxixi/jfox?path=packages/kimi-plugin
+/new
 ```
 
-复制后 Kimi CLI 会根据对话内容自动触发对应的 skill：
-- **jfox-common** — 创建/管理知识库、健康检查
+插件内置 skill：
+- **using-jfox** — 会话启动时自动加载，环境检查与命令速查
+- **jfox-manage** — 创建/管理知识库、笔记 CRUD、健康检查
 - **jfox-ingest** — 从仓库导入 git log / PR / Issues 为 fleeting 笔记
 - **jfox-organize** — 整理知识库、提炼 permanent 笔记、生成 [[wiki links]]
 - **jfox-search** — 搜索笔记、图谱查询、链接推荐
-- **jfox-session-summary** — 将会话总结写入知识库作为 fleeting 笔记
+- **jfox-session-summary** — 将会话总结写入知识库
 
-Kimi CLI 也兼容 `~/.kimi/skills/` 和 `~/.claude/skills/` 目录。
+详见 `packages/kimi-plugin/README.md`。
+
+#### 旧版手动复制（已弃用）
+
+早期 Kimi CLI 没有正式插件机制，只能把 `skills-recommend/kimi-cli/` 下的 SKILL.md 手动复制到 skills 目录。该方式不再维护，仅作为历史参考：
+
+```bash
+mkdir -p ~/.kimi-code/skills/
+cp -r skills-recommend/kimi-cli/* ~/.kimi-code/skills/
+```
 
 ### pi coding agent
 


### PR DESCRIPTION
Close #231

为 Kimi Code CLI 新增可安装插件 `packages/kimi-plugin/`，基于 Kimi Code 0.14.x 正式插件机制（`kimi.plugin.json` + `skills/` + `sessionStart.skill`）重新设计。

### 主要改动

- 新增插件包 `packages/kimi-plugin/`：
  - `kimi.plugin.json`：manifest，`name: jfox`，声明 `sessionStart.skill: using-jfox`
  - `using-jfox`：会话启动自动加载，负责环境检查、术语映射、命令速查
  - 5 个业务 skill：`jfox-manage`、`jfox-search`、`jfox-ingest`、`jfox-organize`、`jfox-session-summary`
- 从 `packages/cc-plugin/` 迁移并适配：
  - skill name 改为 `jfox-*` kebab-case
  - 交叉引用从 `/jfox:xxx` 改为 Kimi Code 的 `/skill:jfox-xxx`
  - 修正 session-summary 中遗留的 "Claude Code 会话" 表述
- 文档更新：
  - `packages/kimi-plugin/README.md`：安装说明、能力对照、已知限制
  - `skills-recommend/README.md`：引导使用新版插件，旧版手动复制标记 deprecated
  - `README.md`：新增 Agent Plugins 章节

### 验证

- `kimi.plugin.json` JSON 校验通过
- `kimi --skills-dir packages/kimi-plugin/skills -p "..."` 验证 manage/search skill 可被自然语言触发
- jfox 0.10.0 相关命令 sanity check 通过

### 安装方式

```bash
cd packages/kimi-plugin
zip -r /tmp/jfox-kimi-plugin.zip .
```

在 Kimi Code CLI TUI 中：

```text
/plugins install /tmp/jfox-kimi-plugin.zip
/new
```

### 后续

- 在真实 Kimi Code TUI 会话中完整验证 `sessionStart` 自动加载和 5 个业务 skill 的端到端执行
- 评估是否通过 MCP server 封装高频 jfox 命令（二期方向）
