### PR TITLE
fix(update): 已是最新版本时显示正确提示

### DIFF
--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -3603,11 +3603,11 @@ def _update_impl() -> dict:
             "message": f"升级失败，请手动执行：{command_str}",
         }
 
-    # uv tool upgrade / pipx upgrade 等工具在已是最新版本时仍会返回 0，
-    # 需要通过输出内容判断是否真的发生了升级。
-    already_latest = "Nothing to upgrade" in (upgrade_result["stdout"] + upgrade_result["stderr"])
-
     current_version = _get_installed_version()
+
+    # 通过版本比较判断是否已经是最新版本，不依赖各工具的具体输出文案。
+    # 这样可以统一覆盖 uv / pipx / pip 等所有安装方式。
+    already_latest = previous_version == current_version
     return {
         "success": True,
         "method": method,

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -3561,6 +3561,7 @@ def _update_impl() -> dict:
             "method": "dev",
             "previous_version": previous_version,
             "current_version": previous_version,
+            "already_latest": True,
             "command": None,
             "output": "",
             "stderr": "",
@@ -3594,6 +3595,7 @@ def _update_impl() -> dict:
             "method": method,
             "previous_version": previous_version,
             "current_version": previous_version,
+            "already_latest": False,
             "command": command_str,
             "output": stdout,
             "stderr": stderr,
@@ -3601,12 +3603,17 @@ def _update_impl() -> dict:
             "message": f"升级失败，请手动执行：{command_str}",
         }
 
