### PR TITLE
chore: add GitHub PR and issue templates (#240)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,129 @@
+name: "🐛 Bug 报告"
+description: 报告一个 bug — 功能损坏、崩溃或行为异常。
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢报告 bug！请填写以下内容，帮助我们快速复现和修复。
+
+        **提交前请确认**：
+        - [ ] 搜索 [现有 issues](https://github.com/zhuxixi/jfox/issues) 避免重复
+        - [ ] 升级到最新版本（`pip install --upgrade jfox` 或 `uv tool upgrade jfox`）确认 bug 仍存在
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug 描述
+      description: 清晰描述什么问题。包含错误消息、堆栈跟踪或截图。
+      placeholder: |
+        发生了什么？期望发生什么？
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: 复现步骤
+      description: 触发 bug 的最小步骤。越具体，修复越快。
+      placeholder: |
+        1. 运行 `jfox search "xxx"`
+        2. 输入 "..."
+        3. 出现错误：...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期望行为
+      description: 应该发生什么？
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 实际行为
+      description: 实际发生了什么？包含完整的错误输出。
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: 受影响组件
+      description: jfox 的哪个部分受影响？
+      multiple: true
+      options:
+        - CLI 命令
+        - 笔记管理（add/edit/delete/show）
+        - 搜索（search/suggest_links）
+        - 知识图谱（graph）
+        - 向量索引（embedding/vector_store）
+        - 守护进程（daemon）
+        - 配置（config/kb_manager）
+        - 安装/部署
+        - 其他
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: 操作系统
+      description: 例如 Ubuntu 24.04, macOS 15.2, Windows 11
+      placeholder: Ubuntu 24.04
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python 版本
+      description: "python --version 的输出"
+      placeholder: "3.11.9"
+    validations:
+      required: true
+
+  - type: input
+    id: uv-version
+    attributes:
+      label: uv 版本（如使用 uv 安装）
+      description: "uv --version 的输出"
+      placeholder: "0.6.0"
+
+  - type: input
+    id: jfox-version
+    attributes:
+      label: jfox 版本
+      description: "jfox --version 的输出"
+      placeholder: "0.10.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: 错误日志 / 堆栈跟踪
+      description: 完整的错误输出。自动格式化。
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: root-cause
+    attributes:
+      label: 根因分析（可选）
+      description: |
+        如果你已经排查到代码层面的根因，请分享。包含文件路径、行号、代码片段。这会大大加速修复。
+      placeholder: |
+        问题在 `jfox/cli.py` 第 123 行。`load_note()` 未处理 frontmatter 缺失的情况...
+
+  - type: checkboxes
+    id: pr-ready
+    attributes:
+      label: 是否愿意提交 PR 修复？
+      options:
+        - label: 我想自己修复并提交 PR

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📖 文档
+    url: https://github.com/zhuxixi/jfox/blob/main/README.md
+    about: 查看 README 和文档。
+  - name: 🤝 贡献指南
+    url: https://github.com/zhuxixi/jfox/blob/main/AGENTS.md
+    about: 提交 PR 前请阅读。

--- a/.github/ISSUE_TEMPLATE/docs_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/docs_improvement.yml
@@ -1,0 +1,54 @@
+name: "📝 文档改进"
+description: 报告文档错误、缺失或改进建议。
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢帮助我们改进文档！
+
+  - type: textarea
+    id: location
+    attributes:
+      label: 文档位置
+      description: 指出需要改进的文档位置（文件路径或 URL）。
+      placeholder: |
+        README.md 第 45 行
+        AGENTS.md 的 "开发环境" 部分
+        https://github.com/zhuxixi/jfox/blob/main/docs/xxx.md
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 问题描述
+      description: 当前文档有什么问题？（错误、过时、缺失、不清晰）
+      placeholder: |
+        文档说 "uv sync" 但应该是 "uv sync --extra dev"...
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: 改进建议
+      description: 你希望怎么改？
+      placeholder: |
+        添加 `--extra dev` 说明，并解释为什么需要 dev 依赖...
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 补充信息（可选）
+      description: 截图、参考链接或其他上下文。
+
+  - type: checkboxes
+    id: pr-ready
+    attributes:
+      label: 是否愿意提交 PR 改进？
+      options:
+        - label: 我想自己修改并提交 PR

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,73 @@
+name: "✨ 功能请求"
+description: 建议新功能或改进。
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢提出建议！提交前请考虑：
+
+        - **搜索 [现有 issues](https://github.com/zhuxixi/jfox/issues)** — 可能有人已经提过类似建议。
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 问题或使用场景
+      description: 这个功能解决什么问题？你目前想做什么但做不到？
+      placeholder: |
+        我想用 jfox 做... 但目前没有方法...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: 建议方案
+      description: 你认为应该怎么实现？尽可能具体 — CLI 参数、配置选项、交互行为。
+      placeholder: |
+        添加 `--foo` 参数到 `jfox search` 命令...
+        或：新增配置项 `bar.baz` 控制...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 替代方案
+      description: 你考虑过其他方法吗？为什么建议方案更好？
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: 功能类型
+      options:
+        - 新 CLI 命令
+        - 现有命令改进
+        - 笔记类型扩展
+        - 搜索/索引改进
+        - 知识图谱改进
+        - 守护进程/后端改进
+        - 配置/安装改进
+        - 性能优化
+        - 开发者体验（测试、文档、CI）
+        - 其他
+    validations:
+      required: true
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: 范围
+      description: 这个改动有多大？
+      options:
+        - 小（单个文件，< 50 行）
+        - 中（几个文件，< 300 行）
+        - 大（新模块或重大重构）
+
+  - type: checkboxes
+    id: pr-ready
+    attributes:
+      label: 贡献
+      options:
+        - label: 我想自己实现并提交 PR

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,65 @@
+## 变更描述
+
+<!-- 描述这次变更的内容。解决了什么问题？为什么选择这个方案？ -->
+
+
+
+## 关联 Issue
+
+<!-- 链接这次 PR 解决的 issue。如果没有，建议先创建一个。 -->
+
+Fixes #
+
+## 变更类型
+
+<!-- 勾选适用的选项 -->
+
+- [ ] 🐛 Bug 修复（不破坏兼容性的修复）
+- [ ] ✨ 新功能（不破坏兼容性的新增）
+- [ ] 🔒 安全修复
+- [ ] 📝 文档更新
+- [ ] ✅ 测试（新增或改进测试覆盖）
+- [ ] ♻️ 重构（无行为变化）
+- [ ] ⚡️ 性能优化
+
+## 具体改动
+
+<!-- 列出具体改动。包含代码文件路径。 -->
+
+- 
+
+## 测试步骤
+
+<!-- 验证这次变更的步骤。对于 bug：复现步骤 + 修复证明。 -->
+
+1. 
+2. 
+3. 
+
+## 检查清单
+
+<!-- 提交前完成以下检查。 -->
+
+### 代码
+
+- [ ] 我已阅读项目的 `AGENTS.md` 和开发规范
+- [ ] 我的 commit 遵循 [Conventional Commits](https://www.conventionalcommits.org/)（`fix:`, `feat:`, `chore:`, `docs:` 等）
+- [ ] 我搜索了 [现有 PR](https://github.com/zhuxixi/jfox/pulls) 确认没有重复
+- [ ] 我的 PR 只包含与本次变更相关的改动（无无关提交）
+- [ ] `uv run ruff check jfox/ tests/` 通过
+- [ ] `uv run black jfox/ tests/` 通过
+- [ ] `uv run pytest tests/ -m "not embedding and not slow"` 通过（快速测试）
+- [ ] 我在本地测试通过：<!-- 例如 Ubuntu 24.04, macOS 15.2, Windows 11 -->
+
+### 文档与维护
+
+<!-- 勾选适用的选项。如果不适用，勾选 "N/A"。 -->
+
+- [ ] 我已更新相关文档（README, AGENTS.md, CHANGELOG）— 或 N/A
+- [ ] 我已考虑跨平台影响（Windows, macOS, Linux）— 或 N/A
+- [ ] 我已更新工具描述或 schema（如果有变更）— 或 N/A
+
+## 截图 / 日志
+
+<!-- 如果适用，添加截图或日志输出展示修复/功能效果。 -->
+


### PR DESCRIPTION
## 变更描述

添加 GitHub PR 模板和 Issue 模板，规范贡献流程。

参考 Hermes Agent 的模板实践，结合 jfox 项目特点（Python CLI、uv 工具链、中文项目）定制。

## 关联 Issue

Fixes #240

## 变更类型

- [x] 📝 文档更新

## 具体改动

- `.github/PULL_REQUEST_TEMPLATE.md` — PR 模板，包含 jfox 特定的检查清单（uv run ruff/black/pytest）
- `.github/ISSUE_TEMPLATE/bug_report.yml` — Bug 报告模板，包含环境信息、复现步骤、日志
- `.github/ISSUE_TEMPLATE/feature_request.yml` — 功能请求模板，包含使用场景、方案、替代方案
- `.github/ISSUE_TEMPLATE/docs_improvement.yml` — 文档改进模板，包含位置、问题、建议
- `.github/ISSUE_TEMPLATE/config.yml` — 配置：链接到 README 和 AGENTS.md

## 检查清单

- [x] `uv run ruff check jfox/ tests/` 通过
- [x] `uv run black jfox/ tests/` 通过
- [x] `uv run pytest` 通过（快速测试）
- [x] 本地手动测试通过

## 截图

N/A — 纯模板文件，无运行时变更
