### PR TITLE
feat(cli): jfox list 增加 Out/In backlinks 计数列 (#253)

### DIFF
--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -807,8 +807,8 @@ def _list_impl(
     data = []
     for n in notes:
         d = n.to_dict()
-        d["outgoing"] = len(n.links)
-        d["incoming"] = len(n.backlinks)
+        d["outgoing"] = len(n.links or [])
+        d["incoming"] = len(n.backlinks or [])
         data.append(d)
 
     result = {
@@ -848,7 +848,7 @@ def _list_impl(
         if output_format == "csv":
             console.print(
                 OutputFormatter.to_csv(
-                    data, headers=["id", "title", "type", "outgoing", "incoming", "tags", "created"]
+                    data, headers=["id", "title", "type", "tags", "created", "outgoing", "incoming"]
                 )
             )
         elif output_format == "yaml":

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -834,8 +834,8 @@ def _list_impl(
                 n.id,
                 n.title[:40],
                 n.type.value,
-                str(len(n.links)),
-                str(len(n.backlinks)),
+                str(len(n.links or [])),
+                str(len(n.backlinks or [])),
                 ", ".join(n.tags) if n.tags else "",
                 created_str,
             )

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -804,7 +804,12 @@ def _list_impl(
             )
 
     notes = note.list_notes(note_type=nt, tags=tags, limit=limit)
-    data = [n.to_dict() for n in notes]
+    data = []
+    for n in notes:
+        d = n.to_dict()
+        d["outgoing"] = len(n.links)
+        d["incoming"] = len(n.backlinks)
+        data.append(d)
 
     result = {
         "total": len(notes),
@@ -818,13 +823,21 @@ def _list_impl(
         table.add_column("ID", style="dim")
         table.add_column("Title", style="cyan")
         table.add_column("Type", style="green")
+        table.add_column("Out", justify="right")
+        table.add_column("In", justify="right")
         table.add_column("Tags", style="yellow")
         table.add_column("Created", style="dim")
 
         for n in notes:
             created_str = n.created.strftime("%Y-%m-%d") if n.created else ""
             table.add_row(
-                n.id, n.title[:40], n.type.value, ", ".join(n.tags) if n.tags else "", created_str
+                n.id,
+                n.title[:40],
+                n.type.value,
+                str(len(n.links)),
+                str(len(n.backlinks)),
+                ", ".join(n.tags) if n.tags else "",
+                created_str,
             )
 
         console.print(table)
@@ -834,7 +847,9 @@ def _list_impl(
         # 对于 csv, yaml, paths，只输出 notes 列表
         if output_format == "csv":
             console.print(
-                OutputFormatter.to_csv(data, headers=["id", "title", "type", "tags", "created"])
+                OutputFormatter.to_csv(
+                    data, headers=["id", "title", "type", "outgoing", "incoming", "tags", "created"]
+                )
             )
         elif output_format == "yaml":
             print(OutputFormatter.to_yaml(result))

--- a/tests/test_cli_format.py
+++ b/tests/test_cli_format.py
@@ -47,6 +47,44 @@ class TestCLIFormat:
         # Table 格式应该有表格边框和标题
         assert "ID" in result.stdout or "Title" in result.stdout
 
+    def test_list_table_shows_link_counts(self, cli, sample_notes):
+        """list --format table 应显示 Out / In 列"""
+        target_title = sample_notes[0]["title"]
+        result = cli.add(f"链接到 [[{target_title}]]", title="链接源笔记", note_type="permanent")
+        assert result.success
+
+        result = cli.run("list", "--format", "table")
+        assert result.success
+        assert "Out" in result.stdout
+        assert "In" in result.stdout
+
+    def test_list_json_includes_link_counts(self, cli, sample_notes):
+        """list --format json 应包含 outgoing / incoming 数量"""
+        target_title = sample_notes[0]["title"]
+        result = cli.add(f"链接到 [[{target_title}]]", title="链接源笔记", note_type="permanent")
+        assert result.success
+
+        result = cli.run("list", "--format", "json")
+        assert result.success
+        data = json.loads(result.stdout)
+        notes = data["notes"]
+
+        source = next(n for n in notes if n["title"] == "链接源笔记")
+        target = next(n for n in notes if n["title"] == target_title)
+        assert source["outgoing"] == 1
+        assert source["incoming"] == 0
+        assert target["outgoing"] == 0
+        assert target["incoming"] == 1
+
+    def test_list_csv_includes_link_counts(self, cli, sample_notes):
+        """list --format csv 应包含 outgoing / incoming 列"""
+        result = cli.run("list", "--format", "csv")
+
+        assert result.success
+        header = result.stdout.strip().split("\n")[0]
+        assert "outgoing" in header
+        assert "incoming" in header
+
     def test_list_format_csv(self, cli, sample_notes):
         """测试 list 命令 --format csv"""
         result = cli.run("list", "--format", "csv")


### PR DESCRIPTION
解决 #253

- 在 `jfox list` 的 table 输出中新增 "Out" / "In" 列，分别显示 outgoing links 和 incoming backlinks 数量。
- `json` / `yaml` / `csv` 格式同步输出 `outgoing` / `incoming` 字段。
- 复用 `Note.links` / `Note.backlinks` 的已有逻辑，与 `jfox refs` 保持一致。
- 新增对应 CLI 格式测试。