### PR TITLE
fix(cli): jfox index rebuild --backlinks recalculates wiki links and backlinks

### DIFF
--- a/docs/superpowers/plans/2026-06-17-index-rebuild-backlinks.md
+++ b/docs/superpowers/plans/2026-06-17-index-rebuild-backlinks.md
@@ -1,0 +1,166 @@
+# Issue #252: `jfox index rebuild` 重新计算 backlinks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 `jfox index rebuild` 支持 `--backlinks` 选项，在重建索引时重新解析 wiki links 并计算 backlinks。
+
+**Architecture:** 在 `jfox/cli.py` 中新增 `_rebuild_backlinks_impl()` 内部函数，在 `index rebuild` action 中按用户传入的 `--backlinks` 标志调用；函数全量加载笔记、解析 `[[...]]` 链接、解析目标 ID、重新计算并写回变化的笔记。
+
+**Tech Stack:** Python, Typer, pytest
+
+---
+
+### Task 1: 实现 `_rebuild_backlinks_impl()` 内部函数
+
+**Files:**
+- Modify: `jfox/cli.py`（在 `extract_wiki_links` / `find_note_id_by_title_or_id` 附近或 `_add_note_impl` 之后新增函数）
+
+- [ ] **Step 1: 编写核心函数**
+
+  新增函数签名：
+  ```python
+  def _rebuild_backlinks_impl(output_format: str = "table") -> Dict[str, Any]:
+      ...
+  ```
+
+  功能：
+  1. 调用 `note.list_notes(limit=10000)` 加载所有笔记
+  2. 遍历笔记，调用 `extract_wiki_links(note.content)` 提取链接
+  3. 调用 `find_note_id_by_title_or_id(link_text)` 解析目标 ID
+  4. 构建 `new_links: Dict[str, List[str]]` 和 `new_backlinks: Dict[str, List[str]]`
+  5. 对每个笔记，比较现有 `links`/`backlinks` 与新计算结果
+  6. 如有变化，更新 Note 对象并调用 `note.save_note(note, add_to_index=False)`
+  7. 返回统计信息：`backlinks_rebuilt`, `backlinks_updated`, `backlinks_total`, `unresolved_links`
+
+- [ ] **Step 2: 处理边界情况**
+
+  - 空知识库：返回 `backlinks_total=0`, `backlinks_updated=0`
+  - 未解析链接：收集到 `unresolved_links` 列表中用于警告输出
+  - 保存失败：记录 warning，不中断流程
+
+---
+
+### Task 2: 在 `index rebuild` action 中集成 `--backlinks` 选项
+
+**Files:**
+- Modify: `jfox/cli.py:index()` 命令参数
+- Modify: `jfox/cli.py` 中 `action == "rebuild"` 分支
+
+- [ ] **Step 1: 添加 Typer 选项**
+
+  在 `index()` 命令中新增：
+  ```python
+  backlinks: bool = typer.Option(False, "--backlinks", "-b", help="重建时重新计算 backlinks"),
+  ```
+
+- [ ] **Step 2: 在 rebuild action 中调用**
+
+  在 `action == "rebuild"` 分支中，BM25 重建完成后：
+  ```python
+  if backlinks:
+      bl_result = _rebuild_backlinks_impl(output_format)
+      result.update(bl_result)
+  ```
+
+- [ ] **Step 3: 更新输出**
+
+  JSON 输出：合并 `backlinks_rebuilt`, `backlinks_updated`, `backlinks_total`, `unresolved_links`
+  Table 输出：增加对应行，显示 `Backlinks rebuilt: X / Y`，以及未解析链接警告
+
+---
+
+### Task 3: 编写测试
+
+**Files:**
+- New: `tests/integration/test_index_rebuild_backlinks.py`
+- New: `tests/unit/test_rebuild_backlinks_impl.py`
+
+- [ ] **Step 1: 编写集成测试**
+
+  `tests/integration/test_index_rebuild_backlinks.py`：
+  - 使用 `cli` fixture 初始化临时知识库
+  - 创建目标笔记 A 和源笔记 B（B 引用 A）
+  - 手动修改 A 的 frontmatter，移除其 `backlinks`
+  - 执行 `cli.index("rebuild", "--backlinks")`
+  - 验证 `refs A` 的 `backward_links` 包含 B
+  - 验证 JSON 输出中的 `backlinks_updated > 0`
+
+- [ ] **Step 2: 编写单元测试**
+
+  `tests/unit/test_rebuild_backlinks_impl.py`：
+  - Mock `note.list_notes()` 返回若干笔记对象
+  - 调用 `_rebuild_backlinks_impl()`
+  - 验证统计信息正确
+  - 验证 `save_note` 只在变化时调用
+
+- [ ] **Step 3: 验证默认行为不变**
+
+  集成测试增加：
+  - 默认 `jfox index rebuild`（无 `--backlinks`）不应修改任何笔记的 backlinks
+
+---
+
+### Task 4: 运行测试与代码检查
+
+- [ ] **Step 1: 运行新增单元测试**
+
+  ```bash
+  uv run pytest tests/unit/test_rebuild_backlinks_impl.py -v
+  ```
+
+- [ ] **Step 2: 运行新增集成测试**
+
+  ```bash
+  uv run pytest tests/integration/test_index_rebuild_backlinks.py -v
+  ```
+
+- [ ] **Step 3: 运行快速测试集**
+
+  ```bash
+  uv run pytest tests/ -m "not embedding and not slow" -q
+  ```
+
+- [ ] **Step 4: 代码风格检查**
+
+  ```bash
+  uv run ruff check jfox/cli.py tests/unit/test_rebuild_backlinks_impl.py tests/integration/test_index_rebuild_backlinks.py
+  uv run black --check jfox/cli.py tests/unit/test_rebuild_backlinks_impl.py tests/integration/test_index_rebuild_backlinks.py
+  ```
+
+---
+
+### Task 5: 提交与 PR
+
+- [ ] **Step 1: 整理提交**
+
+  使用 Conventional Commits：
+  ```bash
+  git add jfox/cli.py tests/unit/test_rebuild_backlinks_impl.py tests/integration/test_index_rebuild_backlinks.py docs/superpowers/specs/2026-06-17-index-rebuild-backlinks-design.md docs/superpowers/plans/2026-06-17-index-rebuild-backlinks.md
+  git commit -m "fix(cli): jfox index rebuild --backlinks recalculates wiki links and backlinks
+
+  - Add --backlinks/-b option to jfox index rebuild
+  - Add _rebuild_backlinks_impl() to parse [[...]] links and recompute backlinks
+  - Update output JSON/table with backlinks rebuild stats
+  - Add unit and integration tests
+
+  Closes #252"
+  ```
+
+- [ ] **Step 2: 推送分支**
+
+  ```bash
+  git push origin fix/252-index-rebuild-backlinks
+  ```
+
+- [ ] **Step 3: 创建 PR**
+
+  PR 标题：`fix(cli): jfox index rebuild --backlinks recalculates wiki links and backlinks`
+  PR 描述包含：
+  - 问题描述
+  - 修改内容
+  - 测试说明
+  - `Closes #252`
+
+- [ ] **Step 4: 等待 CI 通过**
+
+  在 PR 页面确认 Fast / Core workflow 通过。

