### PR TITLE
feat(cli): add self-update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,13 @@ A session is considered "finished" when its file has not been modified for `idle
 
 > **Privacy note:** Auto-summary sends session text to Anthropic API via `claude -p` to generate summaries. Only session content is transmitted.
 
+### Self-Update
+
+| Command | Description |
+|---------|-------------|
+| `jfox update` | Upgrade jfox to the latest version (auto-detects pip/pipx/uv) |
+| `jfox update --json` | JSON output with before/after version info |
+
 ### Global Options
 
 | Option | Description |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -28,6 +28,32 @@ jfox --version
 pip install -e ".[dev]"
 ```
 
+## Upgrade
+
+```bash
+# Auto-detect installation method and upgrade
+jfox update
+
+# JSON output with version info
+jfox update --json
+```
+
+If `jfox update` fails (e.g. behind a proxy or on an unsupported install method), use the manual command for your install method:
+
+```bash
+# uv tool users
+uv tool upgrade jfox-cli
+
+# pipx users
+pipx upgrade jfox-cli
+
+# pip users
+pip install --upgrade jfox-cli
+
+# Development mode (git clone + uv sync --extra dev)
+git pull && uv sync --extra dev
+```
+
 ## Uninstall
 
 ```bash

--- a/docs/superpowers/plans/2026-06-18-self-update-command.md
+++ b/docs/superpowers/plans/2026-06-18-self-update-command.md
@@ -1,0 +1,175 @@
+# jfox self-update 命令 Implementation Plan
+
+> **For agentic workers:** implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `jfox update` command that detects the current installation method (dev / uv / pipx / pip) and invokes the appropriate upgrade command, showing before/after version info and providing manual fallback guidance on failure.
+
+**Architecture:** A new `update` Typer command in `jfox/cli.py` plus helper functions for install-method detection and upgrade command execution. Detection is path-based with command fallbacks. A unit test file `tests/unit/test_update.py` mocks filesystem paths and subprocess calls.
+
+**Tech Stack:** Python 3.10+, Typer, Rich, pytest, unittest.mock.
+
+**Spec:** `docs/superpowers/specs/2026-06-18-self-update-command-design.md`
+
+**Work context:** Work in the isolated worktree `/home/elling/git-repo/github/jfox-wt-238` on branch `feat/issue-238-self-update` (based off `main`). All paths below are relative to that worktree root.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `jfox/cli.py` | **Modify** | Add `_detect_install_method`, `_build_upgrade_command`, `_run_upgrade`, `_update_impl`, and `update` Typer command. |
+| `tests/unit/test_update.py` | **Create** | Unit tests for detection, command selection, JSON output, dev-mode prompt, and failure handling. |
+| `README.md` | **Modify** | Add `jfox update` to the command reference table. |
+| `docs/installation.md` | **Modify** | Add an "Upgrade" section with `jfox update` and manual fallbacks. |
+
+---
+
+## Task 1: Implement install-method detection helpers
+
+**Files:** `jfox/cli.py`
+
+- [ ] **Step 1: Add `_is_dev_installation` helper**
+
+  Determine development mode by checking whether `jfox.__file__` resolves to a source tree containing `pyproject.toml` with `project.name == "jfox-cli"` and a `.git` directory, or whether the path indicates an editable install (`.egg-link`).
+
+- [ ] **Step 2: Add `_is_uv_tool_installation` helper**
+
+  Run `uv tool dir` to obtain the uv tools root. Return `True` if `jfox.__file__` is relative to `<uv-tool-dir>/jfox-cli/`. If `uv` is unavailable, fall back to path-segment matching (`uv/tools/jfox-cli/`).
+
+- [ ] **Step 3: Add `_is_pipx_installation` helper**
+
+  Run `pipx environment --value PIPX_HOME` to obtain pipx home. Return `True` if `jfox.__file__` is relative to `<pipx-home>/venvs/jfox-cli/`. If `pipx` is unavailable, fall back to path-segment matching (`pipx/venvs/jfox-cli/`).
+
+- [ ] **Step 4: Add `_detect_install_method` helper**
+
+  Apply the detection order: dev → uv → pipx → pip. Return a string identifier (`"dev"`, `"uv"`, `"pipx"`, `"pip"`).
+
+---
+
+## Task 2: Implement upgrade execution and version comparison
+
+**Files:** `jfox/cli.py`
+
+- [ ] **Step 1: Add `_build_upgrade_command` helper**
+
+  Map the detected install method to the concrete command list:
+  - `"uv"` → `["uv", "tool", "upgrade", "jfox-cli"]`
+  - `"pipx"` → `["pipx", "upgrade", "jfox-cli"]`
+  - `"pip"` → `[sys.executable, "-m", "pip", "install", "--upgrade", "jfox-cli"]`
+  - `"dev"` → return `None`
+
+- [ ] **Step 2: Add `_run_upgrade` helper**
+
+  Use `subprocess.run(..., check=True, capture_output=True, text=True)` to execute the command. On success return stdout; on `CalledProcessError` raise a custom exception or return an error dict. Surface stderr to the user.
+
+- [ ] **Step 3: Add `_get_installed_version` helper**
+
+  Run `jfox --version` via subprocess and parse the version string. Return `"unknown"` if the call fails.
+
+---
+
+## Task 3: Wire up the `update` Typer command
+
+**Files:** `jfox/cli.py`
+
+- [ ] **Step 1: Add `_update_impl` internal function**
+
+  1. Read current `__version__`.
+  2. Detect install method.
+  3. If dev, return a result dict with `success=True`, `method="dev"`, and an instruction string.
+  4. Build and run the upgrade command.
+  5. Call `_get_installed_version` for the after version.
+  6. Return a result dict: `success`, `method`, `previous_version`, `current_version`, `command`, `output`.
+
+- [ ] **Step 2: Add `update` Typer command**
+
+  Support `--format json/table` and `--json` shortcut. Wrap the implementation in a try/except, print table or JSON output, and exit with code 1 on failure.
+
+---
+
+## Task 4: Add unit tests
+
+**Files:** `tests/unit/test_update.py`
+
+- [ ] **Step 1: Test dev-mode detection**
+
+  Mock `jfox.__file__` to a source tree path with `pyproject.toml` and `.git/`. Assert `jfox update` prints the dev-mode instruction and does not invoke subprocess.
+
+- [ ] **Step 2: Test uv / pipx / pip command selection**
+
+  Mock `jfox.__file__` to each tool's typical site-packages path and assert the correct subprocess command is invoked.
+
+- [ ] **Step 3: Test JSON output**
+
+  Run `jfox update --json` and verify the parsed JSON contains expected keys.
+
+- [ ] **Step 4: Test upgrade failure handling**
+
+  Make `subprocess.run` raise `CalledProcessError`. Assert exit code 1 and manual command guidance appears in output/JSON.
+
+- [ ] **Step 5: Test version before/after display**
+
+  Mock `jfox.__version__` and the post-upgrade `jfox --version` subprocess to verify both versions appear.
+
+---
+
+## Task 5: Update documentation
+
+**Files:** `README.md`, `docs/installation.md`
+
+- [ ] **Step 1: Add `jfox update` to README command table**
+
+  Place it under a new "Self-update" row or in the most appropriate existing section.
+
+- [ ] **Step 2: Add upgrade section to `docs/installation.md`**
+
+  Document `jfox update` and the manual fallbacks for each install method.
+
+---
+
+## Task 6: Run tests and static checks
+
+- [ ] **Step 1: Run the new unit tests**
+
+  ```bash
+  uv run pytest tests/unit/test_update.py -v
+  ```
+
+- [ ] **Step 2: Run fast unit tests**
+
+  ```bash
+  uv run pytest tests/unit/ -m "not embedding and not slow" -q
+  ```
+
+- [ ] **Step 3: Run ruff lint**
+
+  ```bash
+  uv run ruff check jfox/cli.py tests/unit/test_update.py
+  ```
+
+---
+
+## Task 7: Commit and create PR
+
+- [ ] **Step 1: Stage and commit changes**
+
+  Use Conventional Commits:
+
+  ```bash
+  git add jfox/cli.py tests/unit/test_update.py README.md docs/installation.md docs/superpowers/
+  git commit -m "feat(cli): add self-update command (jfox update)"
+  git commit -m "docs(readme): document jfox update command" -- README.md docs/installation.md
+  git commit -m "docs(superpowers): add self-update design and plan"
+  ```
+
+- [ ] **Step 2: Push branch and create PR**
+
+  ```bash
+  git push -u origin feat/issue-238-self-update
+  gh pr create --title "feat(cli): add self-update command" --body "Closes #238" --base main
+  ```
+
+- [ ] **Step 3: Wait for CI**
+
+  Monitor the PR checks and address any failures.

--- a/docs/superpowers/specs/2026-06-18-self-update-command-design.md
+++ b/docs/superpowers/specs/2026-06-18-self-update-command-design.md
@@ -1,0 +1,149 @@
+# Design: jfox self-update 命令
+
+> Issue: #238
+> Branch: `feat/issue-238-self-update`
+
+## 背景
+
+用户希望直接通过 `jfox update` 完成 jfox 自身升级，而不需要手动调用 `uv tool upgrade`、`pipx upgrade` 或 `pip install --upgrade`。
+
+## 目标
+
+- 新增 `jfox update` 命令，自动检测当前安装方式并调用对应升级命令。
+- 显示升级前后版本对比。
+- 开发模式下明确提示使用 `git pull + uv sync --extra dev`。
+- 网络失败时给出清晰的错误提示和手动升级指引。
+
+## 非目标
+
+- 不支持自动检测 `conda`、`poetry` 等其他安装方式。
+- 不实现自动回滚。
+- 不修改现有 CLI 命令的行为。
+
+## 决策记录
+
+| 决策 | 选择 | 理由 |
+|------|------|------|
+| 命令名 | `jfox update` | 与 issue 需求一致，语义直观 |
+| 安装方式检测顺序 | dev → uv → pipx → pip | dev 需要优先识别，避免误升级；uv/pipx 路径特征明显 |
+| 升级包名 | `jfox-cli` | 与 `pyproject.toml` 中的 `project.name` 一致，PyPI 实际分发名 |
+| 版本对比 | 升级前读取 `jfox.__version__`，升级后调用 `jfox --version` 子进程 | 运行中进程的 `__version__` 不会自动更新，需用新进程获取 |
+| 开发模式判定 | 同时检查 `.git` 目录、`pyproject.toml` 和 editable marker | 覆盖 `uv sync --extra dev` 和 `pip install -e ".[dev]"` |
+
+## Section 1: 文件与命名
+
+- 修改文件：`jfox/cli.py`（新增 `update` 命令及内部实现 `_update_impl`）。
+- 新增测试：`tests/unit/test_update.py`。
+- 可选更新：`README.md` 命令速查表、`docs/installation.md` 升级说明。
+
+## Section 2: 安装方式检测逻辑
+
+### 2.1 检测顺序
+
+```
+if is_dev_installation(package_path):
+    return "dev"
+if is_uv_tool_installation(package_path):
+    return "uv"
+if is_pipx_installation(package_path):
+    return "pipx"
+return "pip"
+```
+
+### 2.2 dev 模式判定
+
+满足以下任一条件即视为开发模式：
+
+1. `jfox.__file__` 位于某个包含 `pyproject.toml` 且 `project.name == "jfox-cli"` 的目录下，且该目录同时包含 `.git/`。
+2. `jfox.__file__` 路径中出现 `.egg-link` 或 `site-packages/*.egg-link` 指向源码目录。
+3. `jfox` 可执行文件为源码目录下的 `.venv/bin/jfox`（`uv sync` 产生的虚拟环境入口）。
+
+### 2.3 uv tool 判定
+
+- 优先调用 `uv tool dir` 获取工具根目录。
+- 若 `jfox.__file__` 位于 `<uv-tool-dir>/jfox-cli/` 下，则为 uv tool 安装。
+- 降级策略：若 `uv` 命令不可用，则按路径特征匹配 `uv/tools/jfox-cli/`。
+
+### 2.4 pipx 判定
+
+- 优先调用 `pipx environment --value PIPX_HOME` 获取 pipx 主目录。
+- 若 `jfox.__file__` 位于 `<pipx-home>/venvs/jfox-cli/` 下，则为 pipx 安装。
+- 降级策略：匹配常见路径 `pipx/venvs/jfox-cli/`。
+
+### 2.5 pip 判定
+
+不满足以上任何条件时，默认为 pip 安装（系统 Python 或 user site-packages）。
+
+## Section 3: 升级命令映射
+
+| 安装方式 | 命令 |
+|---------|------|
+| dev | 不执行命令，提示 `git pull && uv sync --extra dev` |
+| uv | `uv tool upgrade jfox-cli` |
+| pipx | `pipx upgrade jfox-cli` |
+| pip | `pip install --upgrade jfox-cli` |
+
+## Section 4: CLI 行为
+
+### 4.1 命令签名
+
+```python
+@app.command()
+def update(
+    output_format: str = typer.Option("table", "--format", "-f", help="输出格式: json, table"),
+    json_output: bool = typer.Option(False, "--json", help="JSON 输出快捷方式"),
+):
+    """升级 jfox 到最新版本"""
+```
+
+### 4.2 输出示例
+
+**table 模式：**
+
+```
+当前版本: 1.0.0
+安装方式: uv tool
+执行: uv tool upgrade jfox-cli
+...
+升级完成: 1.0.0 → 1.1.0
+```
+
+**json 模式：**
+
+```json
+{
+  "success": true,
+  "method": "uv",
+  "previous_version": "1.0.0",
+  "current_version": "1.1.0",
+  "command": "uv tool upgrade jfox-cli"
+}
+```
+
+### 4.3 错误处理
+
+- 无法识别安装方式：按 `pip` 处理，并附带警告。
+- 升级命令返回非零：输出 stderr，提示手动执行对应命令。
+- 升级后无法获取新版本：输出 `"unknown"` 并提示重新运行 `jfox --version`。
+
+## Section 5: 边界与异常
+
+- 升级过程中自身代码被替换，运行中进程不受影响，升级完成后通过子进程获取新版本。
+- Windows 下 `uv tool dir` 等命令同样适用；路径使用 `Path.is_relative_to` 处理。
+- 代理/内网环境：捕获 `subprocess.CalledProcessError`，返回包含完整手动命令的 JSON/table 错误信息。
+
+## Section 6: 验收标准
+
+- [ ] `jfox update` 命令可用，默认输出 table 格式。
+- [ ] `jfox update --json` 输出合法 JSON。
+- [ ] 开发模式提示 `git pull + uv sync --extra dev`，不调用任何升级命令。
+- [ ] uv / pipx / pip 三种安装方式分别调用正确命令。
+- [ ] 升级前后版本号均显示（或升级后显示 `"unknown"`）。
+- [ ] 网络/命令失败时退出码为 1，并给出手动升级指引。
+- [ ] 单元测试覆盖 detection + command selection + JSON output + error handling。
+
+## Section 7: 验证方式
+
+1. 单元测试：mock `shutil.which`、`subprocess.run`、模块路径和版本号，验证各安装方式的命令选择。
+2. 本地 smoke test：在开发模式下运行 `jfox update`，确认提示信息正确。
+3. 静态检查：`ruff check jfox/cli.py tests/unit/test_update.py` 通过。

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -3044,6 +3044,27 @@ def _is_dev_installation(package_file: Path) -> bool:
     except (OSError, ValueError):
         pass
 
+    # uv sync 场景：解释器位于源码目录下的 .venv/bin/python，
+    # 且源码目录包含 pyproject.toml + .git + project.name == jfox-cli。
+    try:
+        exe = Path(sys.executable).resolve()
+        if exe.name.lower().startswith("python") and exe.parent.name == "bin":
+            venv_dir = exe.parent.parent
+            if venv_dir.name == ".venv":
+                project_root = venv_dir.parent
+                pyproject = project_root / "pyproject.toml"
+                git_marker = project_root / ".git"
+                if (
+                    pyproject.exists()
+                    and git_marker.exists()
+                    and package_file.is_relative_to(project_root)
+                ):
+                    name = _read_pyproject_name(pyproject)
+                    if name == "jfox-cli":
+                        return True
+    except (OSError, ValueError):
+        pass
+
     return False
 
 
@@ -3338,6 +3359,7 @@ def update(
     except typer.Exit:
         raise
     except Exception as e:
+        logger.error("jfox update failed: %s", e, exc_info=True)
         if output_format == "json":
             print(output_json({"success": False, "error": str(e)}))
         else:

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -3071,9 +3071,7 @@ def _is_uv_tool_installation(package_file: Path) -> bool:
 
     # 路径特征降级匹配
     parts = [p.lower() for p in package_file.parts]
-    return (
-        "uv" in parts and "tools" in parts and "jfox-cli" in parts
-    )
+    return "uv" in parts and "tools" in parts and "jfox-cli" in parts
 
 
 def _get_pipx_home() -> Optional[Path]:
@@ -3105,9 +3103,7 @@ def _is_pipx_installation(package_file: Path) -> bool:
 
     # 路径特征降级匹配
     parts = [p.lower() for p in package_file.parts]
-    return (
-        "pipx" in parts and "venvs" in parts and "jfox-cli" in parts
-    )
+    return "pipx" in parts and "venvs" in parts and "jfox-cli" in parts
 
 
 def _detect_install_method() -> str:
@@ -3211,9 +3207,7 @@ def _update_impl(output_format: str = "table") -> dict:
 
 @app.command()
 def update(
-    output_format: str = typer.Option(
-        "table", "--format", "-f", help="输出格式: json, table"
-    ),
+    output_format: str = typer.Option("table", "--format", "-f", help="输出格式: json, table"),
     json_output: bool = typer.Option(
         False, "--json", help="JSON 输出（快捷方式，等同于 --format json）"
     ),
@@ -3242,12 +3236,8 @@ def update(
                         f"{result['current_version']}[/green]"
                     )
                 else:
-                    console.print(
-                        f"[red]升级失败: {result.get('error', 'unknown error')}[/red]"
-                    )
-                    console.print(
-                        f"[yellow]请手动执行: {result['command']}[/yellow]"
-                    )
+                    console.print(f"[red]升级失败: {result.get('error', 'unknown error')}[/red]")
+                    console.print(f"[yellow]请手动执行: {result['command']}[/yellow]")
 
         if not result["success"]:
             raise typer.Exit(1)

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -3071,6 +3071,23 @@ def _get_uv_tool_dir() -> Optional[Path]:
     return None
 
 
+def _path_has_contiguous_parts(path: Path, parts: tuple[str, ...]) -> bool:
+    """判断规范化路径是否包含连续的目录切片序列。
+
+    用于在主检测路径失败时做受约束的降级匹配，避免非连续片段组合造成的误命中。
+    """
+    try:
+        path_parts = path.resolve().parts
+    except (OSError, ValueError):
+        return False
+    if len(parts) > len(path_parts):
+        return False
+    for i in range(len(path_parts) - len(parts) + 1):
+        if path_parts[i : i + len(parts)] == parts:
+            return True
+    return False
+
+
 def _is_uv_tool_installation(package_file: Path) -> bool:
     """判断当前是否为 uv tool 安装"""
     uv_dir = _get_uv_tool_dir()
@@ -3080,9 +3097,9 @@ def _is_uv_tool_installation(package_file: Path) -> bool:
         except ValueError:
             pass
 
-    # 降级匹配已移除：非连续路径片段匹配容易误命中（如 ~/uv/backup/tools/old/jfox-cli/），
-    # 直接返回 False 走默认 pip 分支更安全。
-    return False
+    # 降级匹配：受约束的连续路径切片，避免非连续片段误命中
+    # （如 ~/uv/backup/tools/old/jfox-cli/ 不会被命中）。
+    return _path_has_contiguous_parts(package_file, ("uv", "tools", "jfox-cli"))
 
 
 def _get_pipx_home() -> Optional[Path]:
@@ -3120,8 +3137,8 @@ def _is_pipx_installation(package_file: Path) -> bool:
         except ValueError:
             pass
 
-    # 降级匹配已移除：非连续路径片段匹配容易误命中，直接返回 False 走默认 pip 分支。
-    return False
+    # 降级匹配：受约束的连续路径切片
+    return _path_has_contiguous_parts(package_file, ("pipx", "venvs", "jfox-cli"))
 
 
 def _detect_install_method() -> str:
@@ -3156,8 +3173,8 @@ def _build_upgrade_command(method: str) -> Optional[List[str]]:
     return None
 
 
-def _run_upgrade(command: List[str]) -> str:
-    """执行升级命令并返回标准输出与错误输出（合并）"""
+def _run_upgrade(command: List[str]) -> dict:
+    """执行升级命令并分别返回标准输出与错误输出"""
     result = subprocess.run(
         command,
         check=True,
@@ -3167,10 +3184,10 @@ def _run_upgrade(command: List[str]) -> str:
         errors="replace",
         timeout=300,
     )
-    output = result.stdout or ""
-    if result.stderr:
-        output += ("\n" if output else "") + result.stderr
-    return output.strip()
+    return {
+        "stdout": (result.stdout or "").strip(),
+        "stderr": (result.stderr or "").strip(),
+    }
 
 
 def _get_installed_version() -> str:
@@ -3234,7 +3251,7 @@ def _update_impl() -> dict:
         command_str = None
 
     try:
-        output = _run_upgrade(command)
+        upgrade_result = _run_upgrade(command)
     except (
         subprocess.CalledProcessError,
         subprocess.TimeoutExpired,
@@ -3262,7 +3279,8 @@ def _update_impl() -> dict:
         "previous_version": previous_version,
         "current_version": current_version,
         "command": command_str,
-        "output": output,
+        "output": upgrade_result["stdout"],
+        "stderr": upgrade_result["stderr"],
     }
 
 
@@ -3295,6 +3313,8 @@ def update(
                 console.print(f"执行: {result['command']}")
                 if result.get("output"):
                     console.print(result["output"].rstrip(), markup=False)
+                if result.get("stderr"):
+                    console.print(result["stderr"].rstrip(), markup=False)
                 if result["success"]:
                     console.print(
                         f"[green]升级完成: {result['previous_version']} → "

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -4,7 +4,9 @@ import json
 import logging
 import os
 import re
+import shlex
 import shutil
+import site
 import subprocess
 import sys
 import warnings
@@ -3000,7 +3002,7 @@ def _read_pyproject_name(pyproject_path: Path) -> Optional[str]:
     """从 pyproject.toml 中读取 project.name（简单文本匹配，兼容 Python 3.10）"""
     try:
         text = pyproject_path.read_text(encoding="utf-8")
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return None
 
     # 匹配 [project] 区块内的 name = "..." 或 name = '...'
@@ -3019,8 +3021,11 @@ def _read_pyproject_name(pyproject_path: Path) -> Optional[str]:
 
 def _is_dev_installation(package_file: Path) -> bool:
     """判断当前是否为开发模式（源码目录 + git + pyproject.toml）"""
-    # 向上查找 pyproject.toml 和 .git
+    # 向上查找 pyproject.toml 和 .git，但遇到 site-packages 即停止，
+    # 避免把位于项目目录下的 venv 安装误判为 dev 模式。
     for parent in package_file.parents[:6]:
+        if parent.name.lower() == "site-packages":
+            break
         pyproject = parent / "pyproject.toml"
         git_marker = parent / ".git"
         if pyproject.exists() and git_marker.exists():
@@ -3050,12 +3055,18 @@ def _get_uv_tool_dir() -> Optional[Path]:
             check=True,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=5,
         )
         path = Path(result.stdout.strip())
         if path.exists():
             return path.resolve()
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+        OSError,
+    ):
         pass
     return None
 
@@ -3082,12 +3093,18 @@ def _get_pipx_home() -> Optional[Path]:
             check=True,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=5,
         )
         path = Path(result.stdout.strip())
         if path.exists():
             return path.resolve()
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+        OSError,
+    ):
         pass
     return None
 
@@ -3126,7 +3143,15 @@ def _build_upgrade_command(method: str) -> Optional[List[str]]:
     if method == "pipx":
         return ["pipx", "upgrade", "jfox-cli"]
     if method == "pip":
-        return [sys.executable, "-m", "pip", "install", "--upgrade", "jfox-cli"]
+        command = [sys.executable, "-m", "pip", "install", "--upgrade", "jfox-cli"]
+        # 如果当前包安装在用户 site-packages 中，追加 --user 避免权限/位置问题
+        try:
+            user_site = Path(site.getusersitepackages()).resolve()
+            if Path(__file__).resolve().is_relative_to(user_site):
+                command.append("--user")
+        except (AttributeError, ValueError, OSError):
+            pass
+        return command
     return None
 
 
@@ -3137,6 +3162,7 @@ def _run_upgrade(command: List[str]) -> str:
         check=True,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         timeout=300,
     )
     return result.stdout
@@ -3144,20 +3170,33 @@ def _run_upgrade(command: List[str]) -> str:
 
 def _get_installed_version() -> str:
     """调用 jfox --version 获取升级后版本"""
+    # 优先使用同一个 Python 解释器，避免 PATH 中其他 jfox 造成误判
+    candidates = [
+        [sys.executable, "-m", "jfox", "--version"],
+    ]
     jfox_exe = shutil.which("jfox")
-    if not jfox_exe:
-        return "unknown"
-    try:
-        result = subprocess.run(
-            [jfox_exe, "--version"],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        return result.stdout.strip().replace("jfox ", "")
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
-        return "unknown"
+    if jfox_exe:
+        candidates.append([jfox_exe, "--version"])
+
+    for cmd in candidates:
+        try:
+            result = subprocess.run(
+                cmd,
+                check=True,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                timeout=30,
+            )
+            return result.stdout.strip().replace("jfox ", "")
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            FileNotFoundError,
+            OSError,
+        ):
+            continue
+    return "unknown"
 
 
 def _update_impl(output_format: str = "table") -> dict:
@@ -3178,19 +3217,26 @@ def _update_impl(output_format: str = "table") -> dict:
         }
 
     command = _build_upgrade_command(method)
-    command_str = " ".join(command) if command else None
+    command_str = shlex.join(command) if command else None
 
     try:
         output = _run_upgrade(command)
-    except subprocess.CalledProcessError as e:
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+        OSError,
+    ) as e:
+        stderr = getattr(e, "stderr", None) or ""
+        stdout = getattr(e, "stdout", None) or ""
         return {
             "success": False,
             "method": method,
             "previous_version": previous_version,
             "current_version": previous_version,
             "command": command_str,
-            "output": e.stdout or "",
-            "error": e.stderr or str(e),
+            "output": stdout,
+            "error": stderr or str(e),
             "message": f"升级失败，请手动执行：{command_str}",
         }
 
@@ -3217,6 +3263,10 @@ def update(
         if json_output:
             output_format = "json"
 
+        if output_format not in {"table", "json"}:
+            console.print("[red]X[/red] Error: --format 必须是 table 或 json")
+            raise typer.Exit(2)
+
         result = _update_impl(output_format=output_format)
 
         if output_format == "json":
@@ -3229,7 +3279,7 @@ def update(
             else:
                 console.print(f"执行: {result['command']}")
                 if result.get("output"):
-                    console.print(result["output"].rstrip())
+                    console.print(result["output"].rstrip(), markup=False)
                 if result["success"]:
                     console.print(
                         f"[green]升级完成: {result['previous_version']} → "

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -3080,9 +3080,9 @@ def _is_uv_tool_installation(package_file: Path) -> bool:
         except ValueError:
             pass
 
-    # 路径特征降级匹配
-    parts = [p.lower() for p in package_file.parts]
-    return "uv" in parts and "tools" in parts and "jfox-cli" in parts
+    # 降级匹配已移除：非连续路径片段匹配容易误命中（如 ~/uv/backup/tools/old/jfox-cli/），
+    # 直接返回 False 走默认 pip 分支更安全。
+    return False
 
 
 def _get_pipx_home() -> Optional[Path]:
@@ -3120,9 +3120,8 @@ def _is_pipx_installation(package_file: Path) -> bool:
         except ValueError:
             pass
 
-    # 路径特征降级匹配
-    parts = [p.lower() for p in package_file.parts]
-    return "pipx" in parts and "venvs" in parts and "jfox-cli" in parts
+    # 降级匹配已移除：非连续路径片段匹配容易误命中，直接返回 False 走默认 pip 分支。
+    return False
 
 
 def _detect_install_method() -> str:
@@ -3158,7 +3157,7 @@ def _build_upgrade_command(method: str) -> Optional[List[str]]:
 
 
 def _run_upgrade(command: List[str]) -> str:
-    """执行升级命令并返回标准输出"""
+    """执行升级命令并返回标准输出与错误输出（合并）"""
     result = subprocess.run(
         command,
         check=True,
@@ -3168,7 +3167,10 @@ def _run_upgrade(command: List[str]) -> str:
         errors="replace",
         timeout=300,
     )
-    return result.stdout
+    output = result.stdout or ""
+    if result.stderr:
+        output += ("\n" if output else "") + result.stderr
+    return output.strip()
 
 
 def _get_installed_version() -> str:
@@ -3204,7 +3206,7 @@ def _get_installed_version() -> str:
     return "unknown"
 
 
-def _update_impl(output_format: str = "table") -> dict:
+def _update_impl() -> dict:
     """update 命令的内部实现"""
     from . import __version__
 
@@ -3222,7 +3224,14 @@ def _update_impl(output_format: str = "table") -> dict:
         }
 
     command = _build_upgrade_command(method)
-    command_str = shlex.join(command) if command else None
+    if command:
+        # 按平台生成可展示/可手动执行的命令字符串
+        if sys.platform == "win32":
+            command_str = subprocess.list2cmdline(command)
+        else:
+            command_str = shlex.join(command)
+    else:
+        command_str = None
 
     try:
         output = _run_upgrade(command)
@@ -3273,7 +3282,7 @@ def update(
             console.print("[red]X[/red] Error: --format 必须是 table 或 json")
             raise typer.Exit(2)
 
-        result = _update_impl(output_format=output_format)
+        result = _update_impl()
 
         if output_format == "json":
             print(output_json(result))

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -4,6 +4,8 @@ import json
 import logging
 import os
 import re
+import shutil
+import subprocess
 import sys
 import warnings
 from datetime import datetime
@@ -2978,6 +2980,277 @@ def check(
 
         with use_kb(kb):
             _check_impl(clean=clean, output_format=output_format)
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        if output_format == "json":
+            print(output_json({"success": False, "error": str(e)}))
+        else:
+            console.print(f"[red]X[/red] Error: {e}")
+        raise typer.Exit(1)
+
+
+# =============================================================================
+# 自升级
+# =============================================================================
+
+
+def _read_pyproject_name(pyproject_path: Path) -> Optional[str]:
+    """从 pyproject.toml 中读取 project.name（简单文本匹配，兼容 Python 3.10）"""
+    try:
+        text = pyproject_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    # 匹配 [project] 区块内的 name = "..." 或 name = '...'
+    match = re.search(
+        r"^\[project\].*?^name\s*=\s*['\"]([^'\"]+)['\"]",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    if match:
+        return match.group(1)
+
+    # 退回到全局查找
+    match = re.search(r"^name\s*=\s*['\"]([^'\"]+)['\"]", text, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def _is_dev_installation(package_file: Path) -> bool:
+    """判断当前是否为开发模式（源码目录 + git + pyproject.toml）"""
+    # 向上查找 pyproject.toml 和 .git
+    for parent in package_file.parents[:6]:
+        pyproject = parent / "pyproject.toml"
+        git_marker = parent / ".git"
+        if pyproject.exists() and git_marker.exists():
+            name = _read_pyproject_name(pyproject)
+            if name == "jfox-cli":
+                return True
+
+    # editable install 标记
+    try:
+        for parent in package_file.parents:
+            if parent.name.lower() == "site-packages":
+                egg_link = parent / "jfox_cli.egg-link"
+                if egg_link.exists():
+                    return True
+                break
+    except (OSError, ValueError):
+        pass
+
+    return False
+
+
+def _get_uv_tool_dir() -> Optional[Path]:
+    """获取 uv tool 安装根目录"""
+    try:
+        result = subprocess.run(
+            ["uv", "tool", "dir"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        path = Path(result.stdout.strip())
+        if path.exists():
+            return path.resolve()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        pass
+    return None
+
+
+def _is_uv_tool_installation(package_file: Path) -> bool:
+    """判断当前是否为 uv tool 安装"""
+    uv_dir = _get_uv_tool_dir()
+    if uv_dir:
+        try:
+            return package_file.is_relative_to(uv_dir / "jfox-cli")
+        except ValueError:
+            pass
+
+    # 路径特征降级匹配
+    parts = [p.lower() for p in package_file.parts]
+    return (
+        "uv" in parts and "tools" in parts and "jfox-cli" in parts
+    )
+
+
+def _get_pipx_home() -> Optional[Path]:
+    """获取 pipx 主目录"""
+    try:
+        result = subprocess.run(
+            ["pipx", "environment", "--value", "PIPX_HOME"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        path = Path(result.stdout.strip())
+        if path.exists():
+            return path.resolve()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        pass
+    return None
+
+
+def _is_pipx_installation(package_file: Path) -> bool:
+    """判断当前是否为 pipx 安装"""
+    pipx_home = _get_pipx_home()
+    if pipx_home:
+        try:
+            return package_file.is_relative_to(pipx_home / "venvs" / "jfox-cli")
+        except ValueError:
+            pass
+
+    # 路径特征降级匹配
+    parts = [p.lower() for p in package_file.parts]
+    return (
+        "pipx" in parts and "venvs" in parts and "jfox-cli" in parts
+    )
+
+
+def _detect_install_method() -> str:
+    """检测当前安装方式：dev / uv / pipx / pip"""
+    package_file = Path(__file__).resolve()
+
+    if _is_dev_installation(package_file):
+        return "dev"
+    if _is_uv_tool_installation(package_file):
+        return "uv"
+    if _is_pipx_installation(package_file):
+        return "pipx"
+    return "pip"
+
+
+def _build_upgrade_command(method: str) -> Optional[List[str]]:
+    """根据安装方式构造升级命令"""
+    if method == "uv":
+        return ["uv", "tool", "upgrade", "jfox-cli"]
+    if method == "pipx":
+        return ["pipx", "upgrade", "jfox-cli"]
+    if method == "pip":
+        return [sys.executable, "-m", "pip", "install", "--upgrade", "jfox-cli"]
+    return None
+
+
+def _run_upgrade(command: List[str]) -> str:
+    """执行升级命令并返回标准输出"""
+    result = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    return result.stdout
+
+
+def _get_installed_version() -> str:
+    """调用 jfox --version 获取升级后版本"""
+    jfox_exe = shutil.which("jfox")
+    if not jfox_exe:
+        return "unknown"
+    try:
+        result = subprocess.run(
+            [jfox_exe, "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return result.stdout.strip().replace("jfox ", "")
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return "unknown"
+
+
+def _update_impl(output_format: str = "table") -> dict:
+    """update 命令的内部实现"""
+    from . import __version__
+
+    method = _detect_install_method()
+    previous_version = __version__
+
+    if method == "dev":
+        return {
+            "success": True,
+            "method": "dev",
+            "previous_version": previous_version,
+            "current_version": previous_version,
+            "command": None,
+            "message": "开发模式请使用：git pull && uv sync --extra dev",
+        }
+
+    command = _build_upgrade_command(method)
+    command_str = " ".join(command) if command else None
+
+    try:
+        output = _run_upgrade(command)
+    except subprocess.CalledProcessError as e:
+        return {
+            "success": False,
+            "method": method,
+            "previous_version": previous_version,
+            "current_version": previous_version,
+            "command": command_str,
+            "output": e.stdout or "",
+            "error": e.stderr or str(e),
+            "message": f"升级失败，请手动执行：{command_str}",
+        }
+
+    current_version = _get_installed_version()
+    return {
+        "success": True,
+        "method": method,
+        "previous_version": previous_version,
+        "current_version": current_version,
+        "command": command_str,
+        "output": output,
+    }
+
+
+@app.command()
+def update(
+    output_format: str = typer.Option(
+        "table", "--format", "-f", help="输出格式: json, table"
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="JSON 输出（快捷方式，等同于 --format json）"
+    ),
+):
+    """升级 jfox 到最新版本"""
+    try:
+        if json_output:
+            output_format = "json"
+
+        result = _update_impl(output_format=output_format)
+
+        if output_format == "json":
+            print(output_json(result))
+        else:
+            console.print(f"当前版本: {result['previous_version']}")
+            console.print(f"安装方式: {result['method']}")
+            if result["method"] == "dev":
+                console.print(f"[yellow]{result['message']}[/yellow]")
+            else:
+                console.print(f"执行: {result['command']}")
+                if result.get("output"):
+                    console.print(result["output"].rstrip())
+                if result["success"]:
+                    console.print(
+                        f"[green]升级完成: {result['previous_version']} → "
+                        f"{result['current_version']}[/green]"
+                    )
+                else:
+                    console.print(
+                        f"[red]升级失败: {result.get('error', 'unknown error')}[/red]"
+                    )
+                    console.print(
+                        f"[yellow]请手动执行: {result['command']}[/yellow]"
+                    )
+
+        if not result["success"]:
+            raise typer.Exit(1)
 
     except typer.Exit:
         raise

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -3094,6 +3094,7 @@ def _get_pipx_home() -> Optional[Path]:
             capture_output=True,
             text=True,
             encoding="utf-8",
+            errors="replace",
             timeout=5,
         )
         path = Path(result.stdout.strip())
@@ -3104,6 +3105,7 @@ def _get_pipx_home() -> Optional[Path]:
         subprocess.TimeoutExpired,
         FileNotFoundError,
         OSError,
+        UnicodeDecodeError,
     ):
         pass
     return None
@@ -3163,6 +3165,7 @@ def _run_upgrade(command: List[str]) -> str:
         capture_output=True,
         text=True,
         encoding="utf-8",
+        errors="replace",
         timeout=300,
     )
     return result.stdout
@@ -3186,6 +3189,7 @@ def _get_installed_version() -> str:
                 capture_output=True,
                 text=True,
                 encoding="utf-8",
+                errors="replace",
                 timeout=30,
             )
             return result.stdout.strip().replace("jfox ", "")
@@ -3194,6 +3198,7 @@ def _get_installed_version() -> str:
             subprocess.TimeoutExpired,
             FileNotFoundError,
             OSError,
+            UnicodeDecodeError,
         ):
             continue
     return "unknown"
@@ -3226,6 +3231,7 @@ def _update_impl(output_format: str = "table") -> dict:
         subprocess.TimeoutExpired,
         FileNotFoundError,
         OSError,
+        UnicodeDecodeError,
     ) as e:
         stderr = getattr(e, "stderr", None) or ""
         stdout = getattr(e, "stdout", None) or ""

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -3072,9 +3072,10 @@ def _get_uv_tool_dir() -> Optional[Path]:
 
 
 def _path_has_contiguous_parts(path: Path, parts: tuple[str, ...]) -> bool:
-    """判断规范化路径是否包含连续的目录切片序列。
+    """判断规范化路径是否包含连续的目录切片序列（大小写不敏感）。
 
-    用于在主检测路径失败时做受约束的降级匹配，避免非连续片段组合造成的误命中。
+    用于在主检测路径失败时做受约束的降级匹配，避免非连续片段组合造成的误命中，
+    同时兼容 Windows 或大写目录等大小写不一致的场景。
     """
     try:
         path_parts = path.resolve().parts
@@ -3082,8 +3083,10 @@ def _path_has_contiguous_parts(path: Path, parts: tuple[str, ...]) -> bool:
         return False
     if len(parts) > len(path_parts):
         return False
-    for i in range(len(path_parts) - len(parts) + 1):
-        if path_parts[i : i + len(parts)] == parts:
+    parts_lower = tuple(p.lower() for p in parts)
+    path_parts_lower = tuple(p.lower() for p in path_parts)
+    for i in range(len(path_parts_lower) - len(parts_lower) + 1):
+        if path_parts_lower[i : i + len(parts_lower)] == parts_lower:
             return True
     return False
 
@@ -3237,6 +3240,9 @@ def _update_impl() -> dict:
             "previous_version": previous_version,
             "current_version": previous_version,
             "command": None,
+            "output": "",
+            "stderr": "",
+            "error": "",
             "message": "开发模式请使用：git pull && uv sync --extra dev",
         }
 
@@ -3268,6 +3274,7 @@ def _update_impl() -> dict:
             "current_version": previous_version,
             "command": command_str,
             "output": stdout,
+            "stderr": stderr,
             "error": stderr or str(e),
             "message": f"升级失败，请手动执行：{command_str}",
         }
@@ -3281,6 +3288,7 @@ def _update_impl() -> dict:
         "command": command_str,
         "output": upgrade_result["stdout"],
         "stderr": upgrade_result["stderr"],
+        "error": "",
     }
 
 

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -271,6 +271,12 @@ class TestPathHasContiguousParts:
         path.mkdir()
         assert _path_has_contiguous_parts(path, ("a", "b", "c")) is False
 
+    def test_matches_case_insensitive(self, tmp_path):
+        """大小写不一致时仍能命中"""
+        path = tmp_path / "UV" / "Tools" / "JFOX-CLI"
+        path.mkdir(parents=True)
+        assert _path_has_contiguous_parts(path, ("uv", "tools", "jfox-cli")) is True
+
 
 class TestUpdateImpl:
     """_update_impl 行为测试"""
@@ -347,7 +353,7 @@ class TestUpdateImpl:
                                 assert "--user" in result["command"]
 
     def test_upgrade_failure_returns_manual_command(self):
-        """升级失败时返回手动执行命令"""
+        """升级失败时返回统一 schema：output/stderr/error 均存在"""
         error = subprocess.CalledProcessError(1, ["uv", "tool", "upgrade", "jfox-cli"])
         error.stderr = "network error"
 
@@ -356,11 +362,12 @@ class TestUpdateImpl:
                 with patch("jfox.cli._run_upgrade", side_effect=error):
                     result = _update_impl()
                     assert result["success"] is False
+                    assert "network error" in result["stderr"]
                     assert "network error" in result["error"]
                     assert "uv tool upgrade jfox-cli" in result["message"]
 
     def test_upgrade_timeout_returns_failure(self):
-        """升级超时时返回结构化失败"""
+        """升级超时时返回统一 schema"""
         error = subprocess.TimeoutExpired(["uv", "tool", "upgrade", "jfox-cli"], timeout=300)
 
         with patch("jfox.cli._detect_install_method", return_value="uv"):
@@ -368,10 +375,12 @@ class TestUpdateImpl:
                 with patch("jfox.cli._run_upgrade", side_effect=error):
                     result = _update_impl()
                     assert result["success"] is False
+                    assert "stderr" in result
+                    assert "error" in result
                     assert "uv tool upgrade jfox-cli" in result["message"]
 
     def test_success_separates_stdout_and_stderr(self):
-        """成功路径保持 output=stdout，stderr 放入单独 key"""
+        """成功路径保持统一 schema：output/stderr/error 均存在，error 为空"""
         with patch("jfox.cli._detect_install_method", return_value="uv"):
             with patch("jfox.__version__", "1.0.0"):
                 with patch(
@@ -383,6 +392,7 @@ class TestUpdateImpl:
                         assert result["success"] is True
                         assert result["output"] == "stdout msg"
                         assert result["stderr"] == "stderr msg"
+                        assert result["error"] == ""
 
 
 class TestRunUpgrade:
@@ -457,7 +467,7 @@ class TestUpdateCommand:
                     assert "uv tool upgrade jfox-cli" in result.output
 
     def test_json_output_success(self):
-        """--json 输出合法 JSON"""
+        """--json 输出合法 JSON 且 schema 统一"""
         with patch("jfox.cli._detect_install_method", return_value="uv"):
             with patch("jfox.__version__", "1.0.0"):
                 with patch(
@@ -472,6 +482,8 @@ class TestUpdateCommand:
                         assert data["method"] == "uv"
                         assert data["previous_version"] == "1.0.0"
                         assert data["current_version"] == "1.1.0"
+                        assert "stderr" in data
+                        assert data["error"] == ""
 
     def test_json_output_failure(self):
         """失败时 --json 输出 success=false"""

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -1,0 +1,245 @@
+"""
+测试类型: 单元测试
+目标模块: jfox.cli (update 命令)
+预估耗时: < 1 秒
+依赖要求: 无外部依赖
+"""
+
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+from jfox.cli import _detect_install_method, _update_impl, app
+
+runner = CliRunner()
+
+
+class TestDetectInstallMethod:
+    """安装方式检测测试"""
+
+    def test_dev_mode_with_git_and_pyproject(self, tmp_path):
+        """源码目录 + .git + pyproject.toml 判定为 dev"""
+        repo = tmp_path / "jfox"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        (repo / "pyproject.toml").write_text(
+            '[project]\nname = "jfox-cli"\nversion = "1.0.0"\n',
+            encoding="utf-8",
+        )
+        package = repo / "jfox" / "cli.py"
+        package.parent.mkdir(parents=True)
+        package.write_text("", encoding="utf-8")
+
+        with patch("jfox.cli.__file__", str(package)):
+            assert _detect_install_method() == "dev"
+
+    def test_dev_mode_editable_install(self, tmp_path):
+        """site-packages 下存在 jfox_cli.egg-link 判定为 dev"""
+        site_packages = tmp_path / "lib" / "python3.11" / "site-packages"
+        site_packages.mkdir(parents=True)
+        (site_packages / "jfox_cli.egg-link").write_text(
+            "/path/to/src\n.", encoding="utf-8"
+        )
+        package = site_packages / "jfox" / "cli.py"
+        package.parent.mkdir(parents=True)
+        package.write_text("", encoding="utf-8")
+
+        with patch("jfox.cli.__file__", str(package)):
+            assert _detect_install_method() == "dev"
+
+    def test_uv_tool_installation(self, tmp_path):
+        """uv tool 路径判定为 uv"""
+        uv_tools = tmp_path / "uv" / "tools"
+        package = (
+            uv_tools
+            / "jfox-cli"
+            / "lib"
+            / "python3.11"
+            / "site-packages"
+            / "jfox"
+            / "cli.py"
+        )
+        package.parent.mkdir(parents=True)
+        package.write_text("", encoding="utf-8")
+
+        with patch("jfox.cli.__file__", str(package)):
+            with patch("jfox.cli._get_uv_tool_dir", return_value=uv_tools):
+                with patch("jfox.cli._get_pipx_home", return_value=None):
+                    assert _detect_install_method() == "uv"
+
+    def test_pipx_installation(self, tmp_path):
+        """pipx venv 路径判定为 pipx"""
+        pipx_home = tmp_path / "pipx"
+        package = (
+            pipx_home
+            / "venvs"
+            / "jfox-cli"
+            / "lib"
+            / "python3.11"
+            / "site-packages"
+            / "jfox"
+            / "cli.py"
+        )
+        package.parent.mkdir(parents=True)
+        package.write_text("", encoding="utf-8")
+
+        with patch("jfox.cli.__file__", str(package)):
+            with patch("jfox.cli._get_uv_tool_dir", return_value=None):
+                with patch("jfox.cli._get_pipx_home", return_value=pipx_home):
+                    assert _detect_install_method() == "pipx"
+
+    def test_pip_installation_fallback(self, tmp_path):
+        """普通 site-packages 路径回退为 pip"""
+        site_packages = tmp_path / "site-packages"
+        package = site_packages / "jfox" / "cli.py"
+        package.parent.mkdir(parents=True)
+        package.write_text("", encoding="utf-8")
+
+        with patch("jfox.cli.__file__", str(package)):
+            with patch("jfox.cli._get_uv_tool_dir", return_value=None):
+                with patch("jfox.cli._get_pipx_home", return_value=None):
+                    assert _detect_install_method() == "pip"
+
+
+class TestUpdateImpl:
+    """_update_impl 行为测试"""
+
+    def test_dev_mode_returns_instruction(self):
+        """dev 模式不执行升级命令，返回提示"""
+        with patch("jfox.cli._detect_install_method", return_value="dev"):
+            with patch("jfox.__version__", "1.0.0"):
+                result = _update_impl()
+                assert result["success"] is True
+                assert result["method"] == "dev"
+                assert "git pull" in result["message"]
+
+    def test_uv_upgrade_success(self):
+        """uv 模式下调用正确命令并返回版本对比"""
+        with patch("jfox.cli._detect_install_method", return_value="uv"):
+            with patch("jfox.__version__", "1.0.0"):
+                with patch("jfox.cli._run_upgrade", return_value="Upgraded"):
+                    with patch(
+                        "jfox.cli._get_installed_version", return_value="1.1.0"
+                    ):
+                        result = _update_impl()
+                        assert result["success"] is True
+                        assert result["method"] == "uv"
+                        assert result["command"] == "uv tool upgrade jfox-cli"
+                        assert result["previous_version"] == "1.0.0"
+                        assert result["current_version"] == "1.1.0"
+
+    def test_pipx_upgrade_success(self):
+        """pipx 模式下调用正确命令"""
+        with patch("jfox.cli._detect_install_method", return_value="pipx"):
+            with patch("jfox.__version__", "1.0.0"):
+                with patch("jfox.cli._run_upgrade", return_value="Upgraded"):
+                    with patch(
+                        "jfox.cli._get_installed_version", return_value="1.1.0"
+                    ):
+                        result = _update_impl()
+                        assert result["command"] == "pipx upgrade jfox-cli"
+
+    def test_pip_upgrade_success(self):
+        """pip 模式下调用正确命令"""
+        with patch("jfox.cli._detect_install_method", return_value="pip"):
+            with patch("jfox.__version__", "1.0.0"):
+                with patch("jfox.cli._run_upgrade", return_value="Upgraded"):
+                    with patch(
+                        "jfox.cli._get_installed_version", return_value="1.1.0"
+                    ):
+                        result = _update_impl()
+                        assert "pip install --upgrade jfox-cli" in result["command"]
+
+    def test_upgrade_failure_returns_manual_command(self):
+        """升级失败时返回手动执行命令"""
+        error = subprocess.CalledProcessError(
+            1, ["uv", "tool", "upgrade", "jfox-cli"]
+        )
+        error.stderr = "network error"
+
+        with patch("jfox.cli._detect_install_method", return_value="uv"):
+            with patch("jfox.__version__", "1.0.0"):
+                with patch("jfox.cli._run_upgrade", side_effect=error):
+                    result = _update_impl()
+                    assert result["success"] is False
+                    assert "network error" in result["error"]
+                    assert "uv tool upgrade jfox-cli" in result["message"]
+
+
+class TestUpdateCommand:
+    """jfox update CLI 命令测试"""
+
+    def test_dev_mode_shows_instruction(self):
+        """dev 模式在 table 输出中显示提示"""
+        with patch("jfox.cli._detect_install_method", return_value="dev"):
+            with patch("jfox.__version__", "1.0.0"):
+                result = runner.invoke(app, ["update"])
+                assert result.exit_code == 0
+                assert "开发模式" in result.output
+                assert "git pull" in result.output
+
+    def test_table_output_success(self):
+        """table 输出显示版本对比"""
+        with patch("jfox.cli._detect_install_method", return_value="uv"):
+            with patch("jfox.__version__", "1.0.0"):
+                with patch("jfox.cli._run_upgrade", return_value="Upgraded"):
+                    with patch(
+                        "jfox.cli._get_installed_version", return_value="1.1.0"
+                    ):
+                        result = runner.invoke(app, ["update"])
+                        assert result.exit_code == 0
+                        assert "uv" in result.output
+                        assert "1.0.0 → 1.1.0" in result.output
+
+    def test_table_output_failure(self):
+        """升级失败时 table 输出显示错误和手动命令"""
+        error = subprocess.CalledProcessError(
+            1, ["uv", "tool", "upgrade", "jfox-cli"]
+        )
+        error.stderr = "network error"
+
+        with patch("jfox.cli._detect_install_method", return_value="uv"):
+            with patch("jfox.__version__", "1.0.0"):
+                with patch("jfox.cli._run_upgrade", side_effect=error):
+                    result = runner.invoke(app, ["update"])
+                    assert result.exit_code == 1
+                    assert "升级失败" in result.output
+                    assert "network error" in result.output
+                    assert "uv tool upgrade jfox-cli" in result.output
+
+    def test_json_output_success(self):
+        """--json 输出合法 JSON"""
+        with patch("jfox.cli._detect_install_method", return_value="uv"):
+            with patch("jfox.__version__", "1.0.0"):
+                with patch("jfox.cli._run_upgrade", return_value="Upgraded"):
+                    with patch(
+                        "jfox.cli._get_installed_version", return_value="1.1.0"
+                    ):
+                        result = runner.invoke(app, ["update", "--json"])
+                        assert result.exit_code == 0
+                        data = json.loads(result.output)
+                        assert data["success"] is True
+                        assert data["method"] == "uv"
+                        assert data["previous_version"] == "1.0.0"
+                        assert data["current_version"] == "1.1.0"
+
+    def test_json_output_failure(self):
+        """失败时 --json 输出 success=false"""
+        error = subprocess.CalledProcessError(
+            1, ["uv", "tool", "upgrade", "jfox-cli"]
+        )
+        error.stderr = "network error"
+
+        with patch("jfox.cli._detect_install_method", return_value="uv"):
+            with patch("jfox.__version__", "1.0.0"):
+                with patch("jfox.cli._run_upgrade", side_effect=error):
+                    result = runner.invoke(app, ["update", "--json"])
+                    assert result.exit_code == 1
+                    data = json.loads(result.output)
+                    assert data["success"] is False
+                    assert "network error" in data["error"]

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -42,9 +42,7 @@ class TestDetectInstallMethod:
         """site-packages 下存在 jfox_cli.egg-link 判定为 dev"""
         site_packages = tmp_path / "lib" / "python3.11" / "site-packages"
         site_packages.mkdir(parents=True)
-        (site_packages / "jfox_cli.egg-link").write_text(
-            "/path/to/src\n.", encoding="utf-8"
-        )
+        (site_packages / "jfox_cli.egg-link").write_text("/path/to/src\n.", encoding="utf-8")
         package = site_packages / "jfox" / "cli.py"
         package.parent.mkdir(parents=True)
         package.write_text("", encoding="utf-8")
@@ -55,15 +53,7 @@ class TestDetectInstallMethod:
     def test_uv_tool_installation(self, tmp_path):
         """uv tool 路径判定为 uv"""
         uv_tools = tmp_path / "uv" / "tools"
-        package = (
-            uv_tools
-            / "jfox-cli"
-            / "lib"
-            / "python3.11"
-            / "site-packages"
-            / "jfox"
-            / "cli.py"
-        )
+        package = uv_tools / "jfox-cli" / "lib" / "python3.11" / "site-packages" / "jfox" / "cli.py"
         package.parent.mkdir(parents=True)
         package.write_text("", encoding="utf-8")
 
@@ -123,9 +113,7 @@ class TestUpdateImpl:
         with patch("jfox.cli._detect_install_method", return_value="uv"):
             with patch("jfox.__version__", "1.0.0"):
                 with patch("jfox.cli._run_upgrade", return_value="Upgraded"):
-                    with patch(
-                        "jfox.cli._get_installed_version", return_value="1.1.0"
-                    ):
+                    with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
                         result = _update_impl()
                         assert result["success"] is True
                         assert result["method"] == "uv"
@@ -138,9 +126,7 @@ class TestUpdateImpl:
         with patch("jfox.cli._detect_install_method", return_value="pipx"):
             with patch("jfox.__version__", "1.0.0"):
                 with patch("jfox.cli._run_upgrade", return_value="Upgraded"):
-                    with patch(
-                        "jfox.cli._get_installed_version", return_value="1.1.0"
-                    ):
+                    with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
                         result = _update_impl()
                         assert result["command"] == "pipx upgrade jfox-cli"
 
@@ -149,17 +135,13 @@ class TestUpdateImpl:
         with patch("jfox.cli._detect_install_method", return_value="pip"):
             with patch("jfox.__version__", "1.0.0"):
                 with patch("jfox.cli._run_upgrade", return_value="Upgraded"):
-                    with patch(
-                        "jfox.cli._get_installed_version", return_value="1.1.0"
-                    ):
+                    with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
                         result = _update_impl()
                         assert "pip install --upgrade jfox-cli" in result["command"]
 
     def test_upgrade_failure_returns_manual_command(self):
         """升级失败时返回手动执行命令"""
-        error = subprocess.CalledProcessError(
-            1, ["uv", "tool", "upgrade", "jfox-cli"]
-        )
+        error = subprocess.CalledProcessError(1, ["uv", "tool", "upgrade", "jfox-cli"])
         error.stderr = "network error"
 
         with patch("jfox.cli._detect_install_method", return_value="uv"):
@@ -188,9 +170,7 @@ class TestUpdateCommand:
         with patch("jfox.cli._detect_install_method", return_value="uv"):
             with patch("jfox.__version__", "1.0.0"):
                 with patch("jfox.cli._run_upgrade", return_value="Upgraded"):
-                    with patch(
-                        "jfox.cli._get_installed_version", return_value="1.1.0"
-                    ):
+                    with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
                         result = runner.invoke(app, ["update"])
                         assert result.exit_code == 0
                         assert "uv" in result.output
@@ -198,9 +178,7 @@ class TestUpdateCommand:
 
     def test_table_output_failure(self):
         """升级失败时 table 输出显示错误和手动命令"""
-        error = subprocess.CalledProcessError(
-            1, ["uv", "tool", "upgrade", "jfox-cli"]
-        )
+        error = subprocess.CalledProcessError(1, ["uv", "tool", "upgrade", "jfox-cli"])
         error.stderr = "network error"
 
         with patch("jfox.cli._detect_install_method", return_value="uv"):
@@ -217,9 +195,7 @@ class TestUpdateCommand:
         with patch("jfox.cli._detect_install_method", return_value="uv"):
             with patch("jfox.__version__", "1.0.0"):
                 with patch("jfox.cli._run_upgrade", return_value="Upgraded"):
-                    with patch(
-                        "jfox.cli._get_installed_version", return_value="1.1.0"
-                    ):
+                    with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
                         result = runner.invoke(app, ["update", "--json"])
                         assert result.exit_code == 0
                         data = json.loads(result.output)
@@ -230,9 +206,7 @@ class TestUpdateCommand:
 
     def test_json_output_failure(self):
         """失败时 --json 输出 success=false"""
-        error = subprocess.CalledProcessError(
-            1, ["uv", "tool", "upgrade", "jfox-cli"]
-        )
+        error = subprocess.CalledProcessError(1, ["uv", "tool", "upgrade", "jfox-cli"])
         error.stderr = "network error"
 
         with patch("jfox.cli._detect_install_method", return_value="uv"):

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -9,10 +9,7 @@ import json
 import subprocess
 from unittest.mock import patch
 
-import pytest
 from typer.testing import CliRunner
-
-pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 from jfox.cli import (
     _detect_install_method,
@@ -58,6 +55,47 @@ class TestDetectInstallMethod:
 
         with patch("jfox.cli.__file__", str(package)):
             assert _detect_install_method() == "dev"
+
+    def test_dev_mode_uv_sync_venv(self, tmp_path):
+        """uv sync 场景：.venv/bin/python + 源码目录判定为 dev"""
+        repo = tmp_path / "jfox"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        (repo / "pyproject.toml").write_text(
+            '[project]\nname = "jfox-cli"\nversion = "1.0.0"\n',
+            encoding="utf-8",
+        )
+        venv_python = repo / ".venv" / "bin" / "python"
+        venv_python.parent.mkdir(parents=True)
+        venv_python.write_text("", encoding="utf-8")
+        package = repo / "jfox" / "cli.py"
+        package.parent.mkdir(parents=True)
+        package.write_text("", encoding="utf-8")
+
+        with patch("jfox.cli.__file__", str(package)):
+            with patch("jfox.cli.sys.executable", str(venv_python)):
+                assert _detect_install_method() == "dev"
+
+    def test_uv_sync_venv_with_wrong_project_name_is_not_dev(self, tmp_path):
+        """.venv 目录存在但 project.name 不是 jfox-cli 时不应误判为 dev"""
+        repo = tmp_path / "some-project"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        (repo / "pyproject.toml").write_text(
+            '[project]\nname = "other-project"\nversion = "1.0.0"\n',
+            encoding="utf-8",
+        )
+        venv_python = repo / ".venv" / "bin" / "python"
+        venv_python.parent.mkdir(parents=True)
+        venv_python.write_text("", encoding="utf-8")
+        package = repo / "jfox" / "cli.py"
+        package.parent.mkdir(parents=True)
+        package.write_text("", encoding="utf-8")
+
+        with patch("jfox.cli.__file__", str(package)):
+            with patch("jfox.cli.sys.executable", str(venv_python)):
+                # 没有正确的 project.name，应走默认 pip 分支
+                assert _detect_install_method() == "pip"
 
     def test_uv_tool_installation(self, tmp_path):
         """uv tool 路径判定为 uv"""

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -14,7 +14,7 @@ from typer.testing import CliRunner
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
-from jfox.cli import _detect_install_method, _update_impl, app
+from jfox.cli import _detect_install_method, _get_installed_version, _update_impl, app
 
 runner = CliRunner()
 
@@ -95,6 +95,25 @@ class TestDetectInstallMethod:
                 with patch("jfox.cli._get_pipx_home", return_value=None):
                     assert _detect_install_method() == "pip"
 
+    def test_dev_detection_stops_at_site_packages(self, tmp_path):
+        """向上遍历时遇到 site-packages 即停止，避免误判 venv"""
+        repo = tmp_path / "jfox"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        (repo / "pyproject.toml").write_text(
+            '[project]\nname = "jfox-cli"\n',
+            encoding="utf-8",
+        )
+        venv_site = repo / ".venv" / "lib" / "python3.11" / "site-packages"
+        package = venv_site / "jfox" / "cli.py"
+        package.parent.mkdir(parents=True)
+        package.write_text("", encoding="utf-8")
+
+        with patch("jfox.cli.__file__", str(package)):
+            with patch("jfox.cli._get_uv_tool_dir", return_value=None):
+                with patch("jfox.cli._get_pipx_home", return_value=None):
+                    assert _detect_install_method() == "pip"
+
 
 class TestUpdateImpl:
     """_update_impl 行为测试"""
@@ -139,6 +158,25 @@ class TestUpdateImpl:
                         result = _update_impl()
                         assert "pip install --upgrade jfox-cli" in result["command"]
 
+    def test_pip_upgrade_in_user_site_adds_user_flag(self, tmp_path):
+        """pip 用户级安装时追加 --user"""
+        user_site = tmp_path / "user-site"
+        user_site.mkdir(parents=True)
+        package = user_site / "jfox" / "cli.py"
+        package.parent.mkdir(parents=True)
+        package.write_text("", encoding="utf-8")
+
+        with patch("jfox.cli._detect_install_method", return_value="pip"):
+            with patch("jfox.__version__", "1.0.0"):
+                with patch("jfox.cli._run_upgrade", return_value="Upgraded"):
+                    with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
+                        with patch(
+                            "jfox.cli.site.getusersitepackages", return_value=str(user_site)
+                        ):
+                            with patch("jfox.cli.__file__", str(package)):
+                                result = _update_impl()
+                                assert "--user" in result["command"]
+
     def test_upgrade_failure_returns_manual_command(self):
         """升级失败时返回手动执行命令"""
         error = subprocess.CalledProcessError(1, ["uv", "tool", "upgrade", "jfox-cli"])
@@ -150,6 +188,17 @@ class TestUpdateImpl:
                     result = _update_impl()
                     assert result["success"] is False
                     assert "network error" in result["error"]
+                    assert "uv tool upgrade jfox-cli" in result["message"]
+
+    def test_upgrade_timeout_returns_failure(self):
+        """升级超时时返回结构化失败"""
+        error = subprocess.TimeoutExpired(["uv", "tool", "upgrade", "jfox-cli"], timeout=300)
+
+        with patch("jfox.cli._detect_install_method", return_value="uv"):
+            with patch("jfox.__version__", "1.0.0"):
+                with patch("jfox.cli._run_upgrade", side_effect=error):
+                    result = _update_impl()
+                    assert result["success"] is False
                     assert "uv tool upgrade jfox-cli" in result["message"]
 
 
@@ -217,3 +266,52 @@ class TestUpdateCommand:
                     data = json.loads(result.output)
                     assert data["success"] is False
                     assert "network error" in data["error"]
+
+    def test_invalid_format_exits_with_error(self):
+        """--format 传入非法值时返回非零退出码"""
+        result = runner.invoke(app, ["update", "--format", "josn"])
+        assert result.exit_code == 2
+        assert "table" in result.output or "json" in result.output
+
+
+class TestGetInstalledVersion:
+    """_get_installed_version 测试"""
+
+    def test_prefers_sys_executable_module(self):
+        """优先使用 sys.executable -m jfox --version"""
+        with patch("jfox.cli.sys.executable", "/usr/bin/python3"):
+            with patch("jfox.cli.shutil.which", return_value="/usr/local/bin/jfox"):
+                with patch("jfox.cli.subprocess.run") as mock_run:
+                    mock_run.return_value.stdout = "jfox 1.1.0\n"
+                    version = _get_installed_version()
+                    assert version == "1.1.0"
+                    mock_run.assert_called_once()
+                    assert mock_run.call_args[0][0] == [
+                        "/usr/bin/python3",
+                        "-m",
+                        "jfox",
+                        "--version",
+                    ]
+
+    def test_falls_back_to_path_jfox(self):
+        """sys.executable 方式失败时回退到 PATH 中的 jfox"""
+        with patch("jfox.cli.sys.executable", "/usr/bin/python3"):
+            with patch("jfox.cli.shutil.which", return_value="/usr/local/bin/jfox"):
+                with patch("jfox.cli.subprocess.run") as mock_run:
+                    mock_run.side_effect = [
+                        subprocess.CalledProcessError(1, ["python3", "-m", "jfox"]),
+                        type("obj", (object,), {"stdout": "jfox 1.2.0\n"})(),
+                    ]
+                    version = _get_installed_version()
+                    assert version == "1.2.0"
+                    assert mock_run.call_count == 2
+
+    def test_returns_unknown_when_all_fail(self):
+        """所有方式均失败时返回 unknown"""
+        with patch("jfox.cli.sys.executable", "/usr/bin/python3"):
+            with patch("jfox.cli.shutil.which", return_value=None):
+                with patch(
+                    "jfox.cli.subprocess.run",
+                    side_effect=subprocess.CalledProcessError(1, ["python3"]),
+                ):
+                    assert _get_installed_version() == "unknown"

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -14,7 +14,16 @@ from typer.testing import CliRunner
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
-from jfox.cli import _detect_install_method, _get_installed_version, _update_impl, app
+from jfox.cli import (
+    _detect_install_method,
+    _get_installed_version,
+    _is_pipx_installation,
+    _is_uv_tool_installation,
+    _path_has_contiguous_parts,
+    _run_upgrade,
+    _update_impl,
+    app,
+)
 
 runner = CliRunner()
 
@@ -114,6 +123,154 @@ class TestDetectInstallMethod:
                 with patch("jfox.cli._get_pipx_home", return_value=None):
                     assert _detect_install_method() == "pip"
 
+    def test_uv_tool_installation_fallback_slice(self, tmp_path):
+        """uv 二进制不可用时，通过连续路径切片判定为 uv tool"""
+        uv_tools = tmp_path / "uv" / "tools"
+        package = uv_tools / "jfox-cli" / "lib" / "python3.11" / "site-packages" / "jfox" / "cli.py"
+        package.parent.mkdir(parents=True)
+        package.write_text("", encoding="utf-8")
+
+        with patch("jfox.cli.__file__", str(package)):
+            with patch("jfox.cli._get_uv_tool_dir", return_value=None):
+                with patch("jfox.cli._get_pipx_home", return_value=None):
+                    assert _detect_install_method() == "uv"
+
+    def test_pipx_installation_fallback_slice(self, tmp_path):
+        """pipx 二进制不可用时，通过连续路径切片判定为 pipx"""
+        pipx_home = tmp_path / "pipx"
+        package = (
+            pipx_home
+            / "venvs"
+            / "jfox-cli"
+            / "lib"
+            / "python3.11"
+            / "site-packages"
+            / "jfox"
+            / "cli.py"
+        )
+        package.parent.mkdir(parents=True)
+        package.write_text("", encoding="utf-8")
+
+        with patch("jfox.cli.__file__", str(package)):
+            with patch("jfox.cli._get_uv_tool_dir", return_value=None):
+                with patch("jfox.cli._get_pipx_home", return_value=None):
+                    assert _detect_install_method() == "pipx"
+
+    def test_non_contiguous_uv_path_does_not_match(self, tmp_path):
+        """非连续的 uv 路径切片不应误判为 uv tool"""
+        package = tmp_path / "uv" / "backup" / "tools" / "old" / "jfox-cli" / "jfox" / "cli.py"
+        package.parent.mkdir(parents=True)
+        package.write_text("", encoding="utf-8")
+
+        with patch("jfox.cli.__file__", str(package)):
+            with patch("jfox.cli._get_uv_tool_dir", return_value=None):
+                with patch("jfox.cli._get_pipx_home", return_value=None):
+                    assert _detect_install_method() == "pip"
+
+    def test_non_contiguous_pipx_path_does_not_match(self, tmp_path):
+        """非连续的 pipx 路径切片不应误判为 pipx"""
+        package = tmp_path / "pipx" / "backup" / "venvs" / "old" / "jfox-cli" / "jfox" / "cli.py"
+        package.parent.mkdir(parents=True)
+        package.write_text("", encoding="utf-8")
+
+        with patch("jfox.cli.__file__", str(package)):
+            with patch("jfox.cli._get_uv_tool_dir", return_value=None):
+                with patch("jfox.cli._get_pipx_home", return_value=None):
+                    assert _detect_install_method() == "pip"
+
+
+class TestIsUvToolInstallation:
+    """_is_uv_tool_installation 测试"""
+
+    def test_strict_uv_path_match(self, tmp_path):
+        """主路径命中 uv tool 目录"""
+        uv_tools = tmp_path / "uv" / "tools"
+        package = uv_tools / "jfox-cli" / "lib" / "python3.11" / "site-packages" / "jfox" / "cli.py"
+        package.parent.mkdir(parents=True)
+
+        with patch("jfox.cli._get_uv_tool_dir", return_value=uv_tools):
+            assert _is_uv_tool_installation(package) is True
+
+    def test_fallback_slice_match(self, tmp_path):
+        """主路径失败但连续切片命中"""
+        package = (
+            tmp_path
+            / "uv"
+            / "tools"
+            / "jfox-cli"
+            / "lib"
+            / "python3.11"
+            / "site-packages"
+            / "jfox"
+            / "cli.py"
+        )
+        package.parent.mkdir(parents=True)
+
+        with patch("jfox.cli._get_uv_tool_dir", return_value=None):
+            assert _is_uv_tool_installation(package) is True
+
+
+class TestIsPipxInstallation:
+    """_is_pipx_installation 测试"""
+
+    def test_strict_pipx_path_match(self, tmp_path):
+        """主路径命中 pipx venv 目录"""
+        pipx_home = tmp_path / "pipx"
+        package = (
+            pipx_home
+            / "venvs"
+            / "jfox-cli"
+            / "lib"
+            / "python3.11"
+            / "site-packages"
+            / "jfox"
+            / "cli.py"
+        )
+        package.parent.mkdir(parents=True)
+
+        with patch("jfox.cli._get_pipx_home", return_value=pipx_home):
+            assert _is_pipx_installation(package) is True
+
+    def test_fallback_slice_match(self, tmp_path):
+        """主路径失败但连续切片命中"""
+        package = (
+            tmp_path
+            / "pipx"
+            / "venvs"
+            / "jfox-cli"
+            / "lib"
+            / "python3.11"
+            / "site-packages"
+            / "jfox"
+            / "cli.py"
+        )
+        package.parent.mkdir(parents=True)
+
+        with patch("jfox.cli._get_pipx_home", return_value=None):
+            assert _is_pipx_installation(package) is True
+
+
+class TestPathHasContiguousParts:
+    """_path_has_contiguous_parts 辅助函数测试"""
+
+    def test_matches_contiguous_sequence(self, tmp_path):
+        """完全匹配连续切片"""
+        path = tmp_path / "a" / "b" / "c" / "d"
+        path.mkdir(parents=True)
+        assert _path_has_contiguous_parts(path, ("a", "b", "c")) is True
+
+    def test_rejects_non_contiguous_sequence(self, tmp_path):
+        """非连续切片不匹配"""
+        path = tmp_path / "a" / "x" / "b" / "c"
+        path.mkdir(parents=True)
+        assert _path_has_contiguous_parts(path, ("a", "b", "c")) is False
+
+    def test_rejects_longer_sequence_than_path(self, tmp_path):
+        """切片长度超过路径部分数时不匹配"""
+        path = tmp_path / "a"
+        path.mkdir()
+        assert _path_has_contiguous_parts(path, ("a", "b", "c")) is False
+
 
 class TestUpdateImpl:
     """_update_impl 行为测试"""
@@ -131,7 +288,10 @@ class TestUpdateImpl:
         """uv 模式下调用正确命令并返回版本对比"""
         with patch("jfox.cli._detect_install_method", return_value="uv"):
             with patch("jfox.__version__", "1.0.0"):
-                with patch("jfox.cli._run_upgrade", return_value="Upgraded"):
+                with patch(
+                    "jfox.cli._run_upgrade",
+                    return_value={"stdout": "Upgraded", "stderr": ""},
+                ):
                     with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
                         result = _update_impl()
                         assert result["success"] is True
@@ -144,7 +304,10 @@ class TestUpdateImpl:
         """pipx 模式下调用正确命令"""
         with patch("jfox.cli._detect_install_method", return_value="pipx"):
             with patch("jfox.__version__", "1.0.0"):
-                with patch("jfox.cli._run_upgrade", return_value="Upgraded"):
+                with patch(
+                    "jfox.cli._run_upgrade",
+                    return_value={"stdout": "Upgraded", "stderr": ""},
+                ):
                     with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
                         result = _update_impl()
                         assert result["command"] == "pipx upgrade jfox-cli"
@@ -153,7 +316,10 @@ class TestUpdateImpl:
         """pip 模式下调用正确命令"""
         with patch("jfox.cli._detect_install_method", return_value="pip"):
             with patch("jfox.__version__", "1.0.0"):
-                with patch("jfox.cli._run_upgrade", return_value="Upgraded"):
+                with patch(
+                    "jfox.cli._run_upgrade",
+                    return_value={"stdout": "Upgraded", "stderr": ""},
+                ):
                     with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
                         result = _update_impl()
                         assert "pip install --upgrade jfox-cli" in result["command"]
@@ -168,7 +334,10 @@ class TestUpdateImpl:
 
         with patch("jfox.cli._detect_install_method", return_value="pip"):
             with patch("jfox.__version__", "1.0.0"):
-                with patch("jfox.cli._run_upgrade", return_value="Upgraded"):
+                with patch(
+                    "jfox.cli._run_upgrade",
+                    return_value={"stdout": "Upgraded", "stderr": ""},
+                ):
                     with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
                         with patch(
                             "jfox.cli.site.getusersitepackages", return_value=str(user_site)
@@ -201,6 +370,37 @@ class TestUpdateImpl:
                     assert result["success"] is False
                     assert "uv tool upgrade jfox-cli" in result["message"]
 
+    def test_success_separates_stdout_and_stderr(self):
+        """成功路径保持 output=stdout，stderr 放入单独 key"""
+        with patch("jfox.cli._detect_install_method", return_value="uv"):
+            with patch("jfox.__version__", "1.0.0"):
+                with patch(
+                    "jfox.cli._run_upgrade",
+                    return_value={"stdout": "stdout msg", "stderr": "stderr msg"},
+                ):
+                    with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
+                        result = _update_impl()
+                        assert result["success"] is True
+                        assert result["output"] == "stdout msg"
+                        assert result["stderr"] == "stderr msg"
+
+
+class TestRunUpgrade:
+    """_run_upgrade 辅助函数测试"""
+
+    def test_returns_stdout_and_stderr_separately(self):
+        """分别返回 stdout 与 stderr，不合并"""
+        mock_result = type(
+            "obj",
+            (object,),
+            {"stdout": "standard output\n", "stderr": "standard error\n"},
+        )()
+        with patch("jfox.cli.subprocess.run", return_value=mock_result) as mock_run:
+            result = _run_upgrade(["uv", "tool", "upgrade", "jfox-cli"])
+            assert result["stdout"] == "standard output"
+            assert result["stderr"] == "standard error"
+            mock_run.assert_called_once()
+
 
 class TestUpdateCommand:
     """jfox update CLI 命令测试"""
@@ -218,12 +418,29 @@ class TestUpdateCommand:
         """table 输出显示版本对比"""
         with patch("jfox.cli._detect_install_method", return_value="uv"):
             with patch("jfox.__version__", "1.0.0"):
-                with patch("jfox.cli._run_upgrade", return_value="Upgraded"):
+                with patch(
+                    "jfox.cli._run_upgrade",
+                    return_value={"stdout": "Upgraded", "stderr": ""},
+                ):
                     with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
                         result = runner.invoke(app, ["update"])
                         assert result.exit_code == 0
                         assert "uv" in result.output
                         assert "1.0.0 → 1.1.0" in result.output
+
+    def test_table_output_shows_stderr_separately(self):
+        """成功时 stderr 在 table 输出中单独显示"""
+        with patch("jfox.cli._detect_install_method", return_value="uv"):
+            with patch("jfox.__version__", "1.0.0"):
+                with patch(
+                    "jfox.cli._run_upgrade",
+                    return_value={"stdout": "Upgraded", "stderr": "warning: old metadata"},
+                ):
+                    with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
+                        result = runner.invoke(app, ["update"])
+                        assert result.exit_code == 0
+                        assert "Upgraded" in result.output
+                        assert "warning: old metadata" in result.output
 
     def test_table_output_failure(self):
         """升级失败时 table 输出显示错误和手动命令"""
@@ -243,7 +460,10 @@ class TestUpdateCommand:
         """--json 输出合法 JSON"""
         with patch("jfox.cli._detect_install_method", return_value="uv"):
             with patch("jfox.__version__", "1.0.0"):
-                with patch("jfox.cli._run_upgrade", return_value="Upgraded"):
+                with patch(
+                    "jfox.cli._run_upgrade",
+                    return_value={"stdout": "Upgraded", "stderr": ""},
+                ):
                     with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
                         result = runner.invoke(app, ["update", "--json"])
                         assert result.exit_code == 0


### PR DESCRIPTION
## Summary\n\nCloses #238\n\n新增 "jfox update" 命令，自动检测当前安装方式（dev / uv tool / pipx / pip）并调用对应升级命令，同时显示升级前后版本对比。\n\n## Changes\n\n- "jfox/cli.py": 新增安装方式检测、升级命令执行、版本对比及 "jfox update" Typer 命令\n- "tests/unit/test_update.py": 覆盖检测逻辑、命令选择、JSON 输出、失败处理等 15 个单元测试\n- "README.md" / "docs/installation.md": 补充命令说明和手动升级回退\n- "docs/superpowers/": 添加设计文档与执行计划\n\n## Verification\n\n- "uv run --extra dev pytest tests/unit/test_update.py -v"：15/15 passed\n- "uv run --extra dev pytest tests/unit/ -m 'not embedding and not slow' -q"：471 passed, 9 skipped\n- "uv run --extra dev ruff check jfox/cli.py tests/unit/test_update.py"：passed\n- 本地 smoke test："jfox update" 正确识别当前 worktree 为 dev 模式并给出提示