### PR TITLE
docs(changelog): add missing self-update entry for 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to jfox-cli will be documented in this file.
 ## [1.1.0] - 2026-06-21
 
 ### Features
+- **cli**: add self-update command (#258)
 - 笔记归档/软删除功能（archive/unarchive） (#260)
 
 ### Fixes


### PR DESCRIPTION
## Summary
1.1.0 发版时漏掉了 `self-update-command (#258)` 的 CHANGELOG 条目。该功能在 v1.0.0 之后、bump 1.1.0 之前合入 main，属于 1.1.0 版本范围，但在我跑 `release_helper` 生成 CHANGELOG 之后才合入，因此未被收录。

本次补上该条目，使 1.1.0 的 Features 完整：

### Features
- **cli**: add self-update command (#258)   ← 补充
- 笔记归档/软删除功能（archive/unarchive） (#260)

合并后再创建 GitHub Release v1.1.0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)