### PR TITLE
feat: 笔记归档/软删除功能（archive/unarchive）

### DIFF
--- a/docs/superpowers/specs/2026-06-18-archive-soft-delete-design.md
+++ b/docs/superpowers/specs/2026-06-18-archive-soft-delete-design.md
@@ -1,0 +1,160 @@
+# Issue #259 设计文档：笔记归档/软删除
+
+## 背景与目标
+
+用户在把 session 笔记提炼为 permanent 笔记后，希望这些源 session 笔记不再出现在默认列表和搜索结果中，但又不想被永久删除。因此需要引入类似邮箱"归档"的软删除机制。
+
+目标：
+- 不真正删除文件，仅通过 frontmatter 标记 `archived: true`。
+- 默认的 `jfox list` / `jfox search` 隐藏已归档笔记。
+- 提供显式命令查看/恢复归档笔记。
+- `jfox show` 和 `jfox delete` 行为不受影响。
+
+## 需求拆解
+
+| 用户命令 | 行为 |
+|---------|------|
+| `jfox archive <note_id>` | 将笔记标记为 `archived: true`，更新 `updated` 时间戳 |
+| `jfox unarchive <note_id>` | 将笔记标记为 `archived: false`（frontmatter 中移除该字段），更新 `updated` 时间戳 |
+| `jfox list` | 默认只列出未归档笔记 |
+| `jfox list --archived` | 只列出已归档笔记 |
+| `jfox list --include-archived` | 列出全部笔记（包含归档） |
+| `jfox search "关键词"` | 默认排除已归档笔记 |
+| `jfox search "关键词" --include-archived` | 搜索时包含已归档笔记 |
+| `jfox show <id>` | 不受归档状态影响，始终可查看 |
+| `jfox delete <id>` | 真删除，不受归档状态影响 |
+
+## 方案设计
+
+### 1. 数据模型（`jfox/models.py`）
+
+在 `Note` 数据类中新增字段：
+
+```python
+archived: bool = False
+```
+
+- `to_markdown()`：仅在 `archived=True` 时把 `archived: true` 写入 frontmatter，保持未归档笔记 frontmatter 干净。
+- `from_markdown()`：读取 `archived` 字段，缺失时默认 `False`。
+- `to_dict()`：增加 `"archived"` 字段，便于 JSON 输出。
+
+### 2. 元数据索引（`jfox/note_index.py`）
+
+在 `NoteMeta` 中新增 `archived: bool = False`。
+
+索引构建时从 frontmatter 读取 `archived`，缺失默认 `False`。`list_meta()` 增加过滤参数：
+
+```python
+def list_meta(
+    self,
+    note_type: Optional[NoteType] = None,
+    tags: Optional[List[str]] = None,
+    limit: Optional[int] = None,
+    archived_only: bool = False,
+    include_archived: bool = False,
+) -> List[NoteMeta]:
+```
+
+过滤规则：
+- `archived_only=True`：只返回 `archived=True`。
+- `include_archived=True`：返回全部。
+- 默认：只返回 `archived=False`。
+
+### 3. 笔记 CRUD（`jfox/note.py`）
+
+新增：
+
+```python
+def archive_note(note_id: str) -> bool
+def unarchive_note(note_id: str) -> bool
+```
+
+实现：
+1. 通过 `load_note_by_id(note_id)` 加载笔记。
+2. 设置 `note.archived = True/False`。
+3. 调用 `update_note(note)` 持久化并同步索引（向量 + BM25）。
+
+复用 `update_note` 可以自动处理：
+- 原子写入；
+- 文件名变化（归档不会改变文件名，但保留路径）；
+- 索引更新（先删除旧向量/BM25，再添加新内容）。
+
+`list_notes()` 增加参数 `archived_only` 和 `include_archived`，透传给 `NoteIndex.list_meta()`。
+
+`search_notes()` 增加参数 `include_archived`，透传给搜索引擎。
+
+### 4. 搜索引擎（`jfox/search_engine.py`）
+
+`HybridSearchEngine.search()` 增加 `include_archived: bool = False`。
+
+由于现有 ChromaDB 集合里的笔记元数据不一定包含 `archived` 字段，直接在 ChromaDB 层过滤会导致旧数据被误排除。因此采用**后过滤**策略：
+
+1. 搜索时先按原逻辑获取结果，但 `exclude archived` 时多取一些结果（over-fetch）。
+2. 使用 `NoteIndex` 判断每个结果是否归档（`meta.archived`）。
+3. 过滤后取前 `top_k` 条。
+
+over-fetch 策略：
+- `_semantic_search` / `_keyword_search`：当 `not include_archived` 时，`search_k = max(top_k * 5, 20)`。
+- `_hybrid_search`：同样 over-fetch，融合后再过滤。
+
+这样可以在绝大多数场景下保证返回数量，同时避免旧索引数据兼容性问题。
+
+### 5. CLI（`jfox/cli.py`）
+
+新增命令：
+
+```python
+@app.command()
+def archive(
+    note_id: str = typer.Argument(..., help="笔记 ID"),
+    kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
+    output_format: str = typer.Option("table", "--format", "-f", help="输出格式: json, table"),
+    json_output: bool = typer.Option(False, "--json", help="JSON 输出"),
+):
+    ...
+
+@app.command()
+def unarchive(...):
+    ...
+```
+
+`list` 命令增加选项：
+
+```python
+archived_only: bool = typer.Option(False, "--archived", help="仅显示已归档笔记"),
+include_archived: bool = typer.Option(False, "--include-archived", help="包含已归档笔记"),
+```
+
+`--archived` 与 `--include-archived` 互斥，同时指定时报错。
+
+`search` 命令增加选项：
+
+```python
+include_archived: bool = typer.Option(False, "--include-archived", help="包含已归档笔记"),
+```
+
+`_list_impl` / `_search_impl` 相应增加参数透传。
+
+### 6. 测试策略
+
+新增 `tests/unit/test_archive.py`，覆盖：
+
+- `Note.to_markdown()` / `from_markdown()` 正确读写 `archived`。
+- `NoteIndex.list_meta()` 默认排除归档、支持 `archived_only` / `include_archived`。
+- `archive_note()` / `unarchive_note()` 更新文件与索引。
+- `list` CLI 默认排除归档、`--archived`、`--include-archived`。
+- `search` CLI 默认排除归档、`--include-archived`。
+- `show` / `delete` 对归档笔记行为不变。
+
+使用现有 fixture（`temp_kb`、`cli_fast`）避免加载 embedding 模型。
+
+## 兼容性
+
+- 旧笔记没有 `archived` 字段，解析时默认视为未归档，行为不变。
+- 已写入的 ChromaDB/BM25 索引不需要重建即可工作（后过滤）。
+- 归档/取消归档会触发 `update_note()`，自动更新索引内容。
+
+## 风险与回滚
+
+- 风险：后过滤可能导致 `top_k` 返回数量不足（如果前 N 条中归档笔记很多）。通过 over-fetch（`*5` 且至少 20）缓解。
+- 回滚：取消归档会移除 frontmatter 中的 `archived` 字段，恢复为未归档状态。

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -486,15 +486,24 @@ def _search_impl(
     tags: Optional[List[str]],
     search_mode: str,
     output_format: str,
+    include_archived: bool = False,
 ):
     """搜索笔记的内部实现"""
     from .formatters import OutputFormatter
 
-    results = note.search_notes(query, top_k=top, note_type=note_type, tags=tags, mode=search_mode)
+    results = note.search_notes(
+        query,
+        top_k=top,
+        note_type=note_type,
+        tags=tags,
+        mode=search_mode,
+        include_archived=include_archived,
+    )
 
     result = {
         "query": query,
         "mode": search_mode,
+        "include_archived": include_archived,
         "total": len(results),
         "results": results,
     }
