### PR TITLE
feat(cc-plugin): add using-jfox overview/routing skill (#243)

### DIFF
--- a/docs/superpowers/plans/2026-06-17-using-jfox-skill.md
+++ b/docs/superpowers/plans/2026-06-17-using-jfox-skill.md
@@ -1,0 +1,271 @@
+# using-jfox 总览/路由 skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a single `using-jfox` overview/routing skill to the cc-plugin that owns meta-intent ("jfox 能做什么 / 我该用哪个 skill"), routes to the five existing capability skills, and does not compete with them for triggering.
+
+**Architecture:** One new auto-discovered Markdown skill at `packages/cc-plugin/skills/using-jfox/SKILL.md` (no `plugin.json` change — cc-plugin auto-discovers `skills/*`). A small pytest contract test guards the design invariants from issue #243: valid frontmatter, the description carries only meta triggers and **no** competing action verbs, and the body's pointers into `manage`/`organize` resolve to real sections. Nothing else is modified (方案 1 / pure-additive).
+
+**Tech Stack:** Claude Code plugin skill (Markdown + YAML frontmatter), pytest (contract test, no KB/fixtures).
+
+**Spec:** `docs/superpowers/specs/2026-06-17-using-jfox-skill-design.md`
+
+**Work context:** Work in the isolated worktree `/home/elling/workspace/proj/github-personal/jfox-wt-243` on branch `feat/issue-243-using-jfox-skill` (based off `main`, independent of the in-flight `feat/kimi-auto-summary-242` branch). All paths below are relative to that worktree root.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `packages/cc-plugin/skills/using-jfox/SKILL.md` | **Create** | The skill itself: frontmatter (meta-only description) + body (what jfox is, capability-map decision table, note-model pointer, ≥2 composite workflows, conventions pointer, env check, self-boundary). |
+| `tests/unit/test_using_jfox_skill.py` | **Create** | Contract test: asserts the skill exists, frontmatter is valid, description has no competing verbs + has meta triggers, and body pointers resolve. |
+
+**No other files are touched.** In particular: `packages/cc-plugin/.claude-plugin/plugin.json` is NOT modified (auto-discovery), and none of the five existing skills (`search`/`ingest`/`manage`/`organize`/`session-summary`) are edited (方案 1).
+
+---
+
+## Task 1: Create the skill with its contract test (TDD red → green)
+
+**Files:**
+- Create: `tests/unit/test_using_jfox_skill.py`
+- Create: `packages/cc-plugin/skills/using-jfox/SKILL.md`
+
+- [ ] **Step 1: Write the failing contract test**
+
+Create `tests/unit/test_using_jfox_skill.py`:
+
+```python
+"""
+测试类型: 单元测试
+目标: cc-plugin using-jfox 总览/路由 skill 的设计契约（issue #243）
+预估耗时: < 1 秒
+依赖要求: 无外部依赖（纯文件读取，不需要知识库 / fixture）
+
+守护的设计不变量（见 docs/superpowers/specs/2026-06-17-using-jfox-skill-design.md）：
+  1. skill 文件存在，frontmatter 合法（name=using-jfox，description 非空）
+  2. description 只含元意图触发词，不含与 5 个能力型 skill 竞争的强动词
+  3. body 中指向 manage / organize 的指针锚点确实存在
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]  # tests/unit/x.py -> repo root
+SKILL_DIR = REPO_ROOT / "packages" / "cc-plugin" / "skills"
+USING_JFOX = SKILL_DIR / "using-jfox" / "SKILL.md"
+
+
+def _frontmatter(path: Path) -> str:
+    """Return the raw YAML frontmatter block (text between the --- fences)."""
+    text = path.read_text(encoding="utf-8")
+    m = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    assert m, f"{path} has no YAML frontmatter"
+    return m.group(1)
+
+
+def test_skill_file_exists():
+    assert USING_JFOX.is_file(), f"expected skill at {USING_JFOX}"
+
+
+def test_frontmatter_name():
+    assert re.search(r"^name:\s*using-jfox\s*$", _frontmatter(USING_JFOX), re.MULTILINE)
+
+
+def test_frontmatter_has_description():
+    assert "description:" in _frontmatter(USING_JFOX)
+
+
+# 设计核心（#243）：description 绝不能携带 5 个能力型 skill 拥有的强动词，
+# 否则会在 auto-discovery 路由时与它们竞争同一个意图。
+@pytest.mark.parametrize(
+    "verb",
+    ["搜索", "导入", "整理", "保存会话", "创建知识库", "管理知识库"],
+)
+def test_description_has_no_competing_verbs(verb):
+    assert verb not in _frontmatter(USING_JFOX), (
+        f"competing verb {verb!r} must not appear in using-jfox frontmatter "
+        f"(see spec Section 2 / issue #243)"
+    )
+
+
+@pytest.mark.parametrize("trigger", ["能做什么", "overview", "入门"])
+def test_description_carries_meta_triggers(trigger):
+    assert trigger in _frontmatter(USING_JFOX), (
+        f"description should carry meta trigger {trigger!r}"
+    )
+
+
+def test_pointers_resolve():
+    """body 指向 manage / organize 的锚点必须真实存在，避免路由到缺失章节。"""
+    assert USING_JFOX.is_file()
+    checks = [
+        (SKILL_DIR / "manage" / "SKILL.md", "共享约定"),     # §4.1
+        (SKILL_DIR / "manage" / "SKILL.md", "知识库路径"),   # §2
+        (SKILL_DIR / "manage" / "SKILL.md", "健康检查"),     # §5
+        (SKILL_DIR / "organize" / "SKILL.md", "Inbox"),      # Step 1
+        (SKILL_DIR / "organize" / "SKILL.md", "提炼"),       # Step 2
+    ]
+    missing = [
+        (str(p), anchor)
+        for p, anchor in checks
+        if anchor not in p.read_text(encoding="utf-8")
+    ]
+    assert not missing, f"pointers point at missing sections: {missing}"
+```
+
+- [ ] **Step 2: Run the test to verify it fails (red)**
+
+Run: `pytest tests/unit/test_using_jfox_skill.py -v`
+Expected: FAIL — `test_skill_file_exists` fails because `packages/cc-plugin/skills/using-jfox/SKILL.md` does not exist yet (and the pointer test is skipped behind that assertion, but the existence/name/verb tests will error on the missing file).
+
+- [ ] **Step 3: Write the skill (minimal implementation that satisfies the contract)**
+
+Create `packages/cc-plugin/skills/using-jfox/SKILL.md`:
+
+````markdown
+---
+name: using-jfox
+description: |
+  Use when the user asks meta or overview questions about jfox as a whole — what jfox
+  can do, how to get started, or which jfox skill/command fits their goal. Triggers on
+  "jfox 能做什么", "jfox 怎么用", "知识库怎么用", "我该用哪个 jfox 命令", "我该用哪个
+  jfox skill", "jfox 有哪些功能", "jfox 入门", "jfox overview", "what can jfox do",
+  "which jfox skill". This skill orients the user and routes to the specific skill; it
+  is not for performing a concrete action.
+---
+
+# JFox 总览与路由
+
+JFox 是一个本地优先的 Zettelkasten 知识管理 CLI：混合搜索（BM25 + 语义）、知识图谱、多知识库，并提供 Claude Code / Kimi Code 插件集成。
+
+本 skill **只做总览与路由**：帮你判断「该用哪个 skill」，然后把具体动作派发出去。它不自己执行搜索 / 导入 / 整理 / 保存会话 / 管理这些动作。
+
+## 环境检查
+
+确认 jfox 已安装：
+
+```bash
+jfox --version
+```
+
+未安装时：
+
+```bash
+uv tool install jfox-cli
+```
+
+## 我该用哪个 skill
+
+| 你想做的 | 用这个 skill | 典型触发词 |
+|---------|-------------|-----------|
+| 搜索 / 查找笔记、检索知识 | `search` | 搜索 / 查找 / find |
+| 把 git 仓库 / PR / issues 导入成素材 | `ingest` | 导入仓库 / ingest repo |
+| 提炼 fleeting→permanent、清理 inbox、补 wiki link、优化图谱 | `organize` | 整理 / 提炼 / clean inbox |
+| 把当前会话总结存入知识库 | `session-summary` | 保存会话 / save session |
+| 创建 / 切换 / 删除知识库、命令参考、健康检查、daemon | `manage` | 创建知识库 / kb status / 健康检查 |
+
+5 个 skill 一句话职责：
+
+- **search** — 笔记检索：BM25 / 语义 / 混合搜索 + 知识图谱查询。
+- **ingest** — git 仓库 → fleeting 素材笔记（git log / PR / issues）。
+- **organize** — fleeting → permanent 提炼 + 图谱优化（orphans / 补链）。
+- **session-summary** — 当前会话 → 知识库笔记。
+- **manage** — 知识库生命周期 + 笔记 CRUD 权威参考 + 健康检查 + embedding daemon。
+
+## 笔记模型（一句话）
+
+JFox 笔记分 fleeting / literature / permanent 三类，靠 `[[wiki link]]` 互链。完整的模型与提炼流程见 **organize** skill（Step 1 收件箱分析、Step 2 提炼）。
+
+## 典型复合工作流
+
+1. **沉淀新知识**：`ingest`（导入素材为 fleeting）→ `organize`（提炼成 permanent + 补 `[[wiki link]]`）→ `search`（日后检索复用）。
+2. **会话沉淀**：`session-summary`（把这次对话存入知识库）→ `organize`（提炼要点为 permanent）。
+3. **知识库维护**：`manage`（§5 体检 / 衰减信号检测）→ `organize`（清理 orphans / 补链接）。
+
+## 公共约定（一句话）
+
+所有 jfox 命令支持 `--kb <name>` 指定知识库、`--json` / `--format json` 输出 JSON、`--content-file <path>` 从文件读取长内容。完整约定见 **manage** skill §4.1。
+
+## 本 skill 不做
+
+- 不执行具体动作（搜索 / 导入 / 整理 / 保存会话 / 管理）——交给对应 skill。
+- 不重复各 skill 的命令速查——命令在各 skill 内有权威版本。
+````
+
+- [ ] **Step 4: Run the test to verify it passes (green)**
+
+Run: `pytest tests/unit/test_using_jfox_skill.py -v`
+Expected: PASS — all 12 test cases green (existence, name, has-description, 6× no-competing-verbs, 3× meta-triggers, pointers-resolve).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cc-plugin/skills/using-jfox/SKILL.md tests/unit/test_using_jfox_skill.py
+git commit -m "feat(cc-plugin): add using-jfox overview/routing skill (#243)
+
+新增 using-jfox skill 承接元意图（jfox 能做什么 / 我该用哪个 skill），
+路由到现有 5 个能力型 skill。description 只用元词、不含强动词，避免触发竞争。
+附 unit 契约测试守护：frontmatter 合法、无竞争动词、指针锚点可解析。
+
+方案 1（纯加法），不改 plugin.json，不编辑现有 5 个 skill。"
+```
+
+---
+
+## Task 2: Final verification gate
+
+**Files:** none modified (verification only)
+
+- [ ] **Step 1: Re-run the contract test in isolation**
+
+Run: `pytest tests/unit/test_using_jfox_skill.py -v`
+Expected: PASS (all green). Confirms the invariant holds after the commit.
+
+- [ ] **Step 2: Confirm auto-discovery picks up the new skill**
+
+Run: `ls packages/cc-plugin/skills/`
+Expected output includes `using-jfox` alongside `ingest manage organize search session-summary`. No `plugin.json` edit is needed — cc-plugin auto-discovers `skills/*`.
+
+- [ ] **Step 3: Confirm no existing skill or plugin manifest was modified**
+
+Run: `git diff --stat main -- packages/cc-plugin`
+Expected: only `packages/cc-plugin/skills/using-jfox/SKILL.md` shows as added; `ingest/manage/organize/search/session-summary/SKILL.md` and `.claude-plugin/plugin.json` show **no** changes.
+
+- [ ] **Step 4: Manual routing sanity (human)**
+
+With the plugin installed/reloaded, ask two prompts and confirm the routing:
+- 「jfox 能做什么」→ should route to **using-jfox** (overview).
+- 「搜索一下关于 X 的笔记」→ should route to **search**, **not** using-jfox.
+
+If the second one wrongly hits using-jfox, the description picked up a competing verb — re-run the contract test (it should already have caught this) and tighten the description.
+
+- [ ] **Step 5: Done — report**
+
+The feature is complete. Note in the PR/issue:
+- Files added (1 skill + 1 test).
+- Acceptance criteria from spec Section 7 all met (verify the checklist).
+- Follow-ups FU-1 (single-source refactor, post #244–247) and FU-2 (Kimi consistency) remain open, tracked in the spec.
+
+(Do not push or open a PR unless the user asks. If asked, push `feat/issue-243-using-jfox-skill` and open a PR against `main` with `Closes #243`.)
+
+---
+
+## Self-Review (run before handing off)
+
+**Spec coverage** — every spec section maps to a task:
+- §1 File & naming → Task 1 Step 3 (file path + `name: using-jfox`).
+- §2 Description / trigger strategy → Task 1 Step 3 (frontmatter) + guarded by Task 1 Step 1 tests.
+- §3 Body structure (6 sections) → Task 1 Step 3 (env check, capability map, note model, workflows, conventions, boundary).
+- §4 Capability-map decision table → Task 1 Step 3.
+- §5 ≥2 composite workflows → Task 1 Step 3 (3 workflows).
+- §6 Boundary / non-goals → Task 1 Step 3 "本 skill 不做" + Task 2 Step 3 (no-modification check).
+- §7 Acceptance criteria → Task 2 Step 5 checklist + Task 2 Step 4 routing sanity.
+- §8 Verification → Task 1 Step 1 (contract test) + Task 2 Steps 1–4.
+- §9 Follow-ups → Task 2 Step 5 (reported, not implemented by design).
+
+**Placeholder scan:** none — all code/content is complete; no TBD/TODO/"add error handling".
+
+**Type/name consistency:** skill name `using-jfox` and the five sibling names are used identically across the skill body, the test, and the commit message. Pointer anchors (`共享约定`/`知识库路径`/`健康检查`/`Inbox`/`提炼`) match the test's `checks` list exactly.

--- a/docs/superpowers/specs/2026-06-17-using-jfox-skill-design.md
+++ b/docs/superpowers/specs/2026-06-17-using-jfox-skill-design.md
@@ -1,0 +1,153 @@
+# Design: using-jfox 总览/路由 skill (cc-plugin)
+
+> Issue: #243
+> Branch: `feat/issue-243-using-jfox-skill`
+> 方案: **方案 1 — 纯加法**（新增 1 个 skill，不改动现有 5 个 skill）
+
+## 背景
+
+JFox 的 Claude Code 插件（`packages/cc-plugin/`）当前有 5 个**能力型** skill：`search` / `ingest` / `manage` / `organize` / `session-summary`。它们各自 description + 触发词清晰，按 auto-discovery 路由已经很准。
+
+但存在一个真实空白：**总览/元意图没有归属**。「jfox 能做什么」「我该用哪个 jfox 命令」「知识库怎么用」这类问题，5 个 skill 的 description 都不接，目前只能靠 CLAUDE.md 或 agent 自由发挥。
+
+### 关键发现（影响设计的事实）
+
+1. **cc-plugin 是 auto-discovery，无 `sessionStart` 注入机制。** `.claude-plugin/plugin.json` 不声明 skills 列表，也不配 sessionStart。skill 纯粹靠 description 匹配被路由。因此 cc-plugin 的 `using-jfox` **天然就是「按需路由型」**，而不是 superpowers 那种「SessionStart 强制注入的纪律型」。
+2. **kimi-plugin 已有 `using-jfox`，但是相反的形态。** `packages/kimi-plugin/kimi.plugin.json` 配了 `"sessionStart": {"skill": "using-jfox"}`，其 description 写明「在新会话开始时自动加载…通过插件的 sessionStart 自动注入」。这正是 #243 论证**不应**照搬到 cc-plugin 的形态。两端会出现 `using-jfox` 语义分化（见 FU-2）。
+3. **「共享约定单一来源」已有先例。** `skills-recommend/{kimi-cli,pi}/jfox-common/SKILL.md` 已把跨 skill 的公共约定拆成独立 skill，供非 CC 平台使用。
+4. **备选方案 A 有结构性缺陷。** 把元意图触发词塞进 5 个 skill 的 description，会让它们竞争同一个元意图，反而恶化路由。专用 router 在结构上更干净。
+
+## 目标
+
+- 新增 1 个 `using-jfox` skill，**专门承接元/总览意图**，给一张「意图 → skill」能力地图，并把具体动作派发给 5 个 skill。
+- 不与 5 个 skill 竞争触发：description 刻意只用元词，不含强动词（搜索/导入/整理/保存/管理）。
+- 成为概念（笔记模型）与公共约定的**索引入口**（指向现有 skill，不复制内容）。
+- 不引入 `sessionStart` 强制注入。
+
+## 非目标（本期不做）
+
+- ❌ **不编辑现有 5 个 skill 的 body**（方案 1 的核心约束）。
+- ❌ **不做「单一权威来源」重构**（即不把 manage/organize 的笔记模型/约定段落改成引用 using-jfox）。该重构记为 FU-1，待 #244–247 合并后再做。
+- ❌ **不配 `sessionStart` 注入**（避免纪律型 skill 的副作用与触发竞争）。
+- ❌ **不在 using-jfox 内复制完整命令速查表**（命令在各 skill 里已有；复制 = 维护负担，正是 issue 警告的）。
+- ❌ **本期不改 kimi-plugin 的 using-jfox**（见 FU-2）。
+
+## 决策记录
+
+| 决策 | 选择 | 理由 |
+|------|------|------|
+| 是否新增 skill | **新增** | 元意图无归属；备选 A 会造成触发竞争 |
+| 内容范围 | **方案 1 纯加法** | 零风险、避开 #244–247 文件冲突；单一来源重构转 FU-1 |
+| 命名 | **`using-jfox`** | 与 kimi-plugin 同名（跨插件心智一致）；符合 cc-plugin 无前缀惯例 |
+| 注入方式 | **不注入（按需路由）** | cc-plugin 本就无 sessionStart；路由型无副作用 |
+| 命令速查 | **不放** | 避免与各 skill 重复，规避维护负担 |
+
+## Section 1: 文件与命名
+
+- 新增文件：`packages/cc-plugin/skills/using-jfox/SKILL.md`（单文件，无 references 子目录）。
+- skill 名：`using-jfox`（frontmatter `name: using-jfox`）。在 cc-plugin 命名空间下对外为 `jfox:using-jfox`，与其余 5 个一致。
+- **不**修改 `packages/cc-plugin/.claude-plugin/plugin.json`：cc-plugin 用 auto-discovery，新 skill 放进 `skills/` 即被自动发现，无需声明。
+
+## Section 2: description 与触发词策略（路由核心）
+
+description 是 auto-discovery 路由的唯一依据，**最关键的防竞争设计点**。遵循 #243 指引：只用元词、不含强动词。
+
+```yaml
+name: using-jfox
+description: |
+  Use when the user asks meta or overview questions about jfox as a whole — what jfox
+  can do, how to get started, or which jfox skill/command fits their goal. Triggers on
+  "jfox 能做什么", "jfox 怎么用", "知识库怎么用", "我该用哪个 jfox 命令", "我该用哪个
+  jfox skill", "jfox 有哪些功能", "jfox 入门", "jfox overview", "what can jfox do",
+  "which jfox skill". This skill orients the user and routes to the specific skill; it
+  is not for performing a concrete action.
+```
+
+设计约束：
+
+- **只含元词**：能做什么 / 怎么用 / 哪个 / 入门 / overview。**不含** 搜索/导入/整理/保存/管理/创建知识库 等强动词。
+- 末句「not for performing a concrete action」**刻意不点名具体动作**，避免把强动词写进 description 而被匹配器拾取。
+- body 内可以出现 5 个 skill 名（路由表必需），但 body 不参与 description 匹配，不构成竞争。
+
+## Section 3: body 内容结构（6 段）
+
+body 给概念/约定**一句话 + 指针**，不复制完整内容。结构：
+
+1. **JFox 是什么** — 一句话定位：本地优先的 Zettelkasten 知识管理 CLI（混合搜索 BM25+语义 + 知识图谱 + 多知识库 + Claude Code / Kimi Code 插件）。
+2. **能力地图：我该用哪个 skill** — 决策表（见 Section 4）+ 5 个 skill 各一句话职责。
+3. **笔记模型** — 一句话：fleeting / literature / permanent 三类 + `[[wiki link]]` 双链；深入「见 organize（Step 1–2）」。
+4. **典型复合工作流** — ≥2 条（见 Section 5）。
+5. **公共约定** — 一句话：所有 jfox 命令支持 `--kb`/`--json`/`--content-file`；权威「见 manage §4.1」。
+6. **环境检查** — 2 行：`jfox --version`；未安装则 `uv tool install jfox-cli`。
+
+指针锚点（已核实存在于 main）：
+
+| 指向内容 | 锚点 |
+|---------|------|
+| 公共约定 `--kb`/`--json`/`--content-file` | `manage` skill §4.1 共享约定 |
+| 知识库路径约定 / 多 KB | `manage` skill §2 |
+| 笔记模型 + fleeting→permanent 提炼 | `organize` skill Step 1（Inbox 分析）+ Step 2（提炼） |
+| 健康检查 / 衰减信号 | `manage` skill §5 |
+
+## Section 4: 能力地图决策表（body 核心内容）
+
+「你想做的 → 用哪个 skill」：
+
+| 你想做的 | 用这个 skill | 典型触发词 |
+|---------|-------------|-----------|
+| 搜索 / 查找笔记、检索知识 | `search` | 搜索 / 查找 / find |
+| 把 git 仓库 / PR / issues 导入成素材 | `ingest` | 导入仓库 / ingest repo |
+| 提炼 fleeting→permanent、清理 inbox、补 wiki link、优化图谱 | `organize` | 整理 / 提炼 / clean inbox |
+| 把当前会话总结存入知识库 | `session-summary` | 保存会话 / save session |
+| 创建/切换/删除知识库、命令参考、健康检查、daemon | `manage` | 创建知识库 / kb status / 健康检查 |
+
+5 个 skill 一句话职责（放在决策表下方）：
+
+- **search** — 笔记检索：BM25 / 语义 / 混合搜索 + 知识图谱查询。
+- **ingest** — git 仓库 → fleeting 素材笔记（git log / PR / issues）。
+- **organize** — fleeting → permanent 提炼 + 图谱优化（orphans / 补链）。
+- **session-summary** — 当前会话 → 知识库笔记。
+- **manage** — 知识库生命周期 + 笔记 CRUD 权威参考 + 健康检查 + embedding daemon。
+
+## Section 5: 典型复合工作流（body 内容，≥2 条）
+
+1. **沉淀新知识**：`ingest`（导入素材为 fleeting）→ `organize`（提炼成 permanent + 补 `[[wiki link]]`）→ `search`（日后检索复用）。
+2. **会话沉淀**：`session-summary`（把这次对话存入知识库）→ `organize`（提炼要点为 permanent）。
+3. **知识库维护**：`manage` §5（体检 / 衰减信号检测）→ `organize`（清理 orphans / 补链接）。
+
+## Section 6: 边界与不做清单
+
+（同「非目标」，在 SKILL.md body 末尾以简短「本 skill 不做」段落地化，明确自我边界，防止 agent 误用它执行具体动作。）
+
+## Section 7: 验收标准（对照 issue #243）
+
+- [ ] 新增 `packages/cc-plugin/skills/using-jfox/SKILL.md`。
+- [ ] description 只含元意图触发词，不含与 5 skill 重叠的强动词（可 grep 校验）。
+- [ ] 包含能力地图决策表（用户意图 → skill）。
+- [ ] 笔记模型 / 公共约定以「一句话 + 指针」呈现，指针锚点（manage §4.1 / organize Step 1–2）可解析。
+- [ ] 覆盖 ≥2 条典型复合工作流。
+- [ ] 不引入 `sessionStart` 注入；不修改 `plugin.json`。
+- [ ] 不编辑现有 5 个 skill。
+- [ ] 路由 sanity：问「jfox 能做什么」→ 命中 using-jfox；问「搜索笔记」→ 命中 search，**不**命中 using-jfox。
+
+> issue §5「单一权威来源」一条：本期以「指针」实现（using-jfox 索引现有权威位置，不引入第三份副本）；完整重构转 FU-1。
+
+## Section 8: 验证方式
+
+本 skill 为纯 Markdown，无代码逻辑，验证以静态检查 + 路由 sanity 为主：
+
+1. **frontmatter 合法**：YAML 可解析，`name` / `description` 字段齐全。
+2. **防竞争 grep**：`description` 内不含强动词（搜索/导入/整理/保存会话/管理/创建知识库 等）—— 写一条 grep 断言。
+3. **指针可解析**：body 中 `manage §4.1`、`manage §2`、`manage §5`、`organize Step 1/2` 对应章节确实存在（已核实）。
+4. **路由 sanity（手动）**：装上新 skill 后，分别用元意图（「jfox 能做什么」）和具体意图（「搜索笔记」）提问，确认前者命中 using-jfox、后者命中 search。
+5. **auto-discovery 可见**：新 skill 被 cc-plugin 自动发现（无需改 plugin.json）。
+
+## Section 9: Follow-ups（本期不做，记录防漂移）
+
+- **FU-1（方案 2 单一权威来源）**：待 #244–#247（wiki link / backlink 解析重构，正在改 organize/manage）合并后，把 using-jfox 升级为「笔记模型 + 公共约定」的单一权威来源；编辑 `manage` / `organize`，将其重复段落替换为「详见 using-jfox」。届时需验证所有 `[[link]]` / backlinks 行为未被破坏。
+- **FU-2（两端一致性）**：另开 issue 评估 kimi-plugin 的 `using-jfox` 是否也应从「sessionStart 注入型」转为「按需路由型」，或显式接受两端分化并各自注明。注意两端 skill 引用语法不同（Kimi 用 `/skill:jfox-*`，CC 用 skill 名）。
+
+## 备注
+
+- 本 skill 与 #242（Kimi Code auto-summary）无功能耦合，同属「jfox 作为多 Agent 生态工具」的工程化议题。
+- 实现极小：本质是新增一个 Markdown 文件。复杂度集中在 description 措辞与指针准确性，而非代码。

--- a/packages/cc-plugin/skills/using-jfox/SKILL.md
+++ b/packages/cc-plugin/skills/using-jfox/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: using-jfox
+description: |
+  Use when the user asks meta or overview questions about jfox as a whole — what jfox
+  can do, how to get started, or which jfox skill/command fits their goal. Triggers on
+  "jfox 能做什么", "jfox 怎么用", "知识库怎么用", "我该用哪个 jfox 命令", "我该用哪个
+  jfox skill", "jfox 有哪些功能", "jfox 入门", "jfox overview", "what can jfox do",
+  "which jfox skill". This skill orients the user and routes to the specific skill; it
+  is not for performing a concrete action.
+---
+
+# JFox 总览与路由
+
+JFox 是一个本地优先的 Zettelkasten 知识管理 CLI：混合搜索（BM25 + 语义）、知识图谱、多知识库，并提供 Claude Code / Kimi Code 插件集成。
+
+本 skill **只做总览与路由**：帮你判断「该用哪个 skill」，然后把具体动作派发出去。它不自己执行搜索 / 导入 / 整理 / 保存会话 / 管理这些动作。
+
+## 环境检查
+
+确认 jfox 已安装：
+
+```bash
+jfox --version
+```
+
+未安装时：
+
+```bash
+uv tool install jfox-cli
+```
+
+## 我该用哪个 skill
+
+| 你想做的 | 用这个 skill | 典型触发词 |
+|---------|-------------|-----------|
+| 搜索 / 查找笔记、检索知识 | `search` | 搜索 / 查找 / find |
+| 把 git 仓库 / PR / issues 导入成素材 | `ingest` | 导入仓库 / ingest repo |
+| 提炼 fleeting→permanent、清理 inbox、补 wiki link、优化图谱 | `organize` | 整理 / 提炼 / clean inbox |
+| 把当前会话总结存入知识库 | `session-summary` | 保存会话 / save session |
+| 创建 / 切换 / 删除知识库、命令参考、健康检查、daemon | `manage` | 创建知识库 / kb status / 健康检查 |
+
+5 个 skill 一句话职责：
+
+- **search** — 笔记检索：BM25 / 语义 / 混合搜索 + 知识图谱查询。
+- **ingest** — git 仓库 → fleeting 素材笔记（git log / PR / issues）。
+- **organize** — fleeting → permanent 提炼 + 图谱优化（orphans / 补链）。
+- **session-summary** — 当前会话 → 知识库笔记。
+- **manage** — 知识库生命周期 + 笔记 CRUD 权威参考 + 健康检查 + embedding daemon。
+
+## 笔记模型（一句话）
+
+JFox 笔记分 fleeting / literature / permanent 三类，靠 `[[wiki link]]` 互链。完整的模型与提炼流程见 **organize** skill（Step 1 收件箱分析、Step 2 提炼）。
+
+## 典型复合工作流
+
+1. **沉淀新知识**：`ingest`（导入素材为 fleeting）→ `organize`（提炼成 permanent + 补 `[[wiki link]]`）→ `search`（日后检索复用）。
+2. **会话沉淀**：`session-summary`（把这次对话存入知识库）→ `organize`（提炼要点为 permanent）。
+3. **知识库维护**：`manage`（§5 体检 / 衰减信号检测）→ `organize`（清理 orphans / 补链接）。
+
+## 公共约定（一句话）
+
+所有 jfox 命令支持 `--kb <name>` 指定知识库、`--json`（等价于 `--format json`）输出 JSON、`--content-file <path>` 从文件读取长内容。完整约定见 **manage** skill §4.1。
+
+## 本 skill 不做
+
+- 不执行具体动作（搜索 / 导入 / 整理 / 保存会话 / 管理）——交给对应 skill。
+- 不重复各 skill 的命令速查——命令在各 skill 内有权威版本。

--- a/tests/unit/test_using_jfox_skill.py
+++ b/tests/unit/test_using_jfox_skill.py
@@ -1,0 +1,78 @@
+"""
+测试类型: 单元测试
+目标: cc-plugin using-jfox 总览/路由 skill 的设计契约（issue #243）
+预估耗时: < 1 秒
+依赖要求: 无外部依赖（纯文件读取，不需要知识库 / fixture）
+
+守护的设计不变量（见 docs/superpowers/specs/2026-06-17-using-jfox-skill-design.md）：
+  1. skill 文件存在，frontmatter 合法（name=using-jfox，description 非空）
+  2. description 只含元意图触发词，不含与 5 个能力型 skill 竞争的强动词
+  3. body 中指向 manage / organize 的指针锚点确实存在
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]  # tests/unit/x.py -> repo root
+SKILL_DIR = REPO_ROOT / "packages" / "cc-plugin" / "skills"
+USING_JFOX = SKILL_DIR / "using-jfox" / "SKILL.md"
+
+
+def _frontmatter(path: Path) -> str:
+    """Return the raw YAML frontmatter block (text between the --- fences)."""
+    text = path.read_text(encoding="utf-8")
+    m = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    assert m, f"{path} has no YAML frontmatter"
+    return m.group(1)
+
+
+def test_skill_file_exists():
+    assert USING_JFOX.is_file(), f"expected skill at {USING_JFOX}"
+
+
+def test_frontmatter_name():
+    assert re.search(r"^name:\s*using-jfox\s*$", _frontmatter(USING_JFOX), re.MULTILINE)
+
+
+def test_frontmatter_description_is_non_empty():
+    fm = _frontmatter(USING_JFOX)
+    m = re.search(r"^description:\s*\|?\s*\n(.+)", fm, re.MULTILINE | re.DOTALL)
+    assert m and m.group(1).strip(), "description must be present and non-empty"
+
+
+# 设计核心（#243）：description 绝不能携带 5 个能力型 skill 拥有的强动词，
+# 否则会在 auto-discovery 路由时与它们竞争同一个意图。
+@pytest.mark.parametrize(
+    "verb",
+    ["搜索", "查找", "导入", "整理", "保存会话", "创建知识库", "管理知识库", "健康检查"],
+)
+def test_description_has_no_competing_verbs(verb):
+    assert verb not in _frontmatter(USING_JFOX), (
+        f"competing verb {verb!r} must not appear in using-jfox frontmatter "
+        f"(see spec Section 2 / issue #243)"
+    )
+
+
+@pytest.mark.parametrize("trigger", ["能做什么", "overview", "入门"])
+def test_description_carries_meta_triggers(trigger):
+    assert trigger in _frontmatter(USING_JFOX), f"description should carry meta trigger {trigger!r}"
+
+
+def test_pointers_resolve():
+    """body 指向 manage / organize 的锚点必须真实存在，避免路由到缺失章节。"""
+    assert USING_JFOX.is_file()
+    checks = [
+        (SKILL_DIR / "manage" / "SKILL.md", "共享约定"),  # §4.1
+        (SKILL_DIR / "manage" / "SKILL.md", "知识库路径"),  # §2
+        (SKILL_DIR / "manage" / "SKILL.md", "健康检查"),  # §5
+        (SKILL_DIR / "organize" / "SKILL.md", "Inbox"),  # Step 1
+        (SKILL_DIR / "organize" / "SKILL.md", "提炼"),  # Step 2
+    ]
+    missing = [
+        (str(p), anchor) for p, anchor in checks if anchor not in p.read_text(encoding="utf-8")
+    ]
+    assert not missing, f"pointers point at missing sections: {missing}"


### PR DESCRIPTION
## 变更描述

新增 cc-plugin 的 `using-jfox` 总览/路由 skill（issue #243）。

JFox 现有 5 个能力型 skill（search / ingest / manage / organize / session-summary）触发词清晰、路由已准，但「jfox 能做什么 / 我该用哪个 skill」这类**元/总览意图没有归属**，目前只能靠 CLAUDE.md 或 agent 自由发挥。本 PR 新增第 6 个 skill `using-jfox` 专门承接元意图，给出能力地图决策表，并把具体动作派发到那 5 个 skill。

**关键设计决策**：`description` 刻意**只用元词**（能做什么 / 怎么用 / 哪个 / 入门 / overview）、**不含强动词**，避免在 auto-discovery 路由时与 5 个 skill 竞争同一个意图。一个 unit 契约测试守护这个不变量。形态**不是** superpowers 那种 SessionStart 强制注入——cc-plugin 本就是 auto-discovery，按需路由即可，没有「agent 偷懒跳过」的纪律问题需要纠正。

方案为**纯加法（方案 1）**：不改 `plugin.json`、不编辑现有 5 个 skill；笔记模型 / 公共约定以「一句话 + 指针」引用现有权威位置（manage §4.1 / organize Step 1–2），单一权威来源重构留作 follow-up（待 #244–247 合并后）。

## 关联 Issue

Fixes #243

## 变更类型

- [x] ✨ 新功能（不破坏兼容性的新增）
- [x] 📝 文档更新
- [x] ✅ 测试（新增测试覆盖）

## 具体改动

- 新增 `packages/cc-plugin/skills/using-jfox/SKILL.md` —— 总览/路由 skill（能力地图决策表 + 5 skill 职责 + 笔记模型/约定指针 + 3 条复合工作流 + 自我边界）
- 新增 `tests/unit/test_using_jfox_skill.py` —— 契约测试：frontmatter 合法、description 无 8 个竞争动词、含元触发词、body 指针锚点在 manage/organize 中可解析（15 个用例）
- 设计 spec：`docs/superpowers/specs/2026-06-17-using-jfox-skill-design.md`
- 实现计划：`docs/superpowers/plans/2026-06-17-using-jfox-skill.md`
- **不改动** `plugin.json` 或任何现有 skill —— cc-plugin 用 auto-discovery，新 skill 放进 `skills/` 即自动发现

## 测试步骤

1. `uv run pytest tests/unit/test_using_jfox_skill.py -v` → **15 passed**
2. `ls packages/cc-plugin/skills/` → `using-jfox` 与 5 个 skill 并列（auto-discovery 可见）
3. `git diff main -- packages/cc-plugin/.claude-plugin/plugin.json packages/cc-plugin/skills/{search,ingest,manage,organize,session-summary}` → **空**（未改动）
4. 手动路由 sanity（需在装好插件的会话里验证）：问「jfox 能做什么」应命中 **using-jfox**；问「搜索一下笔记」应命中 **search** 而非 using-jfox

## 检查清单

### 代码

- [x] 已阅读项目的 `AGENTS.md` 和开发规范
- [x] commit 遵循 Conventional Commits（`feat:` / `docs:`）
- [x] 已搜索现有 PR 确认无重复
- [x] PR 只含本次相关改动（worktree 里一个无关的 `uv.lock` 变更未提交）
- [x] `uvx ruff check tests/unit/test_using_jfox_skill.py` 通过
- [x] `uvx black --check tests/unit/test_using_jfox_skill.py` 通过
- [ ] `uv run pytest tests/ -m "not embedding and not slow"` —— 本 worktree 环境缺 `typer`，导致 11 个**既有**测试文件（test_show.py 等）收集报错 `ModuleNotFoundError: No module named 'typer'`，与本变更无关（本变更纯加法，不可能影响它们）；新测试 15/15 通过。完整 fast suite 留给 CI 跑。
- [x] 本地测试通过（Linux）

### 文档与维护

- [x] 已更新相关文档（新增 skill + spec + plan）
- [x] N/A 跨平台（纯 Markdown / Python，无平台相关逻辑）
- [x] N/A 工具描述 / schema 变更

## Follow-up（本期不做，spec §9 已记录）

- **FU-1**：待 #244–#247（wiki link / backlink 解析重构）合并后，把 using-jfox 升级为「笔记模型 + 公共约定」的单一权威来源，编辑 `manage` / `organize` 将重复段落改为引用。
- **FU-2**：另开 issue 评估 kimi-plugin 的 `using-jfox`（当前为 sessionStart 注入型）是否也转为按需路由型，或显式接受两端分化。