+    # uv tool upgrade / pipx upgrade 等工具在已是最新版本时仍会返回 0，
+    # 需要通过输出内容判断是否真的发生了升级。
+    already_latest = "Nothing to upgrade" in (upgrade_result["stdout"] + upgrade_result["stderr"])
+
     current_version = _get_installed_version()
     return {
         "success": True,
         "method": method,
         "previous_version": previous_version,
         "current_version": current_version,
+        "already_latest": already_latest,
         "command": command_str,
         "output": upgrade_result["stdout"],
         "stderr": upgrade_result["stderr"],
@@ -3646,10 +3653,15 @@ def update(
                 if result.get("stderr"):
                     console.print(result["stderr"].rstrip(), markup=False)
                 if result["success"]:
-                    console.print(
-                        f"[green]升级完成: {result['previous_version']} → "
-                        f"{result['current_version']}[/green]"
-                    )
+                    if result.get("already_latest"):
+                        console.print(
+                            f"[green]当前已是最新版本: {result['current_version']}[/green]"
+                        )
+                    else:
+                        console.print(
+                            f"[green]升级完成: {result['previous_version']} → "
+                            f"{result['current_version']}[/green]"
+                        )
                 else:
                     console.print(f"[red]升级失败: {result.get('error', 'unknown error')}[/red]")
                     console.print(f"[yellow]请手动执行: {result['command']}[/yellow]")

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -432,8 +432,8 @@ class TestUpdateImpl:
                         assert result["stderr"] == "stderr msg"
                         assert result["error"] == ""
 
-    def test_uv_upgrade_already_latest(self):
-        """uv 输出 Nothing to upgrade 时应标记 already_latest"""
+    def test_upgrade_already_latest_by_version(self):
+        """升级前后版本一致时应标记 already_latest，不依赖工具输出文案"""
         with patch("jfox.cli._detect_install_method", return_value="uv"):
             with patch("jfox.__version__", "1.1.0"):
                 with patch(
@@ -447,13 +447,26 @@ class TestUpdateImpl:
                         assert result["previous_version"] == "1.1.0"
                         assert result["current_version"] == "1.1.0"
 
-    def test_uv_upgrade_already_latest_in_stderr(self):
-        """Nothing to upgrade 也可能出现在 stderr"""
-        with patch("jfox.cli._detect_install_method", return_value="uv"):
+    def test_pip_upgrade_already_latest_by_version(self):
+        """pip 方式升级前后版本一致时也应正确标记 already_latest"""
+        with patch("jfox.cli._detect_install_method", return_value="pip"):
             with patch("jfox.__version__", "1.1.0"):
                 with patch(
                     "jfox.cli._run_upgrade",
-                    return_value={"stdout": "", "stderr": "Nothing to upgrade"},
+                    return_value={"stdout": "Requirement already satisfied", "stderr": ""},
+                ):
+                    with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
+                        result = _update_impl()
+                        assert result["success"] is True
+                        assert result["already_latest"] is True
+
+    def test_pipx_upgrade_already_latest_by_version(self):
+        """pipx 方式升级前后版本一致时也应正确标记 already_latest"""
+        with patch("jfox.cli._detect_install_method", return_value="pipx"):
+            with patch("jfox.__version__", "1.1.0"):
+                with patch(
+                    "jfox.cli._run_upgrade",
+                    return_value={"stdout": "already up-to-date", "stderr": ""},
                 ):
                     with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
                         result = _update_impl()
@@ -524,7 +537,7 @@ class TestUpdateCommand:
             with patch("jfox.__version__", "1.1.0"):
                 with patch(
                     "jfox.cli._run_upgrade",
-                    return_value={"stdout": "Nothing to upgrade", "stderr": ""},
+                    return_value={"stdout": "up-to-date", "stderr": ""},
                 ):
                     with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
                         result = runner.invoke(app, ["update"])
@@ -553,7 +566,7 @@ class TestUpdateCommand:
             with patch("jfox.__version__", "1.1.0"):
                 with patch(
                     "jfox.cli._run_upgrade",
-                    return_value={"stdout": "Nothing to upgrade", "stderr": ""},
+                    return_value={"stdout": "up-to-date", "stderr": ""},
                 ):
                     with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
                         result = runner.invoke(app, ["update", "--json"])

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -432,6 +432,34 @@ class TestUpdateImpl:
                         assert result["stderr"] == "stderr msg"
                         assert result["error"] == ""
 
+    def test_uv_upgrade_already_latest(self):
+        """uv 输出 Nothing to upgrade 时应标记 already_latest"""
+        with patch("jfox.cli._detect_install_method", return_value="uv"):
+            with patch("jfox.__version__", "1.1.0"):
+                with patch(
+                    "jfox.cli._run_upgrade",
+                    return_value={"stdout": "Nothing to upgrade", "stderr": ""},
+                ):
+                    with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
+                        result = _update_impl()
+                        assert result["success"] is True
+                        assert result["already_latest"] is True
+                        assert result["previous_version"] == "1.1.0"
+                        assert result["current_version"] == "1.1.0"
+
+    def test_uv_upgrade_already_latest_in_stderr(self):
+        """Nothing to upgrade 也可能出现在 stderr"""
+        with patch("jfox.cli._detect_install_method", return_value="uv"):
+            with patch("jfox.__version__", "1.1.0"):
+                with patch(
+                    "jfox.cli._run_upgrade",
+                    return_value={"stdout": "", "stderr": "Nothing to upgrade"},
+                ):
+                    with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
+                        result = _update_impl()
+                        assert result["success"] is True
+                        assert result["already_latest"] is True
+
 
 class TestRunUpgrade:
     """_run_upgrade 辅助函数测试"""
@@ -490,6 +518,21 @@ class TestUpdateCommand:
                         assert "Upgraded" in result.output
                         assert "warning: old metadata" in result.output
 
+    def test_table_output_already_latest(self):
+        """已是最新版本时 table 输出显示当前版本，而非升级完成"""
+        with patch("jfox.cli._detect_install_method", return_value="uv"):
+            with patch("jfox.__version__", "1.1.0"):
+                with patch(
+                    "jfox.cli._run_upgrade",
+                    return_value={"stdout": "Nothing to upgrade", "stderr": ""},
+                ):
+                    with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
+                        result = runner.invoke(app, ["update"])
+                        assert result.exit_code == 0
+                        assert "当前已是最新版本" in result.output
+                        assert "1.1.0" in result.output
+                        assert "→" not in result.output
+
     def test_table_output_failure(self):
         """升级失败时 table 输出显示错误和手动命令"""
         error = subprocess.CalledProcessError(1, ["uv", "tool", "upgrade", "jfox-cli"])
@@ -503,6 +546,23 @@ class TestUpdateCommand:
                     assert "升级失败" in result.output
                     assert "network error" in result.output
                     assert "uv tool upgrade jfox-cli" in result.output
+
+    def test_json_output_already_latest(self):
+        """已是最新版本时 --json 输出包含 already_latest"""
+        with patch("jfox.cli._detect_install_method", return_value="uv"):
+            with patch("jfox.__version__", "1.1.0"):
+                with patch(
+                    "jfox.cli._run_upgrade",
+                    return_value={"stdout": "Nothing to upgrade", "stderr": ""},
+                ):
+                    with patch("jfox.cli._get_installed_version", return_value="1.1.0"):
+                        result = runner.invoke(app, ["update", "--json"])
+                        assert result.exit_code == 0
+                        data = json.loads(result.output)
+                        assert data["success"] is True
+                        assert data["already_latest"] is True
+                        assert data["previous_version"] == "1.1.0"
+                        assert data["current_version"] == "1.1.0"
 
     def test_json_output_success(self):
         """--json 输出合法 JSON 且 schema 统一"""


### PR DESCRIPTION
修复 #267。

当 `uv tool upgrade jfox-cli` 输出 "Nothing to upgrade" 时，命令返回 0 但实际没有发生升级。旧逻辑仍会显示 "升级完成: 1.1.0 → 1.1.0"，造成误解。

本次修改：
- `_update_impl` 在 stdout/stderr 中检测 "Nothing to upgrade"，设置 `already_latest=True`。
- `update` 命令在 `already_latest=True` 时显示 "当前已是最新版本: <version>"。
- JSON 输出新增 `already_latest` 字段。
- 补充了相关单元测试。

本地已通过：
```
uv run ruff check jfox/ tests/
uv run black --check jfox/ tests/
uv run pytest tests/unit/test_update.py -v
```