### PR TITLE
chore(cc-plugin): bump version to 0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "JFox Zettelkasten 知识管理工具的 Claude Code 集成",
-    "version": "0.2.0"
+    "version": "0.3.0"
   },
   "plugins": [
     {
       "name": "jfox",
       "source": "./packages/cc-plugin",
       "description": "JFox 知识管理 CLI 的 Claude Code 集成——搜索、写入工作流（导入/整理/会话总结）与知识库管理",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": { "name": "zhuxixi" },
       "keywords": ["zettelkasten", "knowledge-management"],
       "category": "workflow"

--- a/packages/cc-plugin/.claude-plugin/plugin.json
+++ b/packages/cc-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jfox",
   "description": "JFox 知识管理 CLI 的 Claude Code 集成——搜索、写入工作流（导入/整理/会话总结）与知识库管理",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": { "name": "zhuxixi" },
   "homepage": "https://github.com/zhuxixi/jfox",
   "repository": "https://github.com/zhuxixi/jfox",


### PR DESCRIPTION
PR #269 给 cc-plugin 加了 fragment-capture hook（新功能），但漏了 version bump。按 CLAUDE.md 规则（plugin.json + marketplace.json 一起 bump），三处 `0.2.0 → 0.3.0`（minor，新功能）。

- `packages/cc-plugin/.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json` → `metadata.version`
- `.claude-plugin/marketplace.json` → `plugins[0].version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)