### PR TITLE
chore: gitignore .claude/settings.local.json and untrack it

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(cp \"C:/Users/zhuzh/.claude/skills/jfox-ingest/SKILL.md\" \"skills-recommend/claude-code/jfox-ingest/SKILL.md\")",
-      "Bash(cp \"C:/Users/zhuzh/.claude/skills/jfox-organize/SKILL.md\" \"skills-recommend/claude-code/jfox-organize/SKILL.md\")",
-      "Bash(cp \"C:/Users/zhuzh/.claude/skills/jfox-common/SKILL.md\" \"skills-recommend/claude-code/jfox-common/SKILL.md\")"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ cache/
 .claude/scheduled_tasks.json
 .claude/scheduled_tasks.lock
 .claude/worktrees/
+.claude/settings.local.json
 
 # Temporary analysis files
 analysis_report.md


### PR DESCRIPTION
## Summary
`.claude/settings.local.json` 是 Claude Code 的**个人本地权限配置**（`.local` 后缀），记录本机允许免确认执行的命令。这类配置因人而异，不应进入版本库（当前内容里已混入个人 Windows 路径 `C:/Users/zhuzh/.claude/...`，进一步印证不应共享）。

本次改动：
- 在 `.gitignore` 的 "Claude Code runtime files" 段落新增 `.claude/settings.local.json`
- `git rm --cached` 从 git 跟踪移除该文件（**本地文件保留**，仅停止跟踪）

## 改动详情
- `.gitignore`：+1 行（`.claude/settings.local.json`）
- `.claude/settings.local.json`：从仓库移除跟踪（9 行）

## 说明
- 不影响其他共享配置（如 `.claude/settings.json`，若存在仍正常跟踪）
- 合并后各开发者本地的 `settings.local.json` 不再互相干扰，`git status` 也不再显示该文件的本地改动

🤖 Generated with [Claude Code](https://claude.com/claude-code)