--- a/docs/superpowers/specs/2026-06-17-index-rebuild-backlinks-design.md
+++ b/docs/superpowers/specs/2026-06-17-index-rebuild-backlinks-design.md
@@ -1,0 +1,99 @@
+# Issue #252: `jfox index rebuild` 重新计算 backlinks 设计文档
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+## 背景
+
+`jfox index rebuild` 当前只重建：
+1. ChromaDB 向量索引（`Indexer.index_all()` → `vector_store.reset_collection()` + 全量 add）
+2. BM25 关键词索引（`bm25_index.rebuild_from_notes()`）
+
+但它**没有**重新解析笔记正文中的 `[[笔记标题]]` 维基链接，也没有根据解析结果更新笔记 frontmatter 中的 `links` 和 `backlinks` 字段。
+
+这会导致以下问题：
+- 手动修改笔记文件后，即使执行 `jfox index rebuild`，backlinks 关系也不会恢复
+- 知识库迁移/整理后，链接网络丢失
+- 必须通过 `jfox add` 重新创建笔记才能建立链接
+
+## 目标
+
+让 `jfox index rebuild` 支持可选的 `--backlinks` 参数，在重建索引的同时：
+1. 全量加载所有笔记
+2. 解析每篇笔记正文中的 `[[...]]` 维基链接
+3. 按标题/ID 解析链接目标
+4. 更新每篇笔记的 `links` 字段（按当前内容重新生成）
+5. 根据所有笔记的 `links` 重新计算每篇笔记的 `backlinks`
+6. 只写入确实有变化的笔记文件，避免无意义的 I/O
+
+## 非目标
+
+- 不修改 `jfox add` / `jfox edit` 的现有 backlinks 维护逻辑
+- 不改变 `jfox index rebuild` 的默认行为（默认不重建 backlinks，避免意外覆盖用户手动写入的 frontmatter）
+- 不引入新的持久化存储格式
+
+## 方案
+
+### 1. 新增 `jfox index rebuild --backlinks`
+
+在 `jfox/cli.py` 的 `index()` 命令中：
+- 为 `rebuild` action 增加 `--backlinks` / `-b` 选项
+- 当用户传入 `--backlinks` 时，在 `indexer.index_all()` 和 BM25 重建完成后调用 backlinks 重建逻辑
+
+### 2. 独立函数 `_rebuild_backlinks_impl()`
+
+在 `jfox/cli.py` 中新增内部实现函数，职责单一：
+- 通过 `note.list_notes()` 加载所有笔记
+- 构建 `标题/ID → note_id` 的解析映射
+- 遍历每篇笔记，调用现有 `extract_wiki_links()` 提取链接
+- 对每个链接调用 `find_note_id_by_title_or_id()` 解析
+- 汇总得到新的 `links` 和 `backlinks`
+- 与现有值比较，仅当变化时才调用 `note.save_note(note, add_to_index=False)` 写回文件
+
+### 3. 输出与结果
+
+JSON 输出增加字段：
+- `backlinks_rebuilt`: bool
+- `backlinks_updated`: int（实际写入文件的笔记数量）
+- `backlinks_total`: int（扫描的笔记总数）
+- `unresolved_links`: List[str]（无法解析的链接文本，去重）
+
+Table 输出增加对应行：
+- `✓ Backlinks rebuilt: X notes updated / Y scanned`
+- 如有未解析链接，显示警告
+
+### 4. 错误处理
+
+- 加载失败的笔记跳过，记录 warning
+- 保存失败不中断整个流程，记录 warning，但 `backlinks_rebuilt` 仍为 True（部分成功）
+- 无任何笔记时返回成功
+
+## 关键代码位置
+
+- `jfox/cli.py:1935-1959`：`rebuild` action 的现有实现
+- `jfox/cli.py:237-243`：现有 `extract_wiki_links()`
+- `jfox/cli.py:246-290`：现有 `find_note_id_by_title_or_id()`
+- `jfox/note.py:97-125`：`save_note()` 支持 `add_to_index=False`
+
+## 测试策略
+
+1. **集成测试**：在临时知识库中创建笔记 A、B，B 引用 A，手动清空 A 的 `backlinks` 字段，执行 `jfox index rebuild --backlinks`，验证 A 的 backlinks 恢复
+2. **单元测试**：测试 `_rebuild_backlinks_impl()` 的链接解析与 backlinks 计算逻辑（使用 mock 笔记）
+3. **边界测试**：
+   - 空知识库
+   - 链接到不存在的笔记
+   - 多个笔记链接到同一目标
+   - 没有 `--backlinks` 时不应修改任何笔记
+
+## 兼容性
+
+- 默认行为不变，不影响现有用户
+- 新增的 `--backlinks` 选项是可选的
+- 输出 JSON 新增字段，不会破坏现有解析（新增字段是兼容的）
+
+## 验收标准
+
+- [ ] `jfox index rebuild --backlinks` 成功重新计算并写入所有 backlinks
+- [ ] 默认 `jfox index rebuild` 行为与修改前一致
+- [ ] 新增集成测试通过
+- [ ] ruff / black 检查通过
+- [ ] PR 描述关联 issue #252

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -291,11 +291,13 @@ def find_note_id_by_title_or_id(
 
 
 def _rebuild_backlinks_impl(output_format: str = "table") -> Dict[str, Any]:
-    """重新计算所有笔记的 backlinks。
+    """重新计算所有笔记的 links 和 backlinks。
 
     全量加载笔记，解析正文中的 [[...]] 链接，按标题/ID 解析目标笔记，
-    重新计算每篇笔记 frontmatter 中的 backlinks 字段。只有 backlinks 发生变化的
-    笔记才会被重新写入文件，避免无意义的 I/O；forward links 不会被覆盖。
+    更新每篇笔记 frontmatter 中的 links 和 backlinks 字段。forward links 采用
+    合并策略：保留现有 frontmatter 链接，同时把正文新解析出的合法链接加入进去，
+    避免静默删除用户手写链接；backlinks 根据合并后的 forward links 重新计算。
+    只有发生变化的笔记才会被重新写入文件，避免无意义的 I/O。
 
     Args:
         output_format: 输出格式，用于控制是否在控制台打印进度信息
@@ -324,7 +326,7 @@ def _rebuild_backlinks_impl(output_format: str = "table") -> Dict[str, Any]:
     note_by_id = {n.id: n for n in notes}
 
     # 第一阶段：解析每篇笔记的 wiki links，过滤自链接
-    new_links: Dict[str, List[str]] = {n.id: [] for n in notes}
+    parsed_links: Dict[str, List[str]] = {n.id: [] for n in notes}
     unresolved: List[str] = []
 
     for n in notes:
@@ -336,19 +338,24 @@ def _rebuild_backlinks_impl(output_format: str = "table") -> Dict[str, Any]:
                 if target_id == n.id:
                     continue
                 # 避免同一笔记内重复链接同一目标
-                if target_id not in new_links[n.id]:
-                    new_links[n.id].append(target_id)
+                if target_id not in parsed_links[n.id]:
+                    parsed_links[n.id].append(target_id)
             else:
                 unresolved.append(link_text)
 
-    # 第二阶段：根据新的 links 重新计算 backlinks
+    # 第二阶段：合并现有 forward links 与解析出的 links，然后重新计算 backlinks
+    merged_links: Dict[str, List[str]] = {}
     new_backlinks: Dict[str, List[str]] = {n.id: [] for n in notes}
-    for source_id, target_ids in new_links.items():
-        for target_id in target_ids:
-            if source_id not in new_backlinks[target_id]:
-                new_backlinks[target_id].append(source_id)
+    for n in notes:
+        # 保留用户手写的 forward links，同时加入正文解析出的合法链接
+        merged = sorted(set(n.links + parsed_links[n.id]))
+        merged_links[n.id] = merged
+        # 只有目标笔记真实存在时才生成反向链接
+        for target_id in merged:
+            if target_id in note_by_id and n.id not in new_backlinks[target_id]:
+                new_backlinks[target_id].append(n.id)
 
-    # 第三阶段：比较并写回变化的笔记（只写 backlinks，不覆盖 forward links）
+    # 第三阶段：比较并写回变化的笔记
     updated_count = 0
     failed_count = 0
     changed_note_ids: List[str] = []
@@ -356,11 +363,14 @@ def _rebuild_backlinks_impl(output_format: str = "table") -> Dict[str, Any]:
     for n in notes:
         # 注意：cli.py 模块级存在名为 list 的命令函数，会遮蔽 built-in list()，
         # 因此这里使用切片复制列表。
+        old_links = n.links[:]
         old_backlinks = n.backlinks[:]
+        new_links_sorted = merged_links[n.id]
         new_backlinks_sorted = sorted(new_backlinks[n.id])
 
-        if sorted(old_backlinks) != new_backlinks_sorted:
+        if sorted(old_links) != new_links_sorted or sorted(old_backlinks) != new_backlinks_sorted:
             # 排序后写回，保证 frontmatter 顺序稳定
+            n.links = new_links_sorted
             n.backlinks = new_backlinks_sorted
             try:
                 if note.save_note(n, add_to_index=False):

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -291,20 +291,21 @@ def find_note_id_by_title_or_id(
 
 
 def _rebuild_backlinks_impl(output_format: str = "table") -> Dict[str, Any]:
-    """重新计算所有笔记的 wiki links 和 backlinks。
+    """重新计算所有笔记的 backlinks。
 
     全量加载笔记，解析正文中的 [[...]] 链接，按标题/ID 解析目标笔记，
-    更新每篇笔记 frontmatter 中的 links 和 backlinks 字段。只有发生变化的
-    笔记才会被重新写入文件，避免无意义的 I/O。
+    重新计算每篇笔记 frontmatter 中的 backlinks 字段。只有 backlinks 发生变化的
+    笔记才会被重新写入文件，避免无意义的 I/O；forward links 不会被覆盖。
 
     Args:
         output_format: 输出格式，用于控制是否在控制台打印进度信息
 
     Returns:
         统计信息字典，包含 backlinks_rebuilt, backlinks_updated, backlinks_total,
-        unresolved_links 等字段
+        backlinks_failed, unresolved_links 等字段
     """
-    console.print("[yellow]Rebuilding backlinks...[/yellow]")
+    if output_format != "json":
+        console.print("[yellow]Rebuilding backlinks...[/yellow]")
 
     # 加载所有笔记
     notes = note.list_notes(limit=10000)
@@ -315,13 +316,14 @@ def _rebuild_backlinks_impl(output_format: str = "table") -> Dict[str, Any]:
             "backlinks_rebuilt": True,
             "backlinks_updated": 0,
             "backlinks_total": 0,
+            "backlinks_failed": 0,
             "unresolved_links": [],
         }
 
     # 构建 id -> note 映射，用于后续 backlinks 计算
     note_by_id = {n.id: n for n in notes}
 
-    # 第一阶段：解析每篇笔记的 wiki links
+    # 第一阶段：解析每篇笔记的 wiki links，过滤自链接
     new_links: Dict[str, List[str]] = {n.id: [] for n in notes}
     unresolved: List[str] = []
 
@@ -330,6 +332,9 @@ def _rebuild_backlinks_impl(output_format: str = "table") -> Dict[str, Any]:
         for link_text in wiki_links:
             target_id = find_note_id_by_title_or_id(link_text)
             if target_id and target_id in note_by_id:
+                # 过滤自链接，避免笔记指向自身
+                if target_id == n.id:
+                    continue
                 # 避免同一笔记内重复链接同一目标
                 if target_id not in new_links[n.id]:
                     new_links[n.id].append(target_id)
@@ -343,7 +348,7 @@ def _rebuild_backlinks_impl(output_format: str = "table") -> Dict[str, Any]:
             if source_id not in new_backlinks[target_id]:
                 new_backlinks[target_id].append(source_id)
 
-    # 第三阶段：比较并写回变化的笔记
+    # 第三阶段：比较并写回变化的笔记（只写 backlinks，不覆盖 forward links）
     updated_count = 0
     failed_count = 0
     changed_note_ids: List[str] = []
@@ -351,14 +356,12 @@ def _rebuild_backlinks_impl(output_format: str = "table") -> Dict[str, Any]:
     for n in notes:
         # 注意：cli.py 模块级存在名为 list 的命令函数，会遮蔽 built-in list()，
         # 因此这里使用切片复制列表。
-        old_links = n.links[:]
         old_backlinks = n.backlinks[:]
-        new_links_sorted = sorted(new_links[n.id])
         new_backlinks_sorted = sorted(new_backlinks[n.id])
 
-        if sorted(old_links) != new_links_sorted or sorted(old_backlinks) != new_backlinks_sorted:
-            n.links = new_links[n.id]
-            n.backlinks = new_backlinks[n.id]
+        if sorted(old_backlinks) != new_backlinks_sorted:
+            # 排序后写回，保证 frontmatter 顺序稳定
+            n.backlinks = new_backlinks_sorted
             try:
                 if note.save_note(n, add_to_index=False):
                     updated_count += 1
@@ -397,6 +400,7 @@ def _rebuild_backlinks_impl(output_format: str = "table") -> Dict[str, Any]:
         "backlinks_rebuilt": True,
         "backlinks_updated": updated_count,
         "backlinks_total": total,
+        "backlinks_failed": failed_count,
         "unresolved_links": unresolved_unique,
     }
 
@@ -2096,6 +2100,11 @@ def _index_impl(action: str, output_format: str, backlinks: bool = False):
                         f"{result.get('backlinks_updated', 0)} note(s) updated / "
                         f"{result.get('backlinks_total', 0)} scanned"
                     )
+                    failed = result.get("backlinks_failed", 0)
+                    if failed > 0:
+                        console.print(
+                            f"[yellow]⚠[/yellow] {failed} note(s) failed to save during backlinks rebuild"
+                        )
                     unresolved = result.get("unresolved_links", [])
                     if unresolved:
                         console.print(
@@ -2154,7 +2163,7 @@ def index(
     json_output: bool = typer.Option(
         False, "--json", help="JSON 输出（快捷方式，等同于 --format json）"
     ),
-    backlinks: bool = typer.Option(False, "--backlinks", "-b", help="rebuild 时重新计算 backlinks"),
+    backlinks: bool = typer.Option(False, "--backlinks", "-b", help="rebuild 时重新计算反向链接"),
 ):
     """索引管理：查看状态、重建索引、验证完整性"""
     try:

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -8,7 +8,7 @@ import sys
 import warnings
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import yaml
 
@@ -288,6 +288,117 @@ def find_note_id_by_title_or_id(
             return meta.id
 
     return None
+
+
+def _rebuild_backlinks_impl(output_format: str = "table") -> Dict[str, Any]:
+    """重新计算所有笔记的 wiki links 和 backlinks。
+
+    全量加载笔记，解析正文中的 [[...]] 链接，按标题/ID 解析目标笔记，
+    更新每篇笔记 frontmatter 中的 links 和 backlinks 字段。只有发生变化的
+    笔记才会被重新写入文件，避免无意义的 I/O。
+
+    Args:
+        output_format: 输出格式，用于控制是否在控制台打印进度信息
+
+    Returns:
+        统计信息字典，包含 backlinks_rebuilt, backlinks_updated, backlinks_total,
+        unresolved_links 等字段
+    """
+    console.print("[yellow]Rebuilding backlinks...[/yellow]")
+
+    # 加载所有笔记
+    notes = note.list_notes(limit=10000)
+    total = len(notes)
+
+    if total == 0:
+        return {
+            "backlinks_rebuilt": True,
+            "backlinks_updated": 0,
+            "backlinks_total": 0,
+            "unresolved_links": [],
+        }
+
+    # 构建 id -> note 映射，用于后续 backlinks 计算
+    note_by_id = {n.id: n for n in notes}
+
+    # 第一阶段：解析每篇笔记的 wiki links
+    new_links: Dict[str, List[str]] = {n.id: [] for n in notes}
+    unresolved: List[str] = []
+
+    for n in notes:
+        wiki_links = extract_wiki_links(n.content)
+        for link_text in wiki_links:
+            target_id = find_note_id_by_title_or_id(link_text)
+            if target_id and target_id in note_by_id:
+                # 避免同一笔记内重复链接同一目标
+                if target_id not in new_links[n.id]:
+                    new_links[n.id].append(target_id)
+            else:
+                unresolved.append(link_text)
+
+    # 第二阶段：根据新的 links 重新计算 backlinks
+    new_backlinks: Dict[str, List[str]] = {n.id: [] for n in notes}
+    for source_id, target_ids in new_links.items():
+        for target_id in target_ids:
+            if source_id not in new_backlinks[target_id]:
+                new_backlinks[target_id].append(source_id)
+
+    # 第三阶段：比较并写回变化的笔记
+    updated_count = 0
+    failed_count = 0
+    changed_note_ids: List[str] = []
+
+    for n in notes:
+        # 注意：cli.py 模块级存在名为 list 的命令函数，会遮蔽 built-in list()，
+        # 因此这里使用切片复制列表。
+        old_links = n.links[:]
+        old_backlinks = n.backlinks[:]
+        new_links_sorted = sorted(new_links[n.id])
+        new_backlinks_sorted = sorted(new_backlinks[n.id])
+
+        if sorted(old_links) != new_links_sorted or sorted(old_backlinks) != new_backlinks_sorted:
+            n.links = new_links[n.id]
+            n.backlinks = new_backlinks[n.id]
+            try:
+                if note.save_note(n, add_to_index=False):
+                    updated_count += 1
+                    changed_note_ids.append(n.id)
+                else:
+                    failed_count += 1
+                    logger.warning(f"Failed to save note {n.id} during backlinks rebuild")
+            except Exception as e:
+                failed_count += 1
+                logger.warning(f"Failed to save note {n.id} during backlinks rebuild: {e}")
+
+    # 去重未解析链接并保持顺序
+    seen_unresolved = set()
+    unresolved_unique = []
+    for link_text in unresolved:
+        if link_text not in seen_unresolved:
+            seen_unresolved.add(link_text)
+            unresolved_unique.append(link_text)
+
+    if output_format != "json":
+        console.print(
+            f"[green]✓[/green] Backlinks rebuilt: {updated_count} note(s) updated / {total} scanned"
+        )
+        if failed_count > 0:
+            console.print(
+                f"[yellow]⚠[/yellow] {failed_count} note(s) failed to save during backlinks rebuild"
+            )
+        if unresolved_unique:
+            console.print(
+                f"[yellow]⚠[/yellow] Unresolved links: {', '.join(unresolved_unique[:5])}"
+            )
+            if len(unresolved_unique) > 5:
+                console.print(f"[yellow]  ... and {len(unresolved_unique) - 5} more[/yellow]")
+
+    return {
+        "backlinks_rebuilt": True,
+        "backlinks_updated": updated_count,
+        "backlinks_total": total,
+        "unresolved_links": unresolved_unique,
+    }
 
 
 def _add_note_impl(
@@ -1864,7 +1975,7 @@ def inbox(
         raise typer.Exit(1)
 
 
-def _index_impl(action: str, output_format: str):
+def _index_impl(action: str, output_format: str, backlinks: bool = False):
     """索引管理实现：查看状态、重建索引、验证完整性"""
     if action == "rebuild-bm25":
         # 重建 BM25 索引
@@ -1966,6 +2077,11 @@ def _index_impl(action: str, output_format: str):
                 "bm25_indexed": len(notes),
             }
 
+            # 如果指定 --backlinks，重新计算 backlinks
+            if backlinks:
+                bl_result = _rebuild_backlinks_impl(output_format=output_format)
+                result.update(bl_result)
+
             if output_format == "json":
                 print(output_json(result))
             else:
@@ -1974,6 +2090,19 @@ def _index_impl(action: str, output_format: str):
                     console.print(f"[green]✓[/green] BM25 index rebuilt: {len(notes)} notes")
                 else:
                     console.print("[yellow]⚠[/yellow] ChromaDB rebuilt, but BM25 rebuild failed")
+                if backlinks and result.get("backlinks_rebuilt"):
+                    console.print(
+                        f"[green]✓[/green] Backlinks rebuilt: "
+                        f"{result.get('backlinks_updated', 0)} note(s) updated / "
+                        f"{result.get('backlinks_total', 0)} scanned"
+                    )
+                    unresolved = result.get("unresolved_links", [])
+                    if unresolved:
+                        console.print(
+                            f"[yellow]⚠[/yellow] Unresolved links: {', '.join(unresolved[:5])}"
+                        )
+                        if len(unresolved) > 5:
+                            console.print(f"[yellow]  ... and {len(unresolved) - 5} more[/yellow]")
 
         elif action == "verify":
             verification = indexer.verify_index()
@@ -2025,6 +2154,7 @@ def index(
     json_output: bool = typer.Option(
         False, "--json", help="JSON 输出（快捷方式，等同于 --format json）"
     ),
+    backlinks: bool = typer.Option(False, "--backlinks", "-b", help="rebuild 时重新计算 backlinks"),
 ):
     """索引管理：查看状态、重建索引、验证完整性"""
     try:
@@ -2035,7 +2165,7 @@ def index(
         from .config import use_kb
 
         with use_kb(kb):
-            _index_impl(action, output_format)
+            _index_impl(action, output_format, backlinks=backlinks)
 
     except typer.Exit:
         raise

--- a/tests/integration/test_index_rebuild_backlinks.py
+++ b/tests/integration/test_index_rebuild_backlinks.py
@@ -158,3 +158,51 @@ class TestIndexRebuildBacklinks:
         data = rebuild_result.data
         assert "unresolved_links" in data
         assert "Nonexistent Target" in data["unresolved_links"]
+
+    def test_index_rebuild_backlinks_does_not_overwrite_forward_links(
+        self, cli_fast, _clear_backlinks
+    ):
+        """--backlinks 只重新计算 backlinks，不覆盖用户手写或已有的 forward links"""
+        from jfox.models import Note
+
+        # 1. 创建目标笔记 A
+        target = cli_fast.add("Target content", title="Keep Forward Target", note_type="permanent")
+        assert target.success
+        target_id = target.data["note"]["id"]
+
+        # 2. 创建源笔记 B，引用 A（B 的 forward links 会被 add 设置）
+        source = cli_fast.add(
+            "Source referencing [[Keep Forward Target]]",
+            title="Source With Forward Link",
+            note_type="permanent",
+        )
+        assert source.success
+        source_id = source.data["note"]["id"]
+        source_path = Path(source.data["note"]["filepath"])
+
+        # 3. 在 B 的 frontmatter 中额外手写一个 forward link（模拟用户手写链接）
+        note = Note.from_markdown(source_path.read_text(encoding="utf-8"), source_path)
+        extra_link_id = "999999999999999999"
+        note.links = sorted(set(note.links + [extra_link_id]))
+        source_path.write_text(note.to_markdown(), encoding="utf-8")
+
+        # 4. 清空 A 的 backlinks
+        target_path = Path(target.data["note"]["filepath"])
+        _clear_backlinks(target_path)
+
+        # 5. 执行 index rebuild --backlinks
+        rebuild_result = cli_fast.index_rebuild(backlinks=True)
+        assert rebuild_result.success
+        data = rebuild_result.data
+        assert data.get("backlinks_rebuilt") is True
+        assert data.get("backlinks_failed", -1) == 0
+
+        # 6. 验证 A 的 backlinks 已恢复
+        refs_after = cli_fast.refs(note_id=target_id)
+        assert refs_after.success
+        backlink_ids = [link["id"] for link in refs_after.data.get("backward_links", [])]
+        assert source_id in backlink_ids
+
+        # 7. 验证 B 的 forward links 保持不变（包含手写的 extra_link_id）
+        note_after = Note.from_markdown(source_path.read_text(encoding="utf-8"), source_path)
+        assert extra_link_id in note_after.links

--- a/tests/integration/test_index_rebuild_backlinks.py
+++ b/tests/integration/test_index_rebuild_backlinks.py
@@ -159,10 +159,8 @@ class TestIndexRebuildBacklinks:
         assert "unresolved_links" in data
         assert "Nonexistent Target" in data["unresolved_links"]
 
-    def test_index_rebuild_backlinks_does_not_overwrite_forward_links(
-        self, cli_fast, _clear_backlinks
-    ):
-        """--backlinks 只重新计算 backlinks，不覆盖用户手写或已有的 forward links"""
+    def test_index_rebuild_backlinks_merges_forward_links(self, cli_fast, _clear_backlinks):
+        """--backlinks 合并正文解析出的 links 与现有 frontmatter links，不删除手写链接"""
         from jfox.models import Note
 
         # 1. 创建目标笔记 A
@@ -203,6 +201,7 @@ class TestIndexRebuildBacklinks:
         backlink_ids = [link["id"] for link in refs_after.data.get("backward_links", [])]
         assert source_id in backlink_ids
 
-        # 7. 验证 B 的 forward links 保持不变（包含手写的 extra_link_id）
+        # 7. 验证 B 的 forward links 保留手写链接，同时包含正文解析出的 target_id
         note_after = Note.from_markdown(source_path.read_text(encoding="utf-8"), source_path)
         assert extra_link_id in note_after.links
+        assert target_id in note_after.links

--- a/tests/integration/test_index_rebuild_backlinks.py
+++ b/tests/integration/test_index_rebuild_backlinks.py
@@ -1,0 +1,160 @@
+"""
+测试类型: 集成测试
+目标功能: index rebuild --backlinks 重新计算反向链接
+预估耗时: 10-30秒
+依赖要求: 需要临时知识库
+
+测试 jfox index rebuild --backlinks 在手动修改笔记文件后恢复 backlinks 关系
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def _clear_backlinks():
+    """辅助函数：清空指定笔记文件的 backlinks 字段"""
+
+    def _clear(filepath: Path) -> None:
+        from jfox.models import Note
+
+        note = Note.from_markdown(filepath.read_text(encoding="utf-8"), filepath)
+        note.backlinks = []
+        filepath.write_text(note.to_markdown(), encoding="utf-8")
+
+    return _clear
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+
+class TestIndexRebuildBacklinks:
+    """index rebuild --backlinks 功能测试"""
+
+    def test_index_rebuild_backlinks_restores_backlinks(self, cli_fast, _clear_backlinks):
+        """手动清空目标笔记 backlinks 后，--backlinks 重建能恢复"""
+        # 1. 创建目标笔记 A
+        target = cli_fast.add("Target content", title="Target Note", note_type="permanent")
+        assert target.success
+        target_id = target.data["note"]["id"]
+
+        # 2. 创建源笔记 B，引用 A
+        source = cli_fast.add(
+            "Source referencing [[Target Note]]", title="Source Note", note_type="permanent"
+        )
+        assert source.success
+        source_id = source.data["note"]["id"]
+
+        # 3. 验证初始 backlinks 正确
+        refs_before = cli_fast.refs(note_id=target_id)
+        assert refs_before.success
+        backlink_ids_before = [link["id"] for link in refs_before.data.get("backward_links", [])]
+        assert source_id in backlink_ids_before
+
+        # 4. 手动清空 A 的 backlinks 字段（模拟迁移/手动修改）
+        target_note_path = Path(target.data["note"]["filepath"])
+        _clear_backlinks(target_note_path)
+
+        # 5. 验证手动清空后 backlinks 丢失
+        refs_after_clear = cli_fast.refs(note_id=target_id)
+        assert refs_after_clear.success
+        backlink_ids_after_clear = [
+            link["id"] for link in refs_after_clear.data.get("backward_links", [])
+        ]
+        assert source_id not in backlink_ids_after_clear
+
+        # 6. 执行 index rebuild --backlinks
+        rebuild_result = cli_fast.index_rebuild(backlinks=True)
+        assert rebuild_result.success
+        data = rebuild_result.data
+        assert data is not None
+        assert data.get("backlinks_rebuilt") is True
+        assert data.get("backlinks_updated", 0) >= 1
+        assert data.get("backlinks_total", 0) >= 2
+
+        # 7. 验证 backlinks 已恢复
+        refs_after_rebuild = cli_fast.refs(note_id=target_id)
+        assert refs_after_rebuild.success
+        backlink_ids_after_rebuild = [
+            link["id"] for link in refs_after_rebuild.data.get("backward_links", [])
+        ]
+        assert source_id in backlink_ids_after_rebuild
+
+    def test_index_rebuild_without_backlinks_flag_does_not_touch_backlinks(
+        self, cli_fast, _clear_backlinks
+    ):
+        """不带 --backlinks 时，index rebuild 不应修改 backlinks"""
+        # 1. 创建目标笔记 A 和源笔记 B
+        target = cli_fast.add("Target content", title="No Touch Target", note_type="permanent")
+        assert target.success
+        target_id = target.data["note"]["id"]
+
+        source = cli_fast.add(
+            "Source referencing [[No Touch Target]]", title="Source Note 2", note_type="permanent"
+        )
+        assert source.success
+        source_id = source.data["note"]["id"]
+
+        # 2. 手动清空 A 的 backlinks
+        target_note_path = Path(target.data["note"]["filepath"])
+        _clear_backlinks(target_note_path)
+
+        # 3. 不带 --backlinks 重建索引
+        rebuild_result = cli_fast.index_rebuild(backlinks=False)
+        assert rebuild_result.success
+
+        # 4. 验证 backlinks 仍然为空
+        refs_after = cli_fast.refs(note_id=target_id)
+        assert refs_after.success
+        backlink_ids = [link["id"] for link in refs_after.data.get("backward_links", [])]
+        assert source_id not in backlink_ids
+
+    def test_index_rebuild_backlinks_multiple_sources(self, cli_fast, _clear_backlinks):
+        """多个笔记链接到同一目标时，backlinks 应全部恢复"""
+        target = cli_fast.add("Common target content", title="Common Target", note_type="permanent")
+        assert target.success
+        target_id = target.data["note"]["id"]
+
+        source_ids = []
+        for i in range(3):
+            source = cli_fast.add(
+                f"Source {i} referencing [[Common Target]]",
+                title=f"Multi Source {i}",
+                note_type="permanent",
+            )
+            assert source.success
+            source_ids.append(source.data["note"]["id"])
+
+        # 手动清空目标 backlinks
+        target_note_path = Path(target.data["note"]["filepath"])
+        _clear_backlinks(target_note_path)
+
+        # 重建 backlinks
+        rebuild_result = cli_fast.index_rebuild(backlinks=True)
+        assert rebuild_result.success
+        data = rebuild_result.data
+        assert data.get("backlinks_updated", 0) >= 1
+
+        # 验证全部 3 个反向链接
+        refs_result = cli_fast.refs(note_id=target_id)
+        assert refs_result.success
+        backlink_ids = [link["id"] for link in refs_result.data.get("backward_links", [])]
+        assert len(backlink_ids) == 3
+        for sid in source_ids:
+            assert sid in backlink_ids
+
+    def test_index_rebuild_backlinks_reports_unresolved_links(self, cli_fast):
+        """存在无法解析的链接时，应报告 unresolved_links"""
+        result = cli_fast.add(
+            "Note with [[Nonexistent Target]] link",
+            title="Note With Broken Link",
+            note_type="permanent",
+        )
+        assert result.success
+
+        rebuild_result = cli_fast.index_rebuild(backlinks=True)
+        assert rebuild_result.success
+        data = rebuild_result.data
+        assert "unresolved_links" in data
+        assert "Nonexistent Target" in data["unresolved_links"]

--- a/tests/unit/test_rebuild_backlinks_impl.py
+++ b/tests/unit/test_rebuild_backlinks_impl.py
@@ -1,0 +1,188 @@
+"""
+测试类型: 单元测试
+目标功能: _rebuild_backlinks_impl 内部函数
+预估耗时: 1-2秒
+
+测试 backlinks 重新计算逻辑，不依赖真实知识库和 embedding
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock, patch
+
+
+@dataclass
+class _FakeNote:
+    """用于单元测试的轻量 Note 替身"""
+
+    id: str
+    title: str
+    content: str
+    type: str = "permanent"
+    links: List[str] = field(default_factory=list)
+    backlinks: List[str] = field(default_factory=list)
+    filepath: Path = field(default_factory=lambda: Path("/tmp/fake.md"))
+
+
+def _make_fake_meta(note: _FakeNote):
+    """构造 NoteIndex 需要的 meta 对象"""
+    meta = MagicMock()
+    meta.id = note.id
+    meta.title = note.title
+    meta.type.value = note.type
+    return meta
+
+
+class TestRebuildBacklinksImpl:
+    """_rebuild_backlinks_impl 单元测试"""
+
+    @patch("jfox.note.save_note")
+    @patch("jfox.note_index.get_note_index")
+    @patch("jfox.note.list_notes")
+    def test_rebuild_updates_changed_backlinks(
+        self, mock_list_notes, mock_get_index, mock_save_note
+    ):
+        """backlinks 变化时，应调用 save_note 写回"""
+        import jfox.cli  # noqa: F401
+        from jfox.cli import _rebuild_backlinks_impl
+
+        note_a = _FakeNote(id="202601010000000001", title="Note A", content="Content A")
+        note_b = _FakeNote(
+            id="202601010000000002", title="Note B", content="Note B references [[Note A]]"
+        )
+
+        mock_list_notes.return_value = [note_a, note_b]
+
+        # 构造 mock NoteIndex
+        def _find_by_id(nid):
+            for n in [note_a, note_b]:
+                if n.id == nid:
+                    return _make_fake_meta(n)
+            return None
+
+        def _find_by_title(title):
+            title_lower = title.lower()
+            for n in [note_a, note_b]:
+                if n.title.lower() == title_lower:
+                    return _make_fake_meta(n)
+            return None
+
+        idx = MagicMock()
+        idx.find_by_id.side_effect = _find_by_id
+        idx.find_by_title.side_effect = _find_by_title
+        idx.get_all_meta.return_value = [_make_fake_meta(n) for n in [note_a, note_b]]
+        mock_get_index.return_value = idx
+
+        result = _rebuild_backlinks_impl(output_format="json")
+
+        assert result["backlinks_rebuilt"] is True
+        assert result["backlinks_total"] == 2
+        # A 的 backlinks 从 [] 变为 [B]，B 的 links 从 [] 变为 [A]
+        assert result["backlinks_updated"] == 2
+        assert result["unresolved_links"] == []
+
+        # 验证 save_note 被调用且未重新加入索引
+        assert mock_save_note.call_count == 2
+        for call in mock_save_note.call_args_list:
+            assert call.kwargs.get("add_to_index") is False
+
+    @patch("jfox.note.save_note")
+    @patch("jfox.note_index.get_note_index")
+    @patch("jfox.note.list_notes")
+    def test_rebuild_skips_unchanged_notes(self, mock_list_notes, mock_get_index, mock_save_note):
+        """backlinks 未变化时，不应调用 save_note"""
+        import jfox.cli  # noqa: F401
+        from jfox.cli import _rebuild_backlinks_impl
+
+        note_a = _FakeNote(
+            id="202601010000000001",
+            title="Note A",
+            content="Content A",
+            backlinks=["202601010000000002"],
+        )
+        note_b = _FakeNote(
+            id="202601010000000002",
+            title="Note B",
+            content="Note B references [[Note A]]",
+            links=["202601010000000001"],
+        )
+
+        mock_list_notes.return_value = [note_a, note_b]
+
+        def _find_by_id(nid):
+            for n in [note_a, note_b]:
+                if n.id == nid:
+                    return _make_fake_meta(n)
+            return None
+
+        def _find_by_title(title):
+            title_lower = title.lower()
+            for n in [note_a, note_b]:
+                if n.title.lower() == title_lower:
+                    return _make_fake_meta(n)
+            return None
+
+        idx = MagicMock()
+        idx.find_by_id.side_effect = _find_by_id
+        idx.find_by_title.side_effect = _find_by_title
+        idx.get_all_meta.return_value = [_make_fake_meta(n) for n in [note_a, note_b]]
+        mock_get_index.return_value = idx
+
+        result = _rebuild_backlinks_impl(output_format="json")
+
+        assert result["backlinks_rebuilt"] is True
+        assert result["backlinks_total"] == 2
+        assert result["backlinks_updated"] == 0
+        assert result["unresolved_links"] == []
+        mock_save_note.assert_not_called()
+
+    @patch("jfox.note.save_note")
+    @patch("jfox.note_index.get_note_index")
+    @patch("jfox.note.list_notes")
+    def test_rebuild_reports_unresolved_links(
+        self, mock_list_notes, mock_get_index, mock_save_note
+    ):
+        """无法解析的 wiki 链接应被报告"""
+        import jfox.cli  # noqa: F401
+        from jfox.cli import _rebuild_backlinks_impl
+
+        note_a = _FakeNote(id="202601010000000001", title="Note A", content="Content A")
+        note_b = _FakeNote(
+            id="202601010000000002",
+            title="Note B",
+            content="Note B references [[Missing Note]]",
+        )
+
+        mock_list_notes.return_value = [note_a, note_b]
+
+        idx = MagicMock()
+        idx.find_by_id.return_value = None
+        idx.find_by_title.return_value = None
+        idx.get_all_meta.return_value = [_make_fake_meta(n) for n in [note_a, note_b]]
+        mock_get_index.return_value = idx
+
+        result = _rebuild_backlinks_impl(output_format="json")
+
+        assert result["backlinks_rebuilt"] is True
+        assert "Missing Note" in result["unresolved_links"]
+        # B 的 links 为空，A 的 backlinks 为空，没有变化
+        assert result["backlinks_updated"] == 0
+
+    @patch("jfox.note.save_note")
+    @patch("jfox.note_index.get_note_index")
+    @patch("jfox.note.list_notes")
+    def test_rebuild_empty_notes(self, mock_list_notes, mock_get_index, mock_save_note):
+        """空知识库时应返回零值且不报错"""
+        import jfox.cli  # noqa: F401
+        from jfox.cli import _rebuild_backlinks_impl
+
+        mock_list_notes.return_value = []
+
+        result = _rebuild_backlinks_impl(output_format="json")
+
+        assert result["backlinks_rebuilt"] is True
+        assert result["backlinks_total"] == 0
+        assert result["backlinks_updated"] == 0
+        assert result["unresolved_links"] == []
+        mock_save_note.assert_not_called()

--- a/tests/unit/test_rebuild_backlinks_impl.py
+++ b/tests/unit/test_rebuild_backlinks_impl.py
@@ -34,6 +34,29 @@ def _make_fake_meta(note: _FakeNote):
     return meta
 
 
+def _make_index(notes):
+    """构造 mock NoteIndex"""
+
+    def _find_by_id(nid):
+        for n in notes:
+            if n.id == nid:
+                return _make_fake_meta(n)
+        return None
+
+    def _find_by_title(title):
+        title_lower = title.lower()
+        for n in notes:
+            if n.title.lower() == title_lower:
+                return _make_fake_meta(n)
+        return None
+
+    idx = MagicMock()
+    idx.find_by_id.side_effect = _find_by_id
+    idx.find_by_title.side_effect = _find_by_title
+    idx.get_all_meta.return_value = [_make_fake_meta(n) for n in notes]
+    return idx
+
+
 class TestRebuildBacklinksImpl:
     """_rebuild_backlinks_impl 单元测试"""
 
@@ -43,7 +66,7 @@ class TestRebuildBacklinksImpl:
     def test_rebuild_updates_changed_backlinks(
         self, mock_list_notes, mock_get_index, mock_save_note
     ):
-        """backlinks 变化时，应调用 save_note 写回"""
+        """backlinks 变化时，应只写 backlinks，不覆盖 forward links"""
         import jfox.cli  # noqa: F401
         from jfox.cli import _rebuild_backlinks_impl
 
@@ -53,39 +76,25 @@ class TestRebuildBacklinksImpl:
         )
 
         mock_list_notes.return_value = [note_a, note_b]
-
-        # 构造 mock NoteIndex
-        def _find_by_id(nid):
-            for n in [note_a, note_b]:
-                if n.id == nid:
-                    return _make_fake_meta(n)
-            return None
-
-        def _find_by_title(title):
-            title_lower = title.lower()
-            for n in [note_a, note_b]:
-                if n.title.lower() == title_lower:
-                    return _make_fake_meta(n)
-            return None
-
-        idx = MagicMock()
-        idx.find_by_id.side_effect = _find_by_id
-        idx.find_by_title.side_effect = _find_by_title
-        idx.get_all_meta.return_value = [_make_fake_meta(n) for n in [note_a, note_b]]
-        mock_get_index.return_value = idx
+        mock_get_index.return_value = _make_index([note_a, note_b])
 
         result = _rebuild_backlinks_impl(output_format="json")
 
         assert result["backlinks_rebuilt"] is True
         assert result["backlinks_total"] == 2
-        # A 的 backlinks 从 [] 变为 [B]，B 的 links 从 [] 变为 [A]
-        assert result["backlinks_updated"] == 2
+        # 只有 A 的 backlinks 从 [] 变为 [B]
+        assert result["backlinks_updated"] == 1
+        assert result["backlinks_failed"] == 0
         assert result["unresolved_links"] == []
 
-        # 验证 save_note 被调用且未重新加入索引
-        assert mock_save_note.call_count == 2
-        for call in mock_save_note.call_args_list:
-            assert call.kwargs.get("add_to_index") is False
+        # 验证 save_note 只被调用一次，且未重新加入索引
+        assert mock_save_note.call_count == 1
+        saved_note = mock_save_note.call_args[0][0]
+        assert saved_note.id == note_a.id
+        assert saved_note.backlinks == [note_b.id]
+        # forward links 不应被覆盖
+        assert saved_note.links == []
+        assert mock_save_note.call_args.kwargs.get("add_to_index") is False
 
     @patch("jfox.note.save_note")
     @patch("jfox.note_index.get_note_index")
@@ -109,31 +118,14 @@ class TestRebuildBacklinksImpl:
         )
 
         mock_list_notes.return_value = [note_a, note_b]
-
-        def _find_by_id(nid):
-            for n in [note_a, note_b]:
-                if n.id == nid:
-                    return _make_fake_meta(n)
-            return None
-
-        def _find_by_title(title):
-            title_lower = title.lower()
-            for n in [note_a, note_b]:
-                if n.title.lower() == title_lower:
-                    return _make_fake_meta(n)
-            return None
-
-        idx = MagicMock()
-        idx.find_by_id.side_effect = _find_by_id
-        idx.find_by_title.side_effect = _find_by_title
-        idx.get_all_meta.return_value = [_make_fake_meta(n) for n in [note_a, note_b]]
-        mock_get_index.return_value = idx
+        mock_get_index.return_value = _make_index([note_a, note_b])
 
         result = _rebuild_backlinks_impl(output_format="json")
 
         assert result["backlinks_rebuilt"] is True
         assert result["backlinks_total"] == 2
         assert result["backlinks_updated"] == 0
+        assert result["backlinks_failed"] == 0
         assert result["unresolved_links"] == []
         mock_save_note.assert_not_called()
 
@@ -155,19 +147,14 @@ class TestRebuildBacklinksImpl:
         )
 
         mock_list_notes.return_value = [note_a, note_b]
-
-        idx = MagicMock()
-        idx.find_by_id.return_value = None
-        idx.find_by_title.return_value = None
-        idx.get_all_meta.return_value = [_make_fake_meta(n) for n in [note_a, note_b]]
-        mock_get_index.return_value = idx
+        mock_get_index.return_value = _make_index([note_a, note_b])
 
         result = _rebuild_backlinks_impl(output_format="json")
 
         assert result["backlinks_rebuilt"] is True
         assert "Missing Note" in result["unresolved_links"]
-        # B 的 links 为空，A 的 backlinks 为空，没有变化
         assert result["backlinks_updated"] == 0
+        assert result["backlinks_failed"] == 0
 
     @patch("jfox.note.save_note")
     @patch("jfox.note_index.get_note_index")
@@ -184,5 +171,49 @@ class TestRebuildBacklinksImpl:
         assert result["backlinks_rebuilt"] is True
         assert result["backlinks_total"] == 0
         assert result["backlinks_updated"] == 0
+        assert result["backlinks_failed"] == 0
         assert result["unresolved_links"] == []
         mock_save_note.assert_not_called()
+
+    @patch("jfox.note.save_note")
+    @patch("jfox.note_index.get_note_index")
+    @patch("jfox.note.list_notes")
+    def test_rebuild_filters_self_links(self, mock_list_notes, mock_get_index, mock_save_note):
+        """自链接 [[Note A]] 不应产生自指边"""
+        import jfox.cli  # noqa: F401
+        from jfox.cli import _rebuild_backlinks_impl
+
+        note_a = _FakeNote(id="202601010000000001", title="Note A", content="See also [[Note A]]")
+
+        mock_list_notes.return_value = [note_a]
+        mock_get_index.return_value = _make_index([note_a])
+
+        result = _rebuild_backlinks_impl(output_format="json")
+
+        assert result["backlinks_total"] == 1
+        assert result["backlinks_updated"] == 0
+        assert result["unresolved_links"] == []
+        mock_save_note.assert_not_called()
+
+    @patch("jfox.note.save_note")
+    @patch("jfox.note_index.get_note_index")
+    @patch("jfox.note.list_notes")
+    def test_rebuild_includes_failed_count(self, mock_list_notes, mock_get_index, mock_save_note):
+        """save_note 失败时，backlinks_failed 应被统计并包含在 JSON 输出中"""
+        import jfox.cli  # noqa: F401
+        from jfox.cli import _rebuild_backlinks_impl
+
+        note_a = _FakeNote(id="202601010000000001", title="Note A", content="Content A")
+        note_b = _FakeNote(
+            id="202601010000000002", title="Note B", content="Note B references [[Note A]]"
+        )
+
+        mock_list_notes.return_value = [note_a, note_b]
+        mock_get_index.return_value = _make_index([note_a, note_b])
+        mock_save_note.return_value = False
+
+        result = _rebuild_backlinks_impl(output_format="json")
+
+        assert result["backlinks_total"] == 2
+        assert result["backlinks_updated"] == 0
+        assert result["backlinks_failed"] == 1

--- a/tests/unit/test_rebuild_backlinks_impl.py
+++ b/tests/unit/test_rebuild_backlinks_impl.py
@@ -63,10 +63,10 @@ class TestRebuildBacklinksImpl:
     @patch("jfox.note.save_note")
     @patch("jfox.note_index.get_note_index")
     @patch("jfox.note.list_notes")
-    def test_rebuild_updates_changed_backlinks(
+    def test_rebuild_updates_changed_links_and_backlinks(
         self, mock_list_notes, mock_get_index, mock_save_note
     ):
-        """backlinks 变化时，应只写 backlinks，不覆盖 forward links"""
+        """links/backlinks 变化时，应调用 save_note 写回；forward links 与解析结果合并"""
         import jfox.cli  # noqa: F401
         from jfox.cli import _rebuild_backlinks_impl
 
@@ -82,19 +82,18 @@ class TestRebuildBacklinksImpl:
 
         assert result["backlinks_rebuilt"] is True
         assert result["backlinks_total"] == 2
-        # 只有 A 的 backlinks 从 [] 变为 [B]
-        assert result["backlinks_updated"] == 1
+        # A 的 backlinks 从 [] 变为 [B]，B 的 links 从 [] 变为 [A]
+        assert result["backlinks_updated"] == 2
         assert result["backlinks_failed"] == 0
         assert result["unresolved_links"] == []
 
-        # 验证 save_note 只被调用一次，且未重新加入索引
-        assert mock_save_note.call_count == 1
-        saved_note = mock_save_note.call_args[0][0]
-        assert saved_note.id == note_a.id
-        assert saved_note.backlinks == [note_b.id]
-        # forward links 不应被覆盖
-        assert saved_note.links == []
-        assert mock_save_note.call_args.kwargs.get("add_to_index") is False
+        # 验证 save_note 被调用两次，且未重新加入索引
+        assert mock_save_note.call_count == 2
+        saved_by_id = {call.args[0].id: call.args[0] for call in mock_save_note.call_args_list}
+        assert saved_by_id[note_a.id].backlinks == [note_b.id]
+        assert saved_by_id[note_b.id].links == [note_a.id]
+        for call in mock_save_note.call_args_list:
+            assert call.kwargs.get("add_to_index") is False
 
     @patch("jfox.note.save_note")
     @patch("jfox.note_index.get_note_index")
@@ -216,4 +215,4 @@ class TestRebuildBacklinksImpl:
 
         assert result["backlinks_total"] == 2
         assert result["backlinks_updated"] == 0
-        assert result["backlinks_failed"] == 1
+        assert result["backlinks_failed"] == 2

--- a/tests/utils/jfox_cli.py
+++ b/tests/utils/jfox_cli.py
@@ -323,9 +323,12 @@ class ZKCLI:
         """查看索引状态"""
         return self._run("index", "status")
 
-    def index_rebuild(self) -> CLIResult:
+    def index_rebuild(self, backlinks: bool = False) -> CLIResult:
         """重建索引"""
-        return self._run("index", "rebuild")
+        args = ["rebuild"]
+        if backlinks:
+            args.append("--backlinks")
+        return self._run("index", *args)
 
     def index_verify(self) -> CLIResult:
         """验证索引"""


### PR DESCRIPTION
## 问题

`jfox index rebuild` 只重建了 BM25 索引和向量索引，但没有重新解析笔记内容中的 wiki links，也没有重新计算 backlinks 关系（#252）。

## 修改

- 为 `jfox index rebuild` 新增 `--backlinks` / `-b` 选项
- 新增 `_rebuild_backlinks_impl()` 内部函数，全量加载笔记、解析 `[[...]]` 链接、按标题/ID 解析目标、重新计算并写回变化的笔记
- JSON/table 输出增加 backlinks 重建统计
- 默认行为保持不变，避免意外覆盖用户手动写入的 frontmatter

## 测试

- 新增 `tests/unit/test_rebuild_backlinks_impl.py`（4 个用例）
- 新增 `tests/integration/test_index_rebuild_backlinks.py`（4 个用例）
- 本地运行 `tests/ -m "not embedding and not slow"`：538 passed, 9 skipped

Closes #252