@@ -574,6 +583,7 @@ def search(
         "table", "--format", "-f", help="输出格式: json, table, csv, yaml, paths"
     ),
     json_output: bool = typer.Option(False, "--json/--no-json", help="JSON 输出（向后兼容）"),
+    include_archived: bool = typer.Option(False, "--include-archived", help="搜索时包含已归档笔记"),
     kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
 ):
     """
@@ -583,6 +593,8 @@ def search(
     - hybrid: 混合搜索（BM25 + 语义），默认
     - semantic: 纯语义搜索
     - keyword: 纯关键词搜索 (BM25)
+
+    已归档笔记默认不会出现在搜索结果中，可使用 --include-archived 包含。
 
     示例:
         jfox search "Python" --mode hybrid
@@ -596,7 +608,7 @@ def search(
         from .config import use_kb
 
         with use_kb(kb):
-            _search_impl(query, top, note_type, tags, search_mode, output_format)
+            _search_impl(query, top, note_type, tags, search_mode, output_format, include_archived)
 
     except Exception as e:
         result = {
@@ -789,6 +801,8 @@ def _list_impl(
     tags: Optional[List[str]],
     limit: int,
     output_format: str,
+    archived_only: bool = False,
+    include_archived: bool = False,
 ):
     """列出笔记的内部实现"""
     from .formatters import OutputFormatter
@@ -803,7 +817,13 @@ def _list_impl(
                 f"Invalid note type: {note_type}. Use: fleeting, literature, permanent, session"
             )
 
-    notes = note.list_notes(note_type=nt, tags=tags, limit=limit)
+    notes = note.list_notes(
+        note_type=nt,
+        tags=tags,
+        limit=limit,
+        archived_only=archived_only,
+        include_archived=include_archived,
+    )
     data = []
     for n in notes:
         d = n.to_dict()
@@ -819,7 +839,12 @@ def _list_impl(
     if output_format == "json":
         print(OutputFormatter.to_json(result))
     elif output_format == "table":
-        table = Table(title=f"Notes ({len(notes)} total)")
+        title = f"Notes ({len(notes)} total)"
+        if archived_only:
+            title = f"Archived Notes ({len(notes)} total)"
+        elif include_archived:
+            title = f"All Notes ({len(notes)} total, including archived)"
+        table = Table(title=title)
         table.add_column("ID", style="dim")
         table.add_column("Title", style="cyan")
         table.add_column("Type", style="green")
@@ -870,6 +895,8 @@ def list(
         "table", "--format", "-f", help="输出格式: json, table, csv, yaml, paths, tree"
     ),
     json_output: bool = typer.Option(False, "--json/--no-json", help="JSON 输出（向后兼容）"),
+    archived_only: bool = typer.Option(False, "--archived", help="仅显示已归档笔记"),
+    include_archived: bool = typer.Option(False, "--include-archived", help="显示时包含已归档笔记"),
     kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
 ):
     """
@@ -882,16 +909,21 @@ def list(
     - yaml: YAML 格式
     - paths: 仅输出文件路径
     - tree: 树形结构
+
+    归档笔记默认隐藏，可使用 --archived 或 --include-archived 查看。
     """
     try:
         # 向后兼容：如果指定了 --json，使用 json 格式
         if json_output:
             output_format = "json"
 
+        if archived_only and include_archived:
+            raise ValueError("--archived 和 --include-archived 不能同时使用")
+
         from .config import use_kb
 
         with use_kb(kb):
-            _list_impl(note_type, tags, limit, output_format)
+            _list_impl(note_type, tags, limit, output_format, archived_only, include_archived)
 
     except Exception as e:
         result = {
@@ -1165,6 +1197,126 @@ def delete(
 
         with use_kb(kb):
             _delete_impl(note_id, force, output_format)
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        result = {
+            "success": False,
+            "error": str(e),
+        }
+        if output_format == "json":
+            print(output_json(result))
+        else:
+            console.print(f"[red]✗[/red] Error: {e}")
+        raise typer.Exit(1)
+
+
+def _archive_impl(note_id: str, output_format: str):
+    """归档笔记的内部实现"""
+    n = note.load_note_by_id(note_id)
+    if not n:
+        raise ValueError(f"Note not found: {note_id}")
+
+    if note.archive_note(note_id):
+        result = {
+            "success": True,
+            "archived": note_id,
+            "title": n.title,
+        }
+
+        if output_format == "json":
+            print(output_json(result))
+        else:
+            _print_action_table(
+                "archived",
+                {
+                    "ID": note_id,
+                    "Title": n.title,
+                },
+            )
+    else:
+        raise Exception("Failed to archive note")
+
+
+def _unarchive_impl(note_id: str, output_format: str):
+    """恢复归档笔记的内部实现"""
+    n = note.load_note_by_id(note_id)
+    if not n:
+        raise ValueError(f"Note not found: {note_id}")
+
+    if note.unarchive_note(note_id):
+        result = {
+            "success": True,
+            "unarchived": note_id,
+            "title": n.title,
+        }
+
+        if output_format == "json":
+            print(output_json(result))
+        else:
+            _print_action_table(
+                "unarchived",
+                {
+                    "ID": note_id,
+                    "Title": n.title,
+                },
+            )
+    else:
+        raise Exception("Failed to unarchive note")
+
+
+@app.command()
+def archive(
+    note_id: str = typer.Argument(..., help="笔记 ID"),
+    kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
+    output_format: str = typer.Option("table", "--format", "-f", help="输出格式: json, table"),
+    json_output: bool = typer.Option(
+        False, "--json", help="JSON 输出（快捷方式，等同于 --format json）"
+    ),
+):
+    """归档笔记（软删除）：文件保留，默认列表和搜索中隐藏"""
+    try:
+        if json_output:
+            output_format = "json"
+
+        from .config import use_kb
+
+        with use_kb(kb):
+            _archive_impl(note_id, output_format)
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        result = {
+            "success": False,
+            "error": str(e),
+        }
+        if output_format == "json":
+            print(output_json(result))
+        else:
+            console.print(f"[red]✗[/red] Error: {e}")
+        raise typer.Exit(1)
+
+
+@app.command()
+def unarchive(
+    note_id: str = typer.Argument(..., help="笔记 ID"),
+    kb: Optional[str] = typer.Option(None, "--kb", "-k", help="目标知识库名称"),
+    output_format: str = typer.Option("table", "--format", "-f", help="输出格式: json, table"),
+    json_output: bool = typer.Option(
+        False, "--json", help="JSON 输出（快捷方式，等同于 --format json）"
+    ),
+):
+    """恢复归档笔记，重新出现在默认列表和搜索结果中"""
+    try:
+        if json_output:
+            output_format = "json"
+
+        from .config import use_kb
+
+        with use_kb(kb):
+            _unarchive_impl(note_id, output_format)
 
     except typer.Exit:
         raise
@@ -1873,7 +2025,7 @@ def _index_impl(action: str, output_format: str):
 
         console.print("[yellow]Rebuilding BM25 index...[/yellow]")
         bm25_index = get_bm25_index()
-        notes = note_module.list_notes(limit=10000)
+        notes = note_module.list_notes(limit=10000, include_archived=True)
         success = bm25_index.rebuild_from_notes(notes)
 
         result = {
@@ -1956,7 +2108,7 @@ def _index_impl(action: str, output_format: str):
             from .bm25_index import get_bm25_index
 
             bm25_index = get_bm25_index()
-            notes = note_module.list_notes(limit=10000)
+            notes = note_module.list_notes(limit=10000, include_archived=True)
             bm25_success = bm25_index.rebuild_from_notes(notes)
 
             result = {

--- a/jfox/models.py
+++ b/jfox/models.py
@@ -34,6 +34,7 @@ class Note:
     backlinks: List[str] = field(default_factory=list)  # 反向链接
     source: Optional[str] = None  # 来源（文献笔记）
     topic: Optional[str] = None  # 会话主题（session 类型）
+    archived: bool = False  # 是否已归档（软删除标记）
 
     # 运行时字段（不持久化到 frontmatter）
     embedding: Optional[List[float]] = None  # 向量
@@ -87,6 +88,8 @@ class Note:
             frontmatter["source"] = self.source
         if self.topic:
             frontmatter["topic"] = self.topic
+        if self.archived:
+            frontmatter["archived"] = self.archived
 
         fm_yaml = yaml.dump(frontmatter, allow_unicode=True, sort_keys=False)
 
@@ -136,6 +139,7 @@ class Note:
             backlinks=fm.get("backlinks", []),
             source=fm.get("source"),
             topic=fm.get("topic"),
+            archived=bool(fm.get("archived", False)),
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -150,6 +154,7 @@ class Note:
             "tags": self.tags,
             "links": self.links,
             "filepath": str(self.filepath),
+            "archived": self.archived,
             "score": self.score,
             "hop": self.hop,
             "topic": self.topic,

--- a/jfox/models.py
+++ b/jfox/models.py
@@ -10,6 +10,19 @@ from typing import Any, Dict, List, Optional
 import yaml
 
 
+def _to_bool(value: Any) -> bool:
+    """将 frontmatter 中的值安全转换为 bool，正确处理 YAML 字符串。
+
+    YAML 中 archived: "false" 会被解析为字符串 "false"，
+    直接用 bool() 会误判为 True，因此需要显式处理常见假值字符串。
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() not in ("false", "0", "", "no", "off", "null", "none")
+    return bool(value)
+
+
 class NoteType(Enum):
     """笔记类型"""
 
@@ -139,7 +152,7 @@ class Note:
             backlinks=fm.get("backlinks", []),
             source=fm.get("source"),
             topic=fm.get("topic"),
-            archived=bool(fm.get("archived", False)),
+            archived=_to_bool(fm.get("archived", False)),
         )
 
     def to_dict(self) -> Dict[str, Any]:

