### PR TITLE
fix(add): 创建目标笔记后回填引用方的正向 links (#275)

### DIFF
--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -526,6 +526,7 @@ def _add_note_impl(
         original_backlinks_count = len(new_note.backlinks)
         forward_backfilled = 0
         failed_refs: List[str] = []
+        backfilled_ref_ids: List[str] = []
         for ref_meta in idx.find_notes_referencing_title(new_note.title):
             if ref_meta.id == new_note.id:
                 continue
@@ -548,6 +549,7 @@ def _add_note_impl(
             if note.save_note(ref_note, add_to_index=False):
                 forward_backfilled += 1
                 idx.update_note_meta(ref_note)
+                backfilled_ref_ids.append(ref_note.id)
             else:
                 # save_note 内部已吞掉所有异常并返回 False；回滚内存修改保持双向一致
                 if new_note.id in ref_note.links:
@@ -557,11 +559,28 @@ def _add_note_impl(
                 failed_refs.append(ref_note.id)
                 logger.warning(f"回填正向链接时保存笔记 {ref_note.id} 失败")
 
+        new_note_backfill_save_failed = False
         if len(new_note.backlinks) != original_backlinks_count:
             if note.save_note(new_note, add_to_index=False):
                 idx.update_note_meta(new_note)
             else:
+                new_note_backfill_save_failed = True
                 logger.warning("回填后保存新笔记 backlinks 失败")
+                # 回滚已持久化的 ref_note 正向链接，避免 links/backlinks 不一致
+                for ref_id in backfilled_ref_ids:
+                    rb_note = note.load_note_by_id(ref_id)
+                    if not rb_note:
+                        failed_refs.append(ref_id)
+                        continue
+                    if new_note.id in rb_note.links:
+                        rb_note.links.remove(new_note.id)
+                        if note.save_note(rb_note, add_to_index=False):
+                            idx.update_note_meta(rb_note)
+                        else:
+                            failed_refs.append(ref_id)
+                            logger.warning(f"回滚 ref_note {ref_id} 正向链接失败")
+                # 回滚内存中的 new_note.backlinks
+                new_note.backlinks = new_note.backlinks[:original_backlinks_count]
 
         result = {
             "success": True,
@@ -578,6 +597,8 @@ def _add_note_impl(
             result["warnings"] = f"Unresolved links: {', '.join(unresolved)}"
         if failed_refs:
             result["backfill_failures"] = failed_refs
+        if new_note_backfill_save_failed:
+            result["backfill_note_save_failed"] = True
 
         if output_format == "json":
             print(output_json(result))
@@ -596,6 +617,11 @@ def _add_note_impl(
             if forward_backfilled > 0:
                 console.print(
                     f"[dim]  Forward links backfilled: {forward_backfilled} note(s)[/dim]"
+                )
+            if new_note_backfill_save_failed:
+                console.print(
+                    "  [yellow]Warning: Failed to save new note backlinks; "
+                    "forward backfill has been rolled back[/yellow]"
                 )
             if failed_refs:
                 console.print(

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -518,6 +518,37 @@ def _add_note_impl(
                     note.save_note(target_note, add_to_index=False)
                     backlink_updated += 1
 
+        # Backward 回填：正文中引用了新笔记标题但 links 未包含新笔记 ID 的笔记
+        # 把新笔记 ID 回填进它们的 links，并同步更新新笔记的 backlinks
+        from .note_index import get_note_index
+
+        idx = get_note_index()
+        idx.update_note_meta(new_note)
+
+        original_backlinks_count = len(new_note.backlinks)
+        forward_backfilled = 0
+        for ref_meta in idx.find_notes_referencing_title(new_note.title):
+            if ref_meta.id == new_note.id:
+                continue
+            ref_note = note.load_note_by_id(ref_meta.id)
+            if not ref_note:
+                continue
+
+            changed = False
+            if new_note.id not in ref_note.links:
+                ref_note.links.append(new_note.id)
+                changed = True
+            if ref_note.id not in new_note.backlinks:
+                new_note.backlinks.append(ref_note.id)
+                changed = True
+
+            if changed:
+                note.save_note(ref_note, add_to_index=False)
+                forward_backfilled += 1
+
+        if len(new_note.backlinks) != original_backlinks_count:
+            note.save_note(new_note, add_to_index=False)
+
         result = {
             "success": True,
             "note": {
@@ -546,6 +577,10 @@ def _add_note_impl(
             )
             if backlink_updated > 0:
                 console.print(f"[dim]  Backlinks updated: {backlink_updated} note(s)[/dim]")
+            if forward_backfilled > 0:
+                console.print(
+                    f"[dim]  Forward links backfilled: {forward_backfilled} note(s)[/dim]"
+                )
             if unresolved:
                 console.print(
                     f"  [yellow]Warning: Unresolved links - {', '.join(unresolved)}[/yellow]"

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -545,30 +545,23 @@ def _add_note_impl(
                 # ref_note.links 已包含新笔记，只需补齐 new_note.backlinks
                 continue
 
-            try:
-                if note.save_note(ref_note, add_to_index=False):
-                    forward_backfilled += 1
-                    idx.update_note_meta(ref_note)
-                else:
-                    failed_refs.append(ref_note.id)
-                    logger.warning(f"回填正向链接时保存笔记 {ref_note.id} 失败")
-            except Exception as e:
-                # 回滚内存中的修改，保持双向一致
+            if note.save_note(ref_note, add_to_index=False):
+                forward_backfilled += 1
+                idx.update_note_meta(ref_note)
+            else:
+                # save_note 内部已吞掉所有异常并返回 False；回滚内存修改保持双向一致
                 if new_note.id in ref_note.links:
                     ref_note.links.remove(new_note.id)
                 if backlink_changed and ref_note.id in new_note.backlinks:
                     new_note.backlinks.remove(ref_note.id)
                 failed_refs.append(ref_note.id)
-                logger.warning(f"回填正向链接时保存笔记 {ref_note.id} 失败: {e}")
+                logger.warning(f"回填正向链接时保存笔记 {ref_note.id} 失败")
 
         if len(new_note.backlinks) != original_backlinks_count:
-            try:
-                if note.save_note(new_note, add_to_index=False):
-                    idx.update_note_meta(new_note)
-                else:
-                    logger.warning("回填后保存新笔记 backlinks 失败")
-            except Exception as e:
-                logger.warning(f"回填后保存新笔记 backlinks 失败: {e}")
+            if note.save_note(new_note, add_to_index=False):
+                idx.update_note_meta(new_note)
+            else:
+                logger.warning("回填后保存新笔记 backlinks 失败")
 
         result = {
             "success": True,
@@ -583,6 +576,8 @@ def _add_note_impl(
 
         if unresolved:
             result["warnings"] = f"Unresolved links: {', '.join(unresolved)}"
+        if failed_refs:
+            result["backfill_failures"] = failed_refs
 
         if output_format == "json":
             print(output_json(result))
@@ -601,6 +596,11 @@ def _add_note_impl(
             if forward_backfilled > 0:
                 console.print(
                     f"[dim]  Forward links backfilled: {forward_backfilled} note(s)[/dim]"
+                )
+            if failed_refs:
+                console.print(
+                    f"  [yellow]Warning: Forward link backfill failed for "
+                    f"{len(failed_refs)} note(s): {', '.join(failed_refs)}[/yellow]"
                 )
             if unresolved:
                 console.print(

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -245,11 +245,9 @@ def _print_action_table(action: str, fields: dict):
 
 def extract_wiki_links(content: str) -> List[str]:
     """从内容中提取 [[...]] 格式的维基链接"""
-    import re
+    from .note_index import extract_wiki_links_from_text
 
-    pattern = r"\[\[(.*?)\]\]"
-    matches = re.findall(pattern, content)
-    return [m.strip() for m in matches]
+    return extract_wiki_links_from_text(content)
 
 
 def find_note_id_by_title_or_id(
@@ -370,8 +368,8 @@ def _rebuild_backlinks_impl(output_format: str = "table") -> Dict[str, Any]:
     changed_note_ids: List[str] = []
 
     for n in notes:
-        # 注意：cli.py 模块级存在名为 list 的命令函数，会遮蔽 built-in list()，
-        # 因此这里使用切片复制列表。
+        # list 命令函数已重命名为 list_notes，不再遮蔽 built-in list()。
+        # 保留切片复制以避免原地修改遍历中的列表。
         old_links = n.links[:]
         old_backlinks = n.backlinks[:]
         new_links_sorted = merged_links[n.id]
@@ -1053,8 +1051,8 @@ def _list_impl(
         raise ValueError(f"Unsupported format: {output_format}")
 
 
-@app.command()
-def list(
+@app.command(name="list")
+def list_notes(
     note_type: Optional[str] = typer.Option(None, "--type", "-t", help="筛选笔记类型"),
     tags: Optional[List[str]] = typer.Option(
         None, "--tag", help="按标签筛选（可多次使用，AND 逻辑）"

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -526,6 +526,7 @@ def _add_note_impl(
         original_backlinks_count = len(new_note.backlinks)
         forward_backfilled = 0
         failed_refs: List[str] = []
+        rollback_failures: List[str] = []
         backfilled_ref_ids: List[str] = []
         for ref_meta in idx.find_notes_referencing_title(new_note.title):
             if ref_meta.id == new_note.id:
@@ -570,14 +571,15 @@ def _add_note_impl(
                 for ref_id in backfilled_ref_ids:
                     rb_note = note.load_note_by_id(ref_id)
                     if not rb_note:
-                        failed_refs.append(ref_id)
+                        rollback_failures.append(ref_id)
+                        logger.warning(f"回滚时无法加载 ref_note {ref_id}")
                         continue
                     if new_note.id in rb_note.links:
                         rb_note.links.remove(new_note.id)
                         if note.save_note(rb_note, add_to_index=False):
                             idx.update_note_meta(rb_note)
                         else:
-                            failed_refs.append(ref_id)
+                            rollback_failures.append(ref_id)
                             logger.warning(f"回滚 ref_note {ref_id} 正向链接失败")
                 # 回滚内存中的 new_note.backlinks
                 new_note.backlinks = new_note.backlinks[:original_backlinks_count]
@@ -597,6 +599,8 @@ def _add_note_impl(
             result["warnings"] = f"Unresolved links: {', '.join(unresolved)}"
         if failed_refs:
             result["backfill_failures"] = failed_refs
+        if rollback_failures:
+            result["rollback_failures"] = rollback_failures
         if new_note_backfill_save_failed:
             result["backfill_note_save_failed"] = True
 
@@ -627,6 +631,12 @@ def _add_note_impl(
                 console.print(
                     f"  [yellow]Warning: Forward link backfill failed for "
                     f"{len(failed_refs)} note(s): {', '.join(failed_refs)}[/yellow]"
+                )
+            if rollback_failures:
+                console.print(
+                    f"  [red]Warning: Forward link rollback failed for "
+                    f"{len(rollback_failures)} note(s): {', '.join(rollback_failures)}. "
+                    f"Run 'jfox rebuild --backlinks' to repair.[/red]"
                 )
             if unresolved:
                 console.print(

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -525,6 +525,7 @@ def _add_note_impl(
 
         original_backlinks_count = len(new_note.backlinks)
         forward_backfilled = 0
+        failed_refs: List[str] = []
         for ref_meta in idx.find_notes_referencing_title(new_note.title):
             if ref_meta.id == new_note.id:
                 continue
@@ -532,20 +533,42 @@ def _add_note_impl(
             if not ref_note:
                 continue
 
-            changed = False
-            if new_note.id not in ref_note.links:
-                ref_note.links.append(new_note.id)
-                changed = True
-            if ref_note.id not in new_note.backlinks:
-                new_note.backlinks.append(ref_note.id)
-                changed = True
+            ref_changed = new_note.id not in ref_note.links
+            backlink_changed = ref_note.id not in new_note.backlinks
 
-            if changed:
-                note.save_note(ref_note, add_to_index=False)
-                forward_backfilled += 1
+            if ref_changed:
+                ref_note.links.append(new_note.id)
+            if backlink_changed:
+                new_note.backlinks.append(ref_note.id)
+
+            if not ref_changed:
+                # ref_note.links 已包含新笔记，只需补齐 new_note.backlinks
+                continue
+
+            try:
+                if note.save_note(ref_note, add_to_index=False):
+                    forward_backfilled += 1
+                    idx.update_note_meta(ref_note)
+                else:
+                    failed_refs.append(ref_note.id)
+                    logger.warning(f"回填正向链接时保存笔记 {ref_note.id} 失败")
+            except Exception as e:
+                # 回滚内存中的修改，保持双向一致
+                if new_note.id in ref_note.links:
+                    ref_note.links.remove(new_note.id)
+                if backlink_changed and ref_note.id in new_note.backlinks:
+                    new_note.backlinks.remove(ref_note.id)
+                failed_refs.append(ref_note.id)
+                logger.warning(f"回填正向链接时保存笔记 {ref_note.id} 失败: {e}")
 
         if len(new_note.backlinks) != original_backlinks_count:
-            note.save_note(new_note, add_to_index=False)
+            try:
+                if note.save_note(new_note, add_to_index=False):
+                    idx.update_note_meta(new_note)
+                else:
+                    logger.warning("回填后保存新笔记 backlinks 失败")
+            except Exception as e:
+                logger.warning(f"回填后保存新笔记 backlinks 失败: {e}")
 
         result = {
             "success": True,

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -636,7 +636,7 @@ def _add_note_impl(
                 console.print(
                     f"  [red]Warning: Forward link rollback failed for "
                     f"{len(rollback_failures)} note(s): {', '.join(rollback_failures)}. "
-                    f"Run 'jfox rebuild --backlinks' to repair.[/red]"
+                    f"Run 'jfox index rebuild --backlinks' to repair.[/red]"
                 )
             if unresolved:
                 console.print(

--- a/jfox/graph.py
+++ b/jfox/graph.py
@@ -7,7 +7,6 @@ Provides:
 - Hub and authority analysis
 """
 
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
@@ -17,6 +16,7 @@ from rich.console import Console
 
 from .config import ZKConfig
 from .models import Note
+from .note_index import extract_wiki_links_from_text
 
 console = Console()
 
@@ -94,7 +94,7 @@ class KnowledgeGraph:
 
         # Third pass: extract and add wiki links from content [[...]]
         for note_id, note in self._note_cache.items():
-            wiki_links = self._extract_wiki_links(note.content)
+            wiki_links = extract_wiki_links_from_text(note.content)
             for link_text in wiki_links:
                 linked_id = self._resolve_link(link_text)
                 if linked_id and linked_id in self._note_cache:
@@ -103,12 +103,6 @@ class KnowledgeGraph:
                         self.graph.add_edge(note_id, linked_id, type="wiki_link")
 
         return self
-
-    def _extract_wiki_links(self, content: str) -> List[str]:
-        """Extract [[...]] wiki links from content."""
-        pattern = r"\[\[(.*?)\]\]"
-        matches = re.findall(pattern, content)
-        return [m.strip() for m in matches]
 
     def _resolve_link(self, link_text: str) -> Optional[str]:
         """Resolve a link text to a note ID."""

--- a/jfox/note_index.py
+++ b/jfox/note_index.py
@@ -1,6 +1,7 @@
 """轻量级元数据索引，只解析 frontmatter 不读正文"""
 
 import logging
+import re
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -163,6 +164,40 @@ class NoteIndex:
         """按标题前缀模糊匹配"""
         prefix_lower = prefix.lower()
         return [m for m in self._by_id.values() if m.title.lower().startswith(prefix_lower)]
+
+    def find_notes_referencing_title(self, title: str) -> List[NoteMeta]:
+        """查找正文中引用了指定标题的笔记（[[标题]] 语法）。
+
+        基于索引中已缓存的文件路径直接读取内容，避免全量加载 Note 对象。
+        匹配规则为大小写不敏感的精确标题匹配。
+
+        Args:
+            title: 被引用的笔记标题
+
+        Returns:
+            引用了该标题的 NoteMeta 列表
+        """
+        title_lower = title.lower()
+        pattern = re.compile(r"\[\[(.*?)\]\]")
+        results: List[NoteMeta] = []
+
+        for meta in self._by_id.values():
+            filepath = Path(meta.filepath)
+            if not filepath.exists():
+                continue
+
+            try:
+                text = filepath.read_text(encoding="utf-8")
+            except OSError:
+                continue
+
+            for match in pattern.finditer(text):
+                link_text = match.group(1).strip()
+                if link_text.lower() == title_lower:
+                    results.append(meta)
+                    break
+
+        return results
 
     def list_meta(
         self,

--- a/jfox/note_index.py
+++ b/jfox/note_index.py
@@ -20,8 +20,35 @@ _WIKI_LINK_RE = re.compile(r"\[\[(.*?)\]\]")
 
 
 def extract_wiki_links_from_text(text: str) -> List[str]:
-    """从文本中提取 [[...]] 格式的维基链接"""
-    return [m.group(1).strip() for m in _WIKI_LINK_RE.finditer(text)]
+    """从文本中提取 [[...]] 格式的维基链接。
+
+    支持常见变体：
+    - [[标题]]
+    - [[标题|别名]] -> 取标题部分
+    - [[标题#锚点]] -> 取标题部分
+    """
+    raw_links = [m.group(1).strip() for m in _WIKI_LINK_RE.finditer(text)]
+    return [_normalize_wiki_link_title(link) for link in raw_links]
+
+
+def _normalize_wiki_link_title(link_text: str) -> str:
+    """把 [[标题|别名]] / [[标题#锚点]] 归一化为纯标题。"""
+    # 先取管道符左侧的显示标题/目标
+    target = link_text.split("|", 1)[0]
+    # 再取锚点左侧的标题主体
+    return target.split("#", 1)[0].strip()
+
+
+def _strip_wiki_link_exclusions(text: str) -> str:
+    """移除不应参与 wiki-link 匹配的 Markdown 区域（fenced code block、HTML 注释）。
+
+    这是轻量级处理，覆盖最常见的误匹配场景；不保证解析所有 Markdown 边界情况。
+    """
+    # fenced code block（支持可选语言标识）
+    text = re.sub(r"```[\s\S]*?```", "", text)
+    # HTML 注释
+    text = re.sub(r"<!--[\s\S]*?-->", "", text)
+    return text
 
 
 @dataclass
@@ -96,7 +123,7 @@ def _read_body_after_frontmatter(filepath: Path) -> str:
 
             # 有开始标记但没有结束标记，视为无效 frontmatter
             return ""
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return ""
 
 
@@ -200,7 +227,11 @@ class NoteIndex:
         """查找正文中引用了指定标题的笔记（[[标题]] 语法）。
 
         基于索引中已缓存的文件路径直接读取正文，避免全量加载 Note 对象。
-        匹配规则为大小写不敏感的精确标题匹配；frontmatter 中的 [[...]] 不参与匹配。
+        匹配规则为大小写不敏感的精确标题匹配；frontmatter、 fenced code block、
+        HTML 注释中的 [[...]] 不参与匹配。支持 [[标题|别名]] / [[标题#锚点]] 变体。
+
+        注意：与正向解析 find_note_id_by_title_or_id 的“标题包含”子串 fallback 不同，
+        反向回填只回填精确标题引用，避免把 [[Foo]] 错误回填到标题为 "Foo Bar" 的笔记。
 
         Args:
             title: 被引用的笔记标题
@@ -217,6 +248,7 @@ class NoteIndex:
                 continue
 
             body = _read_body_after_frontmatter(filepath)
+            body = _strip_wiki_link_exclusions(body)
             for link_text in extract_wiki_links_from_text(body):
                 if link_text.lower() == title_lower:
                     results.append(meta)

--- a/jfox/note_index.py
+++ b/jfox/note_index.py
@@ -15,6 +15,14 @@ from .models import Note, NoteType, _to_bool
 
 logger = logging.getLogger(__name__)
 
+# 维基链接正则：匹配 [[标题]] 语法（非贪婪，不支持跨行）
+_WIKI_LINK_RE = re.compile(r"\[\[(.*?)\]\]")
+
+
+def extract_wiki_links_from_text(text: str) -> List[str]:
+    """从文本中提取 [[...]] 格式的维基链接"""
+    return [m.group(1).strip() for m in _WIKI_LINK_RE.finditer(text)]
+
 
 @dataclass
 class NoteMeta:
@@ -67,6 +75,29 @@ def _parse_frontmatter_only(filepath: Path) -> Optional[dict]:
 
     except (yaml.YAMLError, UnicodeDecodeError, OSError, AttributeError):
         return None
+
+
+def _read_body_after_frontmatter(filepath: Path) -> str:
+    """读取文件正文部分（跳过 frontmatter）。
+
+    若文件没有 frontmatter，则返回全文。
+    读取失败时返回空字符串。
+    """
+    try:
+        with open(filepath, "r", encoding="utf-8-sig") as f:
+            first_line = f.readline()
+            if first_line.strip() != "---":
+                # 没有 frontmatter，返回剩余全部内容
+                return first_line + f.read()
+
+            for line in f:
+                if line.strip() == "---":
+                    return f.read()
+
+            # 有开始标记但没有结束标记，视为无效 frontmatter
+            return ""
+    except OSError:
+        return ""
 
 
 class NoteIndex:
@@ -168,8 +199,8 @@ class NoteIndex:
     def find_notes_referencing_title(self, title: str) -> List[NoteMeta]:
         """查找正文中引用了指定标题的笔记（[[标题]] 语法）。
 
-        基于索引中已缓存的文件路径直接读取内容，避免全量加载 Note 对象。
-        匹配规则为大小写不敏感的精确标题匹配。
+        基于索引中已缓存的文件路径直接读取正文，避免全量加载 Note 对象。
+        匹配规则为大小写不敏感的精确标题匹配；frontmatter 中的 [[...]] 不参与匹配。
 
         Args:
             title: 被引用的笔记标题
@@ -178,7 +209,6 @@ class NoteIndex:
             引用了该标题的 NoteMeta 列表
         """
         title_lower = title.lower()
-        pattern = re.compile(r"\[\[(.*?)\]\]")
         results: List[NoteMeta] = []
 
         for meta in self._by_id.values():
@@ -186,13 +216,8 @@ class NoteIndex:
             if not filepath.exists():
                 continue
 
-            try:
-                text = filepath.read_text(encoding="utf-8")
-            except OSError:
-                continue
-
-            for match in pattern.finditer(text):
-                link_text = match.group(1).strip()
+            body = _read_body_after_frontmatter(filepath)
+            for link_text in extract_wiki_links_from_text(body):
                 if link_text.lower() == title_lower:
                     results.append(meta)
                     break

--- a/tests/unit/test_add_backfill_links.py
+++ b/tests/unit/test_add_backfill_links.py
@@ -1,0 +1,155 @@
+"""
+测试类型: 单元测试
+目标功能: jfox add 创建目标笔记时，自动回填引用方的正向 links
+预估耗时: < 2秒
+依赖要求: 临时知识库，mock embedding backend
+
+复现 GitHub issue #275：
+先创建笔记 A 引用尚不存在的 B，再创建 B 引用 A。
+期望 B 创建后，A 的 links 字段自动回填 B 的 id。
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+from utils.temp_kb import temp_kb_registered
+
+from jfox.cli import app
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+runner = CliRunner()
+
+
+class TestAddBackwardBackfill:
+    """测试 add 命令的 backward links 回填"""
+
+    def test_add_backfills_unresolved_forward_link(self, mock_embedding_backend):
+        """创建目标笔记后，引用方的出边应自动 resolve"""
+        with temp_kb_registered() as kb_name:
+            with patch("jfox.embedding_backend.get_backend", return_value=mock_embedding_backend):
+                # 1. 创建笔记 A，引用尚不存在的笔记 B
+                a_result = runner.invoke(
+                    app,
+                    [
+                        "add",
+                        "笔记A 正文，引用了 [[笔记B]]。",
+                        "--title",
+                        "笔记A",
+                        "--type",
+                        "permanent",
+                        "--kb",
+                        kb_name,
+                        "--json",
+                    ],
+                )
+                assert a_result.exit_code == 0, a_result.output
+                a_data = json.loads(a_result.output)
+                a_id = a_data["note"]["id"]
+
+                # 2. 创建笔记 B，引用 A
+                b_result = runner.invoke(
+                    app,
+                    [
+                        "add",
+                        "笔记B 正文，引用了 [[笔记A]]。",
+                        "--title",
+                        "笔记B",
+                        "--type",
+                        "permanent",
+                        "--kb",
+                        kb_name,
+                        "--json",
+                    ],
+                )
+                assert b_result.exit_code == 0, b_result.output
+                b_data = json.loads(b_result.output)
+                b_id = b_data["note"]["id"]
+
+                # 3. 验证 A 的 links 已回填 B，且 backlinks 包含 B
+                refs_a = runner.invoke(app, ["refs", "--note", a_id, "--kb", kb_name, "--json"])
+                assert refs_a.exit_code == 0, refs_a.output
+                refs_a_data = json.loads(refs_a.output)
+                forward_a = {link["id"] for link in refs_a_data.get("forward_links", [])}
+                backward_a = {link["id"] for link in refs_a_data.get("backward_links", [])}
+
+                assert b_id in forward_a, "A 的 links 应自动回填 B 的 id"
+                assert b_id in backward_a, "A 的 backlinks 应包含 B"
+
+                # 4. 验证 B 的 links/backlinks 也正确
+                refs_b = runner.invoke(app, ["refs", "--note", b_id, "--kb", kb_name, "--json"])
+                assert refs_b.exit_code == 0, refs_b.output
+                refs_b_data = json.loads(refs_b.output)
+                forward_b = {link["id"] for link in refs_b_data.get("forward_links", [])}
+                backward_b = {link["id"] for link in refs_b_data.get("backward_links", [])}
+
+                assert a_id in forward_b, "B 的 links 应包含 A"
+                assert a_id in backward_b, "B 的 backlinks 应包含 A"
+
+    def test_add_backfill_no_duplicate_links(self, mock_embedding_backend):
+        """重复创建/引用不会导致 links/backlinks 重复"""
+        with temp_kb_registered() as kb_name:
+            with patch("jfox.embedding_backend.get_backend", return_value=mock_embedding_backend):
+                # 创建 A（引用 B）
+                a_result = runner.invoke(
+                    app,
+                    [
+                        "add",
+                        "A 引用 [[B]]。",
+                        "--title",
+                        "A",
+                        "--type",
+                        "permanent",
+                        "--kb",
+                        kb_name,
+                        "--json",
+                    ],
+                )
+                assert a_result.exit_code == 0, a_result.output
+                a_id = json.loads(a_result.output)["note"]["id"]
+
+                # 创建 B（引用 A）触发回填
+                b_result = runner.invoke(
+                    app,
+                    [
+                        "add",
+                        "B 引用 [[A]]。",
+                        "--title",
+                        "B",
+                        "--type",
+                        "permanent",
+                        "--kb",
+                        kb_name,
+                        "--json",
+                    ],
+                )
+                assert b_result.exit_code == 0, b_result.output
+                b_id = json.loads(b_result.output)["note"]["id"]
+
+                # 再次创建 C（引用 A），A 的 backlinks 应只新增 C，不重复 B
+                c_result = runner.invoke(
+                    app,
+                    [
+                        "add",
+                        "C 引用 [[A]]。",
+                        "--title",
+                        "C",
+                        "--type",
+                        "permanent",
+                        "--kb",
+                        kb_name,
+                        "--json",
+                    ],
+                )
+                assert c_result.exit_code == 0, c_result.output
+                c_id = json.loads(c_result.output)["note"]["id"]
+
+                refs_a = runner.invoke(app, ["refs", "--note", a_id, "--kb", kb_name, "--json"])
+                assert refs_a.exit_code == 0, refs_a.output
+                refs_a_data = json.loads(refs_a.output)
+                backward_a = [link["id"] for link in refs_a_data.get("backward_links", [])]
+
+                assert backward_a.count(b_id) == 1
+                assert backward_a.count(c_id) == 1

--- a/tests/unit/test_add_backfill_links.py
+++ b/tests/unit/test_add_backfill_links.py
@@ -156,3 +156,64 @@ class TestAddBackwardBackfill:
 
                 assert backward_a.count(b_id) == 1
                 assert backward_a.count(c_id) == 1
+
+    def test_add_backfill_failed_refs_rolled_back(self, mock_embedding_backend):
+        """回填某篇引用方保存失败时，应回滚并暴露 failed_refs"""
+        import jfox.cli as cli_module
+
+        with temp_kb_registered() as kb_name:
+            with patch("jfox.embedding_backend.get_backend", return_value=mock_embedding_backend):
+                # 1. 创建笔记 A，引用尚不存在的笔记 B
+                a_result = runner.invoke(
+                    app,
+                    [
+                        "add",
+                        "笔记A 正文，引用了 [[笔记B]]。",
+                        "--title",
+                        "笔记A",
+                        "--type",
+                        "permanent",
+                        "--kb",
+                        kb_name,
+                        "--json",
+                    ],
+                )
+                assert a_result.exit_code == 0, a_result.output
+                a_id = json.loads(a_result.output)["note"]["id"]
+
+                original_save_note = cli_module.note.save_note
+
+                def fake_save_note(note, add_to_index=True):
+                    # 让回填 A 时保存失败，其他保存走原逻辑
+                    if note.id == a_id:
+                        return False
+                    return original_save_note(note, add_to_index)
+
+                # 2. 创建 B，触发 A 的回填；A 的保存会失败
+                with patch.object(cli_module.note, "save_note", side_effect=fake_save_note):
+                    b_result = runner.invoke(
+                        app,
+                        [
+                            "add",
+                            "笔记B 正文，引用了 [[笔记A]]。",
+                            "--title",
+                            "笔记B",
+                            "--type",
+                            "permanent",
+                            "--kb",
+                            kb_name,
+                            "--json",
+                        ],
+                    )
+                    assert b_result.exit_code == 0, b_result.output
+                    b_data = json.loads(b_result.output)
+
+                    # JSON 中应暴露失败信息
+                    assert a_id in b_data.get("backfill_failures", []), "失败引用方应出现在 backfill_failures"
+
+                # A 的 backlinks 不应包含 B（已回滚）
+                refs_a = runner.invoke(app, ["refs", "--note", a_id, "--kb", kb_name, "--json"])
+                assert refs_a.exit_code == 0, refs_a.output
+                refs_a_data = json.loads(refs_a.output)
+                backward_a = {link["id"] for link in refs_a_data.get("backward_links", [])}
+                assert b_data["note"]["id"] not in backward_a, "保存失败的引用方不应出现在 A 的 backlinks"

--- a/tests/unit/test_add_backfill_links.py
+++ b/tests/unit/test_add_backfill_links.py
@@ -209,11 +209,83 @@ class TestAddBackwardBackfill:
                     b_data = json.loads(b_result.output)
 
                     # JSON 中应暴露失败信息
-                    assert a_id in b_data.get("backfill_failures", []), "失败引用方应出现在 backfill_failures"
+                    assert a_id in b_data.get(
+                        "backfill_failures", []
+                    ), "失败引用方应出现在 backfill_failures"
 
                 # A 的 backlinks 不应包含 B（已回滚）
                 refs_a = runner.invoke(app, ["refs", "--note", a_id, "--kb", kb_name, "--json"])
                 assert refs_a.exit_code == 0, refs_a.output
                 refs_a_data = json.loads(refs_a.output)
                 backward_a = {link["id"] for link in refs_a_data.get("backward_links", [])}
-                assert b_data["note"]["id"] not in backward_a, "保存失败的引用方不应出现在 A 的 backlinks"
+                assert (
+                    b_data["note"]["id"] not in backward_a
+                ), "保存失败的引用方不应出现在 A 的 backlinks"
+
+    def test_add_backfill_new_note_save_failure_rolls_back_refs(
+        self, mock_embedding_backend
+    ):
+        """回填后保存新笔记 backlinks 失败时，应回滚已保存的 ref_note 并暴露失败"""
+        import jfox.cli as cli_module
+
+        with temp_kb_registered() as kb_name:
+            with patch(
+                "jfox.embedding_backend.get_backend", return_value=mock_embedding_backend
+            ):
+                # 1. 创建笔记 A，引用尚不存在的笔记 B
+                a_result = runner.invoke(
+                    app,
+                    [
+                        "add",
+                        "笔记A 正文，引用了 [[笔记B]]。",
+                        "--title",
+                        "笔记A",
+                        "--type",
+                        "permanent",
+                        "--kb",
+                        kb_name,
+                        "--json",
+                    ],
+                )
+                assert a_result.exit_code == 0, a_result.output
+                a_id = json.loads(a_result.output)["note"]["id"]
+
+                original_save_note = cli_module.note.save_note
+                # 记录 B 的保存次数：第一次创建 B 成功，第二次保存 B 的 backlinks 失败
+                b_save_count = {"count": 0}
+
+                def fake_save_note(note, add_to_index=True):
+                    if note.title == "笔记B":
+                        b_save_count["count"] += 1
+                        if b_save_count["count"] >= 2:
+                            return False
+                    return original_save_note(note, add_to_index)
+
+                # 2. 创建 B，触发 A 的回填；回填成功后保存 B 的 backlinks 会失败
+                with patch.object(cli_module.note, "save_note", side_effect=fake_save_note):
+                    b_result = runner.invoke(
+                        app,
+                        [
+                            "add",
+                            "笔记B 正文，引用了 [[笔记A]]。",
+                            "--title",
+                            "笔记B",
+                            "--type",
+                            "permanent",
+                            "--kb",
+                            kb_name,
+                            "--json",
+                        ],
+                    )
+                    assert b_result.exit_code == 0, b_result.output
+                    b_data = json.loads(b_result.output)
+
+                    # JSON 中应暴露新笔记 backlinks 保存失败
+                    assert b_data.get("backfill_note_save_failed") is True
+
+                # A 的 links 不应包含 B（已被回滚）
+                refs_a = runner.invoke(app, ["refs", "--note", a_id, "--kb", kb_name, "--json"])
+                assert refs_a.exit_code == 0, refs_a.output
+                refs_a_data = json.loads(refs_a.output)
+                forward_a = {link["id"] for link in refs_a_data.get("forward_links", [])}
+                assert b_data["note"]["id"] not in forward_a, "新笔记保存失败后 A 的 links 应被回滚"

--- a/tests/unit/test_add_backfill_links.py
+++ b/tests/unit/test_add_backfill_links.py
@@ -222,16 +222,12 @@ class TestAddBackwardBackfill:
                     b_data["note"]["id"] not in backward_a
                 ), "保存失败的引用方不应出现在 A 的 backlinks"
 
-    def test_add_backfill_new_note_save_failure_rolls_back_refs(
-        self, mock_embedding_backend
-    ):
+    def test_add_backfill_new_note_save_failure_rolls_back_refs(self, mock_embedding_backend):
         """回填后保存新笔记 backlinks 失败时，应回滚已保存的 ref_note 并暴露失败"""
         import jfox.cli as cli_module
 
         with temp_kb_registered() as kb_name:
-            with patch(
-                "jfox.embedding_backend.get_backend", return_value=mock_embedding_backend
-            ):
+            with patch("jfox.embedding_backend.get_backend", return_value=mock_embedding_backend):
                 # 1. 创建笔记 A，引用尚不存在的笔记 B
                 a_result = runner.invoke(
                     app,
@@ -289,3 +285,61 @@ class TestAddBackwardBackfill:
                 refs_a_data = json.loads(refs_a.output)
                 forward_a = {link["id"] for link in refs_a_data.get("forward_links", [])}
                 assert b_data["note"]["id"] not in forward_a, "新笔记保存失败后 A 的 links 应被回滚"
+
+    def test_add_backfill_rollback_failure_exposed(self, mock_embedding_backend):
+        """new_note backlinks 保存失败且 ref_note 回滚也失败时，应单独暴露 rollback_failures"""
+        import jfox.cli as cli_module
+
+        with temp_kb_registered() as kb_name:
+            with patch("jfox.embedding_backend.get_backend", return_value=mock_embedding_backend):
+                # 1. 创建笔记 A
+                a_result = runner.invoke(
+                    app,
+                    [
+                        "add",
+                        "笔记A 正文，引用了 [[笔记B]]。",
+                        "--title",
+                        "笔记A",
+                        "--type",
+                        "permanent",
+                        "--kb",
+                        kb_name,
+                        "--json",
+                    ],
+                )
+                assert a_result.exit_code == 0, a_result.output
+                a_id = json.loads(a_result.output)["note"]["id"]
+
+                original_save_note = cli_module.note.save_note
+                b_save_count = {"count": 0}
+
+                def fake_save_note(note, add_to_index=True):
+                    if note.title == "笔记B":
+                        b_save_count["count"] += 1
+                        if b_save_count["count"] >= 2:
+                            return False
+                    # 回滚阶段 A 的保存也失败
+                    if note.title == "笔记A" and b_save_count["count"] >= 2:
+                        return False
+                    return original_save_note(note, add_to_index)
+
+                with patch.object(cli_module.note, "save_note", side_effect=fake_save_note):
+                    b_result = runner.invoke(
+                        app,
+                        [
+                            "add",
+                            "笔记B 正文，引用了 [[笔记A]]。",
+                            "--title",
+                            "笔记B",
+                            "--type",
+                            "permanent",
+                            "--kb",
+                            kb_name,
+                            "--json",
+                        ],
+                    )
+                    assert b_result.exit_code == 0, b_result.output
+                    b_data = json.loads(b_result.output)
+
+                    assert b_data.get("backfill_note_save_failed") is True
+                    assert a_id in b_data.get("rollback_failures", [])

--- a/tests/unit/test_add_backfill_links.py
+++ b/tests/unit/test_add_backfill_links.py
@@ -68,6 +68,9 @@ class TestAddBackwardBackfill:
                 b_data = json.loads(b_result.output)
                 b_id = b_data["note"]["id"]
 
+                # add --json 返回的 links 字段应包含回填/解析后的结果
+                assert a_id in b_data["note"]["links"], "B 的 JSON 输出 links 应包含 A"
+
                 # 3. 验证 A 的 links 已回填 B，且 backlinks 包含 B
                 refs_a = runner.invoke(app, ["refs", "--note", a_id, "--kb", kb_name, "--json"])
                 assert refs_a.exit_code == 0, refs_a.output

--- a/tests/unit/test_note_index.py
+++ b/tests/unit/test_note_index.py
@@ -390,3 +390,95 @@ class TestNoteIndexFindNotesReferencingTitle:
         assert "20260428003" in ids
         # 新加的这篇因为只在 frontmatter 里出现，不应命中
         assert "20260428004" not in ids
+
+    def test_find_notes_referencing_title_alias_and_anchor(self, kb_with_wiki_links):
+        """支持 [[标题|别名]] 和 [[标题#锚点]] 变体"""
+        cfg = kb_with_wiki_links
+        note_dir = cfg.notes_dir / NoteType.PERMANENT.value
+        note_dir.mkdir(parents=True, exist_ok=True)
+
+        note_file = note_dir / "20260428005.md"
+        note_file.write_text(
+            "---\n"
+            "id: '20260428005'\n"
+            "title: '变体引用'\n"
+            "type: permanent\n"
+            "created: '2026-04-28T00:05:00'\n"
+            "updated: '2026-04-28T00:05:00'\n"
+            "tags: []\n"
+            "links: []\n"
+            "backlinks: []\n"
+            "---\n\n"
+            "正文引用了 [[笔记B|别名]] 和 [[笔记B#章节]]。\n",
+            encoding="utf-8",
+        )
+
+        idx = NoteIndex(cfg)
+        idx.rebuild()
+
+        refs = idx.find_notes_referencing_title("笔记B")
+        ids = {m.id for m in refs}
+
+        assert "20260428005" in ids
+
+    def test_find_notes_referencing_title_skips_code_block_and_comment(self, kb_with_wiki_links):
+        """fenced code block 和 HTML 注释中的 [[...]] 不应被误判"""
+        cfg = kb_with_wiki_links
+        note_dir = cfg.notes_dir / NoteType.PERMANENT.value
+        note_dir.mkdir(parents=True, exist_ok=True)
+
+        note_file = note_dir / "20260428006.md"
+        note_file.write_text(
+            "---\n"
+            "id: '20260428006'\n"
+            "title: '代码块和注释'\n"
+            "type: permanent\n"
+            "created: '2026-04-28T00:06:00'\n"
+            "updated: '2026-04-28T00:06:00'\n"
+            "tags: []\n"
+            "links: []\n"
+            "backlinks: []\n"
+            "---\n\n"
+            "```\n"
+            "这里出现 [[笔记B]] 但属于代码块\n"
+            "```\n\n"
+            "<!-- [[笔记B]] 这是 HTML 注释 -->\n\n"
+            "正文没有实际引用。\n",
+            encoding="utf-8",
+        )
+
+        idx = NoteIndex(cfg)
+        idx.rebuild()
+
+        refs = idx.find_notes_referencing_title("笔记B")
+        ids = {m.id for m in refs}
+
+        assert "20260428006" not in ids
+
+    def test_find_notes_referencing_title_unicode_decode_error(self, kb_with_wiki_links):
+        """遇到非 UTF-8 文件时不抛异常，而是跳过该文件"""
+        cfg = kb_with_wiki_links
+        note_dir = cfg.notes_dir / NoteType.PERMANENT.value
+        note_dir.mkdir(parents=True, exist_ok=True)
+
+        # 写入非法 UTF-8 字节
+        corrupt_file = note_dir / "20260428007.md"
+        corrupt_file.write_bytes(
+            b"---\n"
+            b"id: '20260428007'\n"
+            b"title: '\xff\xfe'\n"
+            b"type: permanent\n"
+            b"---\n\n"
+            b"\xff\xfe [[\xb1\xca\xc7\xf0]]"
+        )
+
+        idx = NoteIndex(cfg)
+        idx.rebuild()
+
+        # 不应抛出 UnicodeDecodeError
+        refs = idx.find_notes_referencing_title("笔记B")
+        ids = {m.id for m in refs}
+
+        # 非法文件本身不会被识别为笔记（frontmatter 解析也会失败），
+        # 但重点是查询过程不崩溃
+        assert "20260428007" not in ids

--- a/tests/unit/test_note_index.py
+++ b/tests/unit/test_note_index.py
@@ -354,3 +354,39 @@ class TestNoteIndexFindNotesReferencingTitle:
 
         refs = idx.find_notes_referencing_title("不存在的笔记")
         assert refs == []
+
+    def test_find_notes_referencing_title_skips_frontmatter(self, kb_with_wiki_links):
+        """frontmatter 中的 [[...]] 不应被误判为正文引用"""
+        cfg = kb_with_wiki_links
+        note_dir = cfg.notes_dir / NoteType.PERMANENT.value
+        note_dir.mkdir(parents=True, exist_ok=True)
+
+        # 手动构造一篇笔记：title 里带 [[笔记B]]，但正文没有引用
+        note_file = note_dir / "20260428004.md"
+        note_file.write_text(
+            "---\n"
+            "id: '20260428004'\n"
+            "title: '[[笔记B]] 的标题只在 frontmatter'\n"
+            "type: permanent\n"
+            "created: '2026-04-28T00:04:00'\n"
+            "updated: '2026-04-28T00:04:00'\n"
+            "tags: []\n"
+            "links: []\n"
+            "backlinks: []\n"
+            "---\n\n"
+            "# 标题\n\n"
+            "正文没有任何维基链接。\n",
+            encoding="utf-8",
+        )
+
+        idx = NoteIndex(cfg)
+        idx.rebuild()
+
+        refs = idx.find_notes_referencing_title("笔记B")
+        ids = {m.id for m in refs}
+
+        # 原来的 20260428001 和 20260428003 仍然命中
+        assert "20260428001" in ids
+        assert "20260428003" in ids
+        # 新加的这篇因为只在 frontmatter 里出现，不应命中
+        assert "20260428004" not in ids

--- a/tests/unit/test_note_index.py
+++ b/tests/unit/test_note_index.py
@@ -279,3 +279,78 @@ class TestListNotesViaIndex:
 
         result = list_notes(limit=3, cfg=kb_with_many_notes)
         assert len(result) == 3
+
+
+class TestNoteIndexFindNotesReferencingTitle:
+    """测试 find_notes_referencing_title"""
+
+    @pytest.fixture
+    def kb_with_wiki_links(self, temp_kb):
+        """创建包含维基链接引用的知识库"""
+        cfg = ZKConfig(base_dir=temp_kb)
+        cfg.ensure_dirs()
+
+        notes = [
+            Note(
+                id="20260428001",
+                title="笔记A",
+                content="笔记A 正文，引用了 [[笔记B]]。",
+                type=NoteType.PERMANENT,
+                created=datetime(2026, 4, 28, 0, 1),
+                updated=datetime(2026, 4, 28, 0, 1),
+            ),
+            Note(
+                id="20260428002",
+                title="笔记B",
+                content="笔记B 正文。",
+                type=NoteType.PERMANENT,
+                created=datetime(2026, 4, 28, 0, 2),
+                updated=datetime(2026, 4, 28, 0, 2),
+            ),
+            Note(
+                id="20260428003",
+                title="笔记C",
+                content="笔记C 引用了 [[笔记A]] 和 [[笔记B]]。",
+                type=NoteType.PERMANENT,
+                created=datetime(2026, 4, 28, 0, 3),
+                updated=datetime(2026, 4, 28, 0, 3),
+            ),
+        ]
+
+        for n in notes:
+            note_dir = cfg.notes_dir / n.type.value
+            note_dir.mkdir(parents=True, exist_ok=True)
+            note_file = note_dir / f"{n.id}.md"
+            note_file.write_text(n.to_markdown(), encoding="utf-8")
+
+        return cfg
+
+    def test_find_notes_referencing_title(self, kb_with_wiki_links):
+        """能找出正文中引用了指定标题的笔记"""
+        idx = NoteIndex(kb_with_wiki_links)
+        idx.rebuild()
+
+        refs = idx.find_notes_referencing_title("笔记B")
+        ids = {m.id for m in refs}
+
+        assert "20260428001" in ids
+        assert "20260428003" in ids
+        assert "20260428002" not in ids
+
+    def test_find_notes_referencing_title_case_insensitive(self, kb_with_wiki_links):
+        """标题匹配大小写不敏感"""
+        idx = NoteIndex(kb_with_wiki_links)
+        idx.rebuild()
+
+        refs = idx.find_notes_referencing_title("笔记a")
+        ids = {m.id for m in refs}
+
+        assert "20260428003" in ids
+
+    def test_find_notes_referencing_title_not_found(self, kb_with_wiki_links):
+        """不存在引用时返回空列表"""
+        idx = NoteIndex(kb_with_wiki_links)
+        idx.rebuild()
+
+        refs = idx.find_notes_referencing_title("不存在的笔记")
+        assert refs == []


### PR DESCRIPTION
## 问题\n\njfox add 创建笔记时，若正文 [[引用]] 了尚不存在的笔记，等目标笔记后续创建后，引用方的出边 links 不会自动回填，导致知识图谱断链（#275）。\n\n## 修复\n\n- 在 `jfox/cli.py` 的 `_add_note_impl` 保存新笔记后，增加 backward 回填逻辑：\n  - 通过 `NoteIndex.find_notes_referencing_title(new_note.title)` 找出正文中引用了新笔记标题的现有笔记；\n  - 将新笔记 ID 回填到这些笔记的 `links` 中；\n  - 同步把引用方 ID 追加到新笔记的 `backlinks` 中。\n\n- 在 `jfox/note_index.py` 新增 `find_notes_referencing_title(title)`，基于索引中已有的文件路径直接读取内容查找 `[[标题]]` 语法，避免全量加载 `Note` 对象。\n\n## 测试\n\n- `tests/unit/test_add_backfill_links.py`：复现 #275 的端到端 CLI 场景，并验证重复引用不会导致 links/backlinks 重复。\n- `tests/unit/test_note_index.py`：覆盖 `find_notes_referencing_title` 的基本匹配、大小写不敏感匹配与未命中情况。\n\n## 验证\n\n```bash\nuv run ruff check jfox/ tests/ && uv run black --check jfox/ tests/ && uv run pytest tests/unit/ -v\n```\n\n全部通过。\n\nCloses #275