### PR TITLE
fix(cc-plugin): emphasize --type permanent filtering in search skill (#270)

### DIFF
--- a/packages/cc-plugin/skills/search/SKILL.md
+++ b/packages/cc-plugin/skills/search/SKILL.md
@@ -23,6 +23,7 @@ Choose the right search approach based on user intent:
 | Explore related topics | Graph traversal | `jfox query "<topic>" --depth 2 --json` |
 | What links to note X | Backlinks | `jfox refs --search "<title>" --format json` |
 | What should I link to | Link suggestions | `jfox suggest-links "<content>" --format json` |
+| Filter by note type | Type filter | `jfox search "<query>" --type permanent --format json` |
 
 **Default strategy**: `--mode hybrid` (best balance of precision and recall).
 
@@ -31,8 +32,10 @@ Choose the right search approach based on user intent:
 ### Single Search
 
 ```bash
-jfox search "<query>" --mode hybrid --top 10 --format json
+jfox search "<query>" --mode hybrid --type permanent --top 10 --format json
 ```
+
+> **提示**: 搜索 permanent 知识或参考内容时，建议加上 `--type permanent` 过滤，避免被大量 session/fleeting 笔记淹没。
 
 Parse the JSON output and present results as:
 

--- a/packages/cc-plugin/skills/search/SKILL.md
+++ b/packages/cc-plugin/skills/search/SKILL.md
@@ -35,7 +35,8 @@ Choose the right search approach based on user intent:
 jfox search "<query>" --mode hybrid --type permanent --top 10 --format json
 ```
 
-> **提示**: 搜索 permanent 知识或参考内容时，建议加上 `--type permanent` 过滤，避免被大量 session/fleeting 笔记淹没。
+> **提示**: 搜索 permanent 知识或参考内容时，建议加上 `--type permanent` 过滤，
+> 避免被大量 session/fleeting 笔记淹没。
 
 Parse the JSON output and present results as:
 


### PR DESCRIPTION
修复 Issue #270：CC plugin 的 search skill 中 --type 参数只在底部提到一次，Agent 搜索时不按笔记类型过滤，导致 permanent 笔记被大量 session 笔记淹没。

修改点：
1. 在 Search Strategy Selection 表格中新增「按类型筛选笔记」策略行。
2. 在 Single Search 工作流中，默认示例加上 "--type permanent"。
3. 在 Workflow 部分加提示：搜索 permanent 知识时建议加 "--type permanent" 过滤，避免被 session/fleeting 笔记淹没。

Fixes #270