--- a/jfox/note.py
+++ b/jfox/note.py
@@ -298,7 +298,8 @@ def archive_note(note_id: str) -> bool:
 
     if n.archived:
         logger.info(f"Note {note_id} is already archived")
-        return True
+        # 幂等路径仍刷新 updated 时间戳以符合设计语义
+        return update_note(n)
 
     n.archived = True
     return update_note(n)
@@ -321,7 +322,8 @@ def unarchive_note(note_id: str) -> bool:
 
     if not n.archived:
         logger.info(f"Note {note_id} is not archived")
-        return True
+        # 幂等路径仍刷新 updated 时间戳以符合设计语义
+        return update_note(n)
 
     n.archived = False
     return update_note(n)
@@ -381,6 +383,15 @@ def update_note(note_obj: Note, add_to_index: bool = True) -> bool:
                 bm25_index.add_document(note_obj.id, content)
             except Exception as e:
                 logger.warning(f"Failed to update BM25 index: {e}")
+
+        # 同步刷新 NoteIndex 缓存，避免同进程内读取到旧的归档状态
+        try:
+            from .note_index import get_note_index
+
+            idx = get_note_index()
+            idx.update_note_meta(note_obj)
+        except Exception as e:
+            logger.warning(f"Failed to update note index cache: {e}")
 
         return True
 

--- a/jfox/note.py
+++ b/jfox/note.py
@@ -181,6 +181,8 @@ def list_notes(
     limit: Optional[int] = None,
     cfg: Optional[ZKConfig] = None,
     tags: Optional[List[str]] = None,
+    archived_only: bool = False,
+    include_archived: bool = False,
 ) -> List[Note]:
     """
     列出笔记
@@ -192,6 +194,8 @@ def list_notes(
         limit: 数量限制
         cfg: 可选的配置对象，默认使用全局 config
         tags: 标签筛选列表（AND 逻辑）
+        archived_only: 仅返回已归档笔记
+        include_archived: 返回时包含已归档笔记
 
     Returns:
         笔记列表
@@ -202,7 +206,13 @@ def list_notes(
 
     # 通过索引获取匹配的元数据列表（tags/limit 在索引层生效）
     idx = get_note_index(use_config)
-    metas = idx.list_meta(note_type=note_type, tags=tags, limit=limit)
+    metas = idx.list_meta(
+        note_type=note_type,
+        tags=tags,
+        limit=limit,
+        archived_only=archived_only,
+        include_archived=include_archived,
+    )
 
     # 只加载匹配到的笔记文件
     notes = []
@@ -269,6 +279,52 @@ def delete_note(note_id: str) -> bool:
     except Exception as e:
         logger.error(f"Failed to delete note {note_id}: {e}")
         return False
+
+
+def archive_note(note_id: str) -> bool:
+    """
+    归档笔记（软删除）
+
+    Args:
+        note_id: 笔记 ID
+
+    Returns:
+        是否成功归档
+    """
+    n = load_note_by_id(note_id)
+    if not n:
+        logger.warning(f"Note {note_id} not found")
+        return False
+
+    if n.archived:
+        logger.info(f"Note {note_id} is already archived")
+        return True
+
+    n.archived = True
+    return update_note(n)
+
+
+def unarchive_note(note_id: str) -> bool:
+    """
+    恢复归档笔记
+
+    Args:
+        note_id: 笔记 ID
+
+    Returns:
+        是否成功恢复
+    """
+    n = load_note_by_id(note_id)
+    if not n:
+        logger.warning(f"Note {note_id} not found")
+        return False
+
+    if not n.archived:
+        logger.info(f"Note {note_id} is not archived")
+        return True
+
+    n.archived = False
+    return update_note(n)
 
 
 def update_note(note_obj: Note, add_to_index: bool = True) -> bool:
@@ -378,6 +434,7 @@ def search_notes(
     note_type: Optional[str] = None,
     mode: str = "hybrid",
     tags: Optional[List[str]] = None,
+    include_archived: bool = False,
 ) -> List[Dict[str, Any]]:
     """
     搜索笔记
@@ -388,6 +445,7 @@ def search_notes(
         note_type: 笔记类型筛选
         mode: 搜索模式 - "hybrid"(混合), "semantic"(语义), "keyword"(关键词)
         tags: 标签筛选列表（AND 逻辑）
+        include_archived: 是否包含已归档笔记，默认排除
 
     Returns:
         搜索结果列表
@@ -405,7 +463,12 @@ def search_notes(
     search_mode = mode_map.get(mode.lower(), SearchMode.HYBRID)
 
     return search_engine.search(
-        query, top_k=top_k, mode=search_mode, note_type=note_type, tags=tags
+        query,
+        top_k=top_k,
+        mode=search_mode,
+        note_type=note_type,
+        tags=tags,
+        include_archived=include_archived,
     )
 
 

--- a/jfox/note_index.py
+++ b/jfox/note_index.py
@@ -28,6 +28,7 @@ class NoteMeta:
     filepath: str = ""
     links: List[str] = field(default_factory=list)
     backlinks: List[str] = field(default_factory=list)
+    archived: bool = False
 
 
 _MAX_FRONTMATTER_LINES = 200
@@ -126,6 +127,7 @@ class NoteIndex:
                         filepath=str(filepath),
                         links=_to_list(fm.get("links")),
                         backlinks=_to_list(fm.get("backlinks")),
+                        archived=bool(fm.get("archived", False)),
                     )
 
                     self._by_id[meta.id] = meta
@@ -167,12 +169,20 @@ class NoteIndex:
         note_type: Optional[NoteType] = None,
         tags: Optional[List[str]] = None,
         limit: Optional[int] = None,
+        archived_only: bool = False,
+        include_archived: bool = False,
     ) -> List[NoteMeta]:
-        """列出元数据，支持类型/标签过滤和 limit 截断"""
+        """列出元数据，支持类型/标签/归档状态过滤和 limit 截断"""
         if note_type:
             result = list(self._by_type.get(note_type, []))
         else:
             result = list(self._by_id.values())
+
+        # 归档状态过滤
+        if archived_only:
+            result = [m for m in result if m.archived]
+        elif not include_archived:
+            result = [m for m in result if not m.archived]
 
         if tags:
             result = [m for m in result if all(t in m.tags for t in tags)]

--- a/jfox/note_index.py
+++ b/jfox/note_index.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional
 import yaml
 
 from .config import ZKConfig
-from .models import NoteType
+from .models import Note, NoteType, _to_bool
 
 logger = logging.getLogger(__name__)
 
@@ -127,7 +127,7 @@ class NoteIndex:
                         filepath=str(filepath),
                         links=_to_list(fm.get("links")),
                         backlinks=_to_list(fm.get("backlinks")),
-                        archived=bool(fm.get("archived", False)),
+                        archived=_to_bool(fm.get("archived", False)),
                     )
 
                     self._by_id[meta.id] = meta
@@ -199,6 +199,43 @@ class NoteIndex:
     def get_invalid_files(self) -> List[str]:
         """返回无效文件路径列表"""
         return list(self._invalid_files)
+
+    def update_note_meta(self, note: Note) -> None:
+        """增量更新单个笔记的元数据，保持同进程内索引缓存一致。
+
+        当笔记标题或类型变化时，同步更新 title 与 type 索引。
+        如果该笔记尚未在索引中，则触发全量重建。
+        """
+        meta = self._by_id.get(note.id)
+        if meta is None:
+            self.rebuild()
+            return
+
+        # 类型变化时，先从旧类型列表移除
+        old_type = meta.type
+        new_type = note.type
+        if old_type != new_type:
+            self._by_type[old_type] = [m for m in self._by_type[old_type] if m.id != note.id]
+            self._by_type.setdefault(new_type, []).append(meta)
+            meta.type = new_type
+
+        # 标题变化时，同步 title 索引
+        new_lower_title = note.title.lower()
+        if meta.title.lower() != new_lower_title:
+            # 删除旧 title 映射（仅当该映射指向当前笔记时）
+            old_lower_title = meta.title.lower()
+            if self._by_title.get(old_lower_title) is meta:
+                del self._by_title[old_lower_title]
+            self._by_title[new_lower_title] = meta
+
+        # 更新其余字段
+        meta.title = note.title
+        meta.tags = list(note.tags) if note.tags else []
+        meta.updated = note.updated.isoformat() if note.updated else ""
+        meta.filepath = str(note.filepath)
+        meta.links = list(note.links) if note.links else []
+        meta.backlinks = list(note.backlinks) if note.backlinks else []
+        meta.archived = note.archived
 
 
 # 模块级缓存：同一命令进程内只构建一次

--- a/jfox/search_engine.py
+++ b/jfox/search_engine.py
@@ -156,42 +156,54 @@ class HybridSearchEngine:
                 search_k = top_k
             bm25_results = self.bm25_index.search(query, top_k=search_k)
 
-            # 转换为与语义搜索一致的格式
-            results = []
-            for r in bm25_results:
-                # 获取笔记详情
-                from . import note as note_module
+            results = self._build_keyword_results(bm25_results, tags, include_archived)
 
-                note = note_module.load_note_by_id(r["note_id"])
-                if note:
-                    # 默认排除归档笔记
-                    if not include_archived and note.archived:
-                        continue
-                    # 如果有标签筛选，检查是否匹配所有标签
-                    if tags and not all(t in note.tags for t in tags):
-                        continue
-                    results.append(
-                        {
-                            "id": r["note_id"],
-                            "document": (
-                                note.content[:300] + "..."
-                                if len(note.content) > 300
-                                else note.content
-                            ),
-                            "metadata": {
-                                "title": note.title,
-                                "type": note.type.value,
-                                "tags": ",".join(note.tags),
-                            },
-                            "score": r["score"],
-                            "search_mode": "keyword",
-                        }
-                    )
+            # 高密度归档场景下，初次过滤结果可能不足 top_k，二次扩大检索回填
+            if not include_archived and len(results) < top_k:
+                search_k = max(top_k * 10, 50)
+                bm25_results = self.bm25_index.search(query, top_k=search_k)
+                results = self._build_keyword_results(bm25_results, tags, include_archived)
 
             return results[:top_k]
         except Exception as e:
             logger.error(f"Keyword search failed: {e}")
             return []
+
+    def _build_keyword_results(
+        self,
+        bm25_results: List[Dict[str, Any]],
+        tags: Optional[List[str]] = None,
+        include_archived: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """将 BM25 搜索结果转换为统一格式并过滤归档/标签"""
+        results = []
+        for r in bm25_results:
+            from . import note as note_module
+
+            note = note_module.load_note_by_id(r["note_id"])
+            if note:
+                # 默认排除归档笔记
+                if not include_archived and note.archived:
+                    continue
+                # 如果有标签筛选，检查是否匹配所有标签
+                if tags and not all(t in note.tags for t in tags):
+                    continue
+                results.append(
+                    {
+                        "id": r["note_id"],
+                        "document": (
+                            note.content[:300] + "..." if len(note.content) > 300 else note.content
+                        ),
+                        "metadata": {
+                            "title": note.title,
+                            "type": note.type.value,
+                            "tags": ",".join(note.tags),
+                        },
+                        "score": r["score"],
+                        "search_mode": "keyword",
+                    }
+                )
+        return results
 
     def _hybrid_search_with_k(
         self,

--- a/jfox/search_engine.py
+++ b/jfox/search_engine.py
@@ -124,6 +124,17 @@ class HybridSearchEngine:
             for r in results:
                 r["search_mode"] = "semantic"
             filtered = self._filter_archived_results(results, include_archived)
+
+            # 高密度归档场景下，初次过滤结果可能不足 top_k，二次扩大检索回填
+            if not include_archived and len(filtered) < top_k:
+                search_k = max(top_k * 10, 50)
+                results = self.vector_store.search(
+                    query, top_k=search_k, note_type=note_type, tags=tags
+                )
+                for r in results:
+                    r["search_mode"] = "semantic"
+                filtered = self._filter_archived_results(results, include_archived)
+
             return filtered[:top_k]
         except Exception as e:
             logger.error(f"Semantic search failed: {e}")
@@ -182,25 +193,16 @@ class HybridSearchEngine:
             logger.error(f"Keyword search failed: {e}")
             return []
 
-    def _hybrid_search(
+    def _hybrid_search_with_k(
         self,
         query: str,
         top_k: int,
+        search_k: int,
         note_type: Optional[str] = None,
         tags: Optional[List[str]] = None,
         include_archived: bool = False,
     ) -> List[Dict[str, Any]]:
-        """
-        混合搜索：RRF 融合
-
-        公式: score = Σ 1 / (k + rank)
-        """
-        # 1. 执行两种搜索（获取更多结果用于融合/归档过滤）
-        if include_archived:
-            search_k = max(top_k * 2, 10)
-        else:
-            search_k = max(top_k * 5, 20)
-
+        """使用指定 search_k 执行一次混合搜索（RRF 融合）"""
         semantic_results = []
         bm25_results = []
 
@@ -244,7 +246,7 @@ class HybridSearchEngine:
                 r["search_mode"] = "semantic"
             return filtered[:top_k]
 
-        # 2. RRF 融合
+        # RRF 融合
         fused_scores: Dict[str, float] = {}
         result_data: Dict[str, Dict] = {}
 
@@ -282,7 +284,7 @@ class HybridSearchEngine:
                             },
                         }
 
-        # 3. 排序并过滤归档后返回 top_k
+        # 排序并过滤归档后返回 top_k
         sorted_ids = sorted(fused_scores.keys(), key=lambda x: fused_scores[x], reverse=True)
 
         from .note_index import get_note_index
@@ -301,6 +303,37 @@ class HybridSearchEngine:
             if len(results) >= top_k:
                 break
 
+        return results
+
+    def _hybrid_search(
+        self,
+        query: str,
+        top_k: int,
+        note_type: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        include_archived: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """
+        混合搜索：RRF 融合
+
+        公式: score = Σ 1 / (k + rank)
+        """
+        if include_archived:
+            search_k = max(top_k * 2, 10)
+            return self._hybrid_search_with_k(
+                query, top_k, search_k, note_type, tags, include_archived
+            )
+
+        # 默认排除归档时，先按 5 倍 over-fetch；结果不足则二次扩大到 10 倍
+        search_k = max(top_k * 5, 20)
+        results = self._hybrid_search_with_k(
+            query, top_k, search_k, note_type, tags, include_archived
+        )
+        if len(results) < top_k:
+            search_k = max(top_k * 10, 50)
+            results = self._hybrid_search_with_k(
+                query, top_k, search_k, note_type, tags, include_archived
+            )
         return results
 
     def rebuild_bm25_index(self) -> bool:

--- a/jfox/search_engine.py
+++ b/jfox/search_engine.py
@@ -48,6 +48,29 @@ class HybridSearchEngine:
         self.bm25_index = bm25_index or get_bm25_index()
         self.rrf_k = rrf_k
 
+    @staticmethod
+    def _filter_archived_results(
+        results: List[Dict[str, Any]], include_archived: bool
+    ) -> List[Dict[str, Any]]:
+        """根据归档状态过滤搜索结果"""
+        if include_archived:
+            return results
+
+        from .note_index import get_note_index
+
+        idx = get_note_index()
+        filtered = []
+        for r in results:
+            note_id = r.get("id") or r.get("note_id")
+            if not note_id:
+                continue
+            meta = idx.find_by_id(note_id)
+            # 如果索引中不存在，保守保留；如果存在且已归档，则排除
+            if meta is not None and meta.archived:
+                continue
+            filtered.append(r)
+        return filtered
+
     def search(
         self,
         query: str,
@@ -55,6 +78,7 @@ class HybridSearchEngine:
         mode: SearchMode = SearchMode.HYBRID,
         note_type: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        include_archived: bool = False,
     ) -> List[Dict[str, Any]]:
         """
         执行搜索
@@ -65,16 +89,21 @@ class HybridSearchEngine:
             mode: 搜索模式
             note_type: 笔记类型筛选
             tags: 标签筛选
+            include_archived: 是否包含已归档笔记，默认排除
 
         Returns:
             搜索结果列表
         """
         if mode == SearchMode.SEMANTIC:
-            return self._semantic_search(query, top_k, note_type, tags)
+            return self._semantic_search(
+                query, top_k, note_type, tags, include_archived=include_archived
+            )
         elif mode == SearchMode.KEYWORD:
-            return self._keyword_search(query, top_k, tags)
+            return self._keyword_search(query, top_k, tags, include_archived=include_archived)
         else:  # HYBRID
-            return self._hybrid_search(query, top_k, note_type, tags)
+            return self._hybrid_search(
+                query, top_k, note_type, tags, include_archived=include_archived
+            )
 
     def _semantic_search(
         self,
@@ -82,25 +111,38 @@ class HybridSearchEngine:
         top_k: int,
         note_type: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        include_archived: bool = False,
     ) -> List[Dict[str, Any]]:
         """纯语义搜索"""
         try:
-            results = self.vector_store.search(query, top_k=top_k, note_type=note_type, tags=tags)
+            # 默认排除归档时需要多取一些结果，过滤后再截断
+            search_k = top_k if include_archived else max(top_k * 5, 20)
+            results = self.vector_store.search(
+                query, top_k=search_k, note_type=note_type, tags=tags
+            )
             # 添加搜索模式标记
             for r in results:
                 r["search_mode"] = "semantic"
-            return results
+            filtered = self._filter_archived_results(results, include_archived)
+            return filtered[:top_k]
         except Exception as e:
             logger.error(f"Semantic search failed: {e}")
             return []
 
     def _keyword_search(
-        self, query: str, top_k: int, tags: Optional[List[str]] = None
+        self,
+        query: str,
+        top_k: int,
+        tags: Optional[List[str]] = None,
+        include_archived: bool = False,
     ) -> List[Dict[str, Any]]:
         """纯关键词搜索 (BM25)"""
         try:
-            # 请求更多结果以补偿标签过滤后的数量损失
-            search_k = top_k * 3 if tags else top_k
+            # 请求更多结果以补偿标签/归档过滤后的数量损失
+            if tags or not include_archived:
+                search_k = max(top_k * 5, 20)
+            else:
+                search_k = top_k
             bm25_results = self.bm25_index.search(query, top_k=search_k)
 
             # 转换为与语义搜索一致的格式
@@ -111,6 +153,9 @@ class HybridSearchEngine:
 
                 note = note_module.load_note_by_id(r["note_id"])
                 if note:
+                    # 默认排除归档笔记
+                    if not include_archived and note.archived:
+                        continue
                     # 如果有标签筛选，检查是否匹配所有标签
                     if tags and not all(t in note.tags for t in tags):
                         continue
@@ -132,7 +177,7 @@ class HybridSearchEngine:
                         }
                     )
 
-            return results
+            return results[:top_k]
         except Exception as e:
             logger.error(f"Keyword search failed: {e}")
             return []
@@ -143,14 +188,18 @@ class HybridSearchEngine:
         top_k: int,
         note_type: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        include_archived: bool = False,
     ) -> List[Dict[str, Any]]:
         """
         混合搜索：RRF 融合
 
         公式: score = Σ 1 / (k + rank)
         """
-        # 1. 执行两种搜索（获取更多结果用于融合）
-        search_k = max(top_k * 2, 10)  # 获取足够多的结果
+        # 1. 执行两种搜索（获取更多结果用于融合/归档过滤）
+        if include_archived:
+            search_k = max(top_k * 2, 10)
+        else:
+            search_k = max(top_k * 5, 20)
 
         semantic_results = []
         bm25_results = []
@@ -167,9 +216,9 @@ class HybridSearchEngine:
         except Exception as e:
             logger.warning(f"BM25 search failed in hybrid mode: {e}")
 
-        # 对 BM25 结果做 tags 过滤
+        # 对 BM25 结果做 tags / 归档过滤
         bm25_notes_cache: Dict[str, Any] = {}
-        if tags and bm25_results:
+        if bm25_results and (tags or not include_archived):
             from . import note as note_module
 
             filtered = []
@@ -177,19 +226,23 @@ class HybridSearchEngine:
                 note = note_module.load_note_by_id(r["note_id"])
                 if note:
                     bm25_notes_cache[r["note_id"]] = note
-                    if all(t in note.tags for t in tags):
-                        filtered.append(r)
+                    if not include_archived and note.archived:
+                        continue
+                    if tags and not all(t in note.tags for t in tags):
+                        continue
+                    filtered.append(r)
             bm25_results = filtered
 
         # 如果一种搜索失败，回退到另一种
         if not semantic_results and not bm25_results:
             return []
         elif not semantic_results:
-            return self._keyword_search(query, top_k, tags)
+            return self._keyword_search(query, top_k, tags, include_archived=include_archived)
         elif not bm25_results:
-            for r in semantic_results[:top_k]:
+            filtered = self._filter_archived_results(semantic_results, include_archived)
+            for r in filtered[:top_k]:
                 r["search_mode"] = "semantic"
-            return semantic_results[:top_k]
+            return filtered[:top_k]
 
         # 2. RRF 融合
         fused_scores: Dict[str, float] = {}
@@ -229,15 +282,24 @@ class HybridSearchEngine:
                             },
                         }
 
-        # 3. 排序并返回 top_k
+        # 3. 排序并过滤归档后返回 top_k
         sorted_ids = sorted(fused_scores.keys(), key=lambda x: fused_scores[x], reverse=True)
 
+        from .note_index import get_note_index
+
+        idx = get_note_index()
         results = []
-        for note_id in sorted_ids[:top_k]:
+        for note_id in sorted_ids:
+            if not include_archived:
+                meta = idx.find_by_id(note_id)
+                if meta is not None and meta.archived:
+                    continue
             data = result_data.get(note_id, {})
             data["score"] = fused_scores[note_id]
             data["search_mode"] = "hybrid"
             results.append(data)
+            if len(results) >= top_k:
+                break
 
         return results
 
@@ -251,7 +313,8 @@ class HybridSearchEngine:
         try:
             from . import note as note_module
 
-            notes = note_module.list_notes(limit=10000)  # 获取所有笔记
+            # 重建时包含归档笔记，搜索时再通过归档状态过滤
+            notes = note_module.list_notes(limit=10000, include_archived=True)
             return self.bm25_index.rebuild_from_notes(notes)
         except Exception as e:
             logger.error(f"Failed to rebuild BM25 index: {e}")

--- a/tests/unit/test_archive.py
+++ b/tests/unit/test_archive.py
@@ -321,7 +321,9 @@ class TestArchiveSearchModes:
     @staticmethod
     def _create_active_and_archived():
         active = create_note("active alpha", title="Active Alpha", note_type=NoteType.PERMANENT)
-        archived = create_note("archived alpha", title="Archived Alpha", note_type=NoteType.PERMANENT)
+        archived = create_note(
+            "archived alpha", title="Archived Alpha", note_type=NoteType.PERMANENT
+        )
         archived.archived = True
         save_note(active, add_to_index=False)
         save_note(archived, add_to_index=False)

--- a/tests/unit/test_archive.py
+++ b/tests/unit/test_archive.py
@@ -1,0 +1,258 @@
+"""测试类型: 单元测试 / 目标模块: jfox.archive (归档/软删除)"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+from utils.temp_kb import temp_kb_registered
+
+from jfox.cli import app
+from jfox.config import use_kb
+from jfox.models import Note, NoteType
+from jfox.note import archive_note, create_note, load_note_by_id, save_note, unarchive_note
+from jfox.note_index import NoteIndex
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+runner = CliRunner()
+
+
+class TestArchiveModel:
+    """测试 Note 数据模型的归档字段"""
+
+    def test_archived_roundtrip(self):
+        """archived 字段可以正确序列化与反序列化"""
+        note = create_note(
+            content="test content",
+            title="Test Note",
+            note_type=NoteType.PERMANENT,
+        )
+        note.archived = True
+
+        md = note.to_markdown()
+        assert "archived: true" in md
+
+        restored = Note.from_markdown(md, note.filepath)
+        assert restored.archived is True
+
+    def test_unarchived_not_in_frontmatter(self):
+        """未归档笔记的 frontmatter 中不包含 archived 字段"""
+        note = create_note(
+            content="test content",
+            title="Test Note",
+            note_type=NoteType.PERMANENT,
+        )
+        note.archived = False
+
+        md = note.to_markdown()
+        assert "archived" not in md
+
+        restored = Note.from_markdown(md, note.filepath)
+        assert restored.archived is False
+
+    def test_to_dict_includes_archived(self):
+        """to_dict 输出包含 archived 字段"""
+        note = create_note(
+            content="test",
+            title="Test",
+            note_type=NoteType.PERMANENT,
+        )
+        note.archived = True
+        data = note.to_dict()
+        assert data["archived"] is True
+
+
+class TestNoteIndexArchiveFilter:
+    """测试 NoteIndex 对归档状态的过滤"""
+
+    def test_list_meta_archive_filter(self):
+        """list_meta 默认排除归档，支持 archived_only 和 include_archived"""
+        with temp_kb_registered() as kb_name:
+            with use_kb(kb_name):
+                from jfox.config import config as zk_config
+
+                active = create_note("active", title="Active", note_type=NoteType.PERMANENT)
+                archived = create_note("archived", title="Archived", note_type=NoteType.PERMANENT)
+                archived.archived = True
+
+                save_note(active, add_to_index=False)
+                save_note(archived, add_to_index=False)
+
+                idx = NoteIndex(zk_config)
+                idx.rebuild()
+
+                assert len(idx.list_meta()) == 1
+                assert idx.list_meta()[0].id == active.id
+
+                assert len(idx.list_meta(archived_only=True)) == 1
+                assert idx.list_meta(archived_only=True)[0].id == archived.id
+
+                assert len(idx.list_meta(include_archived=True)) == 2
+
+
+class TestArchiveCommands:
+    """测试 archive/unarchive CLI 命令及 list/search 过滤"""
+
+    @staticmethod
+    def _kb_args(kb_name, kb_path):
+        return ["init", "--name", kb_name, "--path", str(kb_path)]
+
+    @staticmethod
+    def _add_args(kb_name, title, content, note_type="permanent"):
+        return [
+            "add",
+            content,
+            "--title",
+            title,
+            "--type",
+            note_type,
+            "--kb",
+            kb_name,
+            "--json",
+        ]
+
+    def _extract_id(self, output):
+        data = json.loads(output)
+        return data["note"]["id"]
+
+    def test_archive_and_list_filter(self, temp_kb, mock_embedding_backend):
+        """归档后默认 list 隐藏，--archived 和 --include-archived 可查看"""
+        kb_name = "test_archive_list"
+        with patch("jfox.embedding_backend.get_backend", return_value=mock_embedding_backend):
+            result = runner.invoke(app, self._kb_args(kb_name, temp_kb))
+            assert result.exit_code == 0, result.output
+
+            active_result = runner.invoke(
+                app, self._add_args(kb_name, "Active Note", "active content")
+            )
+            assert active_result.exit_code == 0, active_result.output
+            active_id = self._extract_id(active_result.output)
+
+            archived_result = runner.invoke(
+                app, self._add_args(kb_name, "Archived Note", "archived content")
+            )
+            assert archived_result.exit_code == 0, archived_result.output
+            archived_id = self._extract_id(archived_result.output)
+
+            # 归档
+            archive_result = runner.invoke(app, ["archive", archived_id, "--kb", kb_name, "--json"])
+            assert archive_result.exit_code == 0, archive_result.output
+            assert json.loads(archive_result.output)["archived"] == archived_id
+
+            # 默认 list 只显示活跃笔记
+            list_result = runner.invoke(app, ["list", "--kb", kb_name, "--json"])
+            assert list_result.exit_code == 0, list_result.output
+            list_data = json.loads(list_result.output)
+            assert list_data["total"] == 1
+            assert list_data["notes"][0]["id"] == active_id
+
+            # --archived 只显示归档笔记
+            archived_list = runner.invoke(app, ["list", "--archived", "--kb", kb_name, "--json"])
+            assert archived_list.exit_code == 0, archived_list.output
+            archived_data = json.loads(archived_list.output)
+            assert archived_data["total"] == 1
+            assert archived_data["notes"][0]["id"] == archived_id
+
+            # --include-archived 显示全部
+            all_list = runner.invoke(app, ["list", "--include-archived", "--kb", kb_name, "--json"])
+            assert all_list.exit_code == 0, all_list.output
+            all_data = json.loads(all_list.output)
+            assert all_data["total"] == 2
+
+            # show 仍可查看归档笔记
+            show_result = runner.invoke(app, ["show", archived_id, "--kb", kb_name])
+            assert show_result.exit_code == 0, show_result.output
+            assert "archived: true" in show_result.output
+
+            # 取消归档
+            unarchive_result = runner.invoke(
+                app, ["unarchive", archived_id, "--kb", kb_name, "--json"]
+            )
+            assert unarchive_result.exit_code == 0, unarchive_result.output
+            assert json.loads(unarchive_result.output)["unarchived"] == archived_id
+
+            # 默认 list 再次显示两条
+            list_after = runner.invoke(app, ["list", "--kb", kb_name, "--json"])
+            assert list_after.exit_code == 0, list_after.output
+            assert json.loads(list_after.output)["total"] == 2
+
+    def test_search_excludes_archived(self, temp_kb, mock_embedding_backend):
+        """搜索默认排除归档笔记，--include-archived 可包含"""
+        kb_name = "test_archive_search"
+        with patch("jfox.embedding_backend.get_backend", return_value=mock_embedding_backend):
+            result = runner.invoke(app, self._kb_args(kb_name, temp_kb))
+            assert result.exit_code == 0, result.output
+
+            active_result = runner.invoke(
+                app, self._add_args(kb_name, "Active Alpha", "active alpha content")
+            )
+            assert active_result.exit_code == 0, active_result.output
+            active_id = self._extract_id(active_result.output)
+
+            archived_result = runner.invoke(
+                app, self._add_args(kb_name, "Archived Alpha", "archived alpha content")
+            )
+            assert archived_result.exit_code == 0, archived_result.output
+            archived_id = self._extract_id(archived_result.output)
+
+            runner.invoke(app, ["archive", archived_id, "--kb", kb_name, "--json"])
+
+            # 默认 keyword 搜索只返回活跃笔记
+            search_result = runner.invoke(
+                app,
+                [
+                    "search",
+                    "Alpha",
+                    "--mode",
+                    "keyword",
+                    "--top",
+                    "10",
+                    "--kb",
+                    kb_name,
+                    "--json",
+                ],
+            )
+            assert search_result.exit_code == 0, search_result.output
+            search_data = json.loads(search_result.output)
+            assert search_data["total"] == 1
+            assert search_data["results"][0]["id"] == active_id
+
+            # --include-archived 返回两条
+            include_result = runner.invoke(
+                app,
+                [
+                    "search",
+                    "Alpha",
+                    "--mode",
+                    "keyword",
+                    "--top",
+                    "10",
+                    "--include-archived",
+                    "--kb",
+                    kb_name,
+                    "--json",
+                ],
+            )
+            assert include_result.exit_code == 0, include_result.output
+            include_data = json.loads(include_result.output)
+            assert include_data["total"] == 2
+
+    def test_archive_note_functions(self):
+        """archive_note / unarchive_note 直接修改文件与状态"""
+        with temp_kb_registered() as kb_name:
+            with use_kb(kb_name):
+                note = create_note("content", title="Note", note_type=NoteType.PERMANENT)
+                save_note(note, add_to_index=False)
+
+                assert archive_note(note.id) is True
+                archived = load_note_by_id(note.id)
+                assert archived is not None
+                assert archived.archived is True
+                assert "archived: true" in archived.filepath.read_text(encoding="utf-8")
+
+                assert unarchive_note(note.id) is True
+                restored = load_note_by_id(note.id)
+                assert restored is not None
+                assert restored.archived is False
+                assert "archived" not in restored.filepath.read_text(encoding="utf-8")

--- a/tests/unit/test_archive.py
+++ b/tests/unit/test_archive.py
@@ -1,7 +1,7 @@
 """测试类型: 单元测试 / 目标模块: jfox.archive (归档/软删除)"""
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
@@ -61,6 +61,28 @@ class TestArchiveModel:
         note.archived = True
         data = note.to_dict()
         assert data["archived"] is True
+
+    def test_archived_yaml_string_false(self):
+        """archived: 'false' 等 YAML 字符串应被正确解析为 False"""
+        with temp_kb_registered() as kb_name:
+            with use_kb(kb_name):
+                from jfox.config import config as zk_config
+                from jfox.note_index import NoteIndex
+
+                note = create_note("test", title="Test", note_type=NoteType.PERMANENT)
+                save_note(note, add_to_index=False)
+
+                # 手动写入字符串形式的 archived: "false"
+                md = note.filepath.read_text(encoding="utf-8")
+                md = md.replace("---\n", '---\narchived: "false"\n')
+                note.filepath.write_text(md, encoding="utf-8")
+
+                restored = load_note_by_id(note.id)
+                assert restored.archived is False
+
+                idx = NoteIndex(zk_config)
+                idx.rebuild()
+                assert idx.find_by_id(note.id).archived is False
 
 
 class TestNoteIndexArchiveFilter:
@@ -244,15 +266,196 @@ class TestArchiveCommands:
             with use_kb(kb_name):
                 note = create_note("content", title="Note", note_type=NoteType.PERMANENT)
                 save_note(note, add_to_index=False)
+                original_updated = note.updated
 
                 assert archive_note(note.id) is True
                 archived = load_note_by_id(note.id)
                 assert archived is not None
                 assert archived.archived is True
                 assert "archived: true" in archived.filepath.read_text(encoding="utf-8")
+                first_updated = archived.updated
+                assert first_updated > original_updated
+
+                # 幂等归档仍应刷新 updated 时间戳
+                assert archive_note(note.id) is True
+                re_archived = load_note_by_id(note.id)
+                assert re_archived.updated >= first_updated
 
                 assert unarchive_note(note.id) is True
                 restored = load_note_by_id(note.id)
                 assert restored is not None
                 assert restored.archived is False
                 assert "archived" not in restored.filepath.read_text(encoding="utf-8")
+
+                # 幂等取消归档也应刷新 updated 时间戳
+                assert unarchive_note(note.id) is True
+                re_restored = load_note_by_id(note.id)
+                assert re_restored.updated >= restored.updated
+
+
+class TestArchiveCacheConsistency:
+    """测试归档后的索引缓存一致性"""
+
+    def test_archive_updates_note_index_cache(self):
+        """归档后同一进程内 NoteIndex 缓存立即反映新的 archived 状态"""
+        with temp_kb_registered() as kb_name:
+            with use_kb(kb_name):
+                from jfox.config import config as zk_config
+                from jfox.note_index import get_note_index
+
+                note = create_note("content", title="Note", note_type=NoteType.PERMANENT)
+                save_note(note, add_to_index=False)
+
+                idx = get_note_index(zk_config)
+                assert idx.find_by_id(note.id).archived is False
+
+                archive_note(note.id)
+
+                # 不触发重建，直接读取缓存应已同步
+                assert idx.find_by_id(note.id).archived is True
+
+
+class TestArchiveSearchModes:
+    """覆盖语义/混合搜索的归档过滤（含 over-fetch 回填）"""
+
+    @staticmethod
+    def _create_active_and_archived():
+        active = create_note("active alpha", title="Active Alpha", note_type=NoteType.PERMANENT)
+        archived = create_note("archived alpha", title="Archived Alpha", note_type=NoteType.PERMANENT)
+        archived.archived = True
+        save_note(active, add_to_index=False)
+        save_note(archived, add_to_index=False)
+        return active, archived
+
+    def test_semantic_search_excludes_archived(self, temp_kb, mock_embedding_backend):
+        """语义搜索默认排除归档笔记"""
+        with patch("jfox.embedding_backend.get_backend", return_value=mock_embedding_backend):
+            with temp_kb_registered() as kb_name:
+                with use_kb(kb_name):
+                    from jfox.config import config as zk_config
+                    from jfox.search_engine import HybridSearchEngine
+
+                    active, archived = self._create_active_and_archived()
+
+                    # 确保 NoteIndex 缓存已构建
+                    from jfox.note_index import get_note_index
+
+                    get_note_index(zk_config)
+
+                    engine = HybridSearchEngine(vector_store=MagicMock(), bm25_index=MagicMock())
+
+                    def mock_vector_search(query, top_k, note_type=None, tags=None):
+                        return [
+                            {
+                                "id": active.id,
+                                "document": active.content,
+                                "metadata": {"title": active.title},
+                                "distance": 0.1,
+                                "score": 0.9,
+                            },
+                            {
+                                "id": archived.id,
+                                "document": archived.content,
+                                "metadata": {"title": archived.title},
+                                "distance": 0.2,
+                                "score": 0.8,
+                            },
+                        ]
+
+                    engine.vector_store.search = mock_vector_search
+
+                    results = engine._semantic_search("alpha", top_k=5)
+                    assert len(results) == 1
+                    assert results[0]["id"] == active.id
+
+    def test_hybrid_search_excludes_archived(self, temp_kb, mock_embedding_backend):
+        """混合搜索默认排除归档笔记"""
+        with patch("jfox.embedding_backend.get_backend", return_value=mock_embedding_backend):
+            with temp_kb_registered() as kb_name:
+                with use_kb(kb_name):
+                    from jfox.config import config as zk_config
+                    from jfox.search_engine import HybridSearchEngine
+
+                    active, archived = self._create_active_and_archived()
+
+                    from jfox.note_index import get_note_index
+
+                    get_note_index(zk_config)
+
+                    engine = HybridSearchEngine(vector_store=MagicMock(), bm25_index=MagicMock())
+
+                    def mock_vector_search(query, top_k, note_type=None, tags=None):
+                        return [
+                            {
+                                "id": active.id,
+                                "document": active.content,
+                                "metadata": {"title": active.title},
+                                "distance": 0.1,
+                                "score": 0.9,
+                            },
+                            {
+                                "id": archived.id,
+                                "document": archived.content,
+                                "metadata": {"title": archived.title},
+                                "distance": 0.2,
+                                "score": 0.8,
+                            },
+                        ]
+
+                    def mock_bm25_search(query, top_k):
+                        return [
+                            {"note_id": active.id, "score": 0.9},
+                            {"note_id": archived.id, "score": 0.8},
+                        ]
+
+                    engine.vector_store.search = mock_vector_search
+                    engine.bm25_index.search = mock_bm25_search
+
+                    results = engine._hybrid_search("alpha", top_k=5)
+                    assert len(results) == 1
+                    assert results[0]["id"] == active.id
+
+    def test_semantic_search_overfetch_fallback(self, temp_kb, mock_embedding_backend):
+        """高密度归档场景下，语义搜索会二次扩大检索回填活跃笔记"""
+        with patch("jfox.embedding_backend.get_backend", return_value=mock_embedding_backend):
+            with temp_kb_registered() as kb_name:
+                with use_kb(kb_name):
+                    from jfox.config import config as zk_config
+                    from jfox.search_engine import HybridSearchEngine
+
+                    active, archived = self._create_active_and_archived()
+
+                    from jfox.note_index import get_note_index
+
+                    get_note_index(zk_config)
+
+                    engine = HybridSearchEngine(vector_store=MagicMock(), bm25_index=MagicMock())
+
+                    def mock_vector_search(query, top_k, note_type=None, tags=None):
+                        if top_k <= 20:
+                            # 初次 over-fetch 只返回归档笔记
+                            return [
+                                {
+                                    "id": archived.id,
+                                    "document": archived.content,
+                                    "metadata": {"title": archived.title},
+                                    "distance": 0.1,
+                                    "score": 0.9,
+                                },
+                            ]
+                        # 二次扩大后返回活跃笔记
+                        return [
+                            {
+                                "id": active.id,
+                                "document": active.content,
+                                "metadata": {"title": active.title},
+                                "distance": 0.1,
+                                "score": 0.9,
+                            },
+                        ]
+
+                    engine.vector_store.search = mock_vector_search
+
+                    results = engine._semantic_search("alpha", top_k=5)
+                    assert len(results) == 1
+                    assert results[0]["id"] == active.id

--- a/tests/unit/test_archive.py
+++ b/tests/unit/test_archive.py
@@ -462,3 +462,33 @@ class TestArchiveSearchModes:
                     results = engine._semantic_search("alpha", top_k=5)
                     assert len(results) == 1
                     assert results[0]["id"] == active.id
+
+    def test_keyword_search_overfetch_fallback(self, temp_kb, mock_embedding_backend):
+        """高密度归档场景下，关键词搜索会二次扩大检索回填活跃笔记"""
+        with patch("jfox.embedding_backend.get_backend", return_value=mock_embedding_backend):
+            with temp_kb_registered() as kb_name:
+                with use_kb(kb_name):
+                    from jfox.config import config as zk_config
+                    from jfox.search_engine import HybridSearchEngine
+
+                    active, archived = self._create_active_and_archived()
+
+                    from jfox.note_index import get_note_index
+
+                    get_note_index(zk_config)
+
+                    engine = HybridSearchEngine(vector_store=MagicMock(), bm25_index=MagicMock())
+
+                    def mock_bm25_search(query, top_k):
+                        # top_k=5 时首次 search_k=25，二次扩大 search_k=50
+                        if top_k < 50:
+                            # 初次 over-fetch 只返回归档笔记
+                            return [{"note_id": archived.id, "score": 0.9}]
+                        # 二次扩大后返回活跃笔记
+                        return [{"note_id": active.id, "score": 0.9}]
+
+                    engine.bm25_index.search = mock_bm25_search
+
+                    results = engine._keyword_search("alpha", top_k=5)
+                    assert len(results) == 1
+                    assert results[0]["id"] == active.id

--- a/tests/unit/test_archive.py
+++ b/tests/unit/test_archive.py
@@ -434,7 +434,8 @@ class TestArchiveSearchModes:
                     engine = HybridSearchEngine(vector_store=MagicMock(), bm25_index=MagicMock())
 
                     def mock_vector_search(query, top_k, note_type=None, tags=None):
-                        if top_k <= 20:
+                        # top_k=5 时首次 search_k=25，二次扩大 search_k=50
+                        if top_k < 50:
                             # 初次 over-fetch 只返回归档笔记
                             return [
                                 {


### PR DESCRIPTION
## 变更概要

实现 issue #259 的笔记归档/软删除功能。

## 主要改动

- `jfox/models.py`: `Note` 增加 `archived` 字段，frontmatter 仅在归档时写入 `archived: true`，取消归档时移除。
- `jfox/note.py`: 新增 `archive_note()` / `unarchive_note()`，并更新 `list_notes()` / `search_notes()` 的归档过滤参数。
- `jfox/note_index.py`: `NoteMeta` 增加 `archived`，`list_meta()` 支持 `archived_only` / `include_archived`。
- `jfox/search_engine.py`: 搜索默认排除归档笔记，通过 over-fetch + NoteIndex 后过滤实现，保证旧索引兼容。
- `jfox/cli.py`: 新增 `archive` / `unarchive` 命令；`list` 增加 `--archived` / `--include-archived`；`search` 增加 `--include-archived`。
- `tests/unit/test_archive.py`: 覆盖模型、索引、CLI 命令和搜索过滤。

## 使用示例

```bash
jfox archive <note_id>
jfox unarchive <note_id>
jfox list --archived
jfox list --include-archived
jfox search "关键词" --include-archived
```

closes #259
