### PR TITLE
fix(cc-plugin): remove redundant hooks field from plugin.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "JFox Zettelkasten 知识管理工具的 Claude Code 集成",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   "plugins": [
     {
       "name": "jfox",
       "source": "./packages/cc-plugin",
       "description": "JFox 知识管理 CLI 的 Claude Code 集成——搜索、写入工作流（导入/整理/会话总结）与知识库管理",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "author": { "name": "zhuxixi" },
       "keywords": ["zettelkasten", "knowledge-management"],
       "category": "workflow"

--- a/packages/cc-plugin/.claude-plugin/plugin.json
+++ b/packages/cc-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jfox",
   "description": "JFox 知识管理 CLI 的 Claude Code 集成——搜索、写入工作流（导入/整理/会话总结）与知识库管理",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": { "name": "zhuxixi" },
   "homepage": "https://github.com/zhuxixi/jfox",
   "repository": "https://github.com/zhuxixi/jfox",

--- a/packages/cc-plugin/.claude-plugin/plugin.json
+++ b/packages/cc-plugin/.claude-plugin/plugin.json
@@ -6,6 +6,5 @@
   "homepage": "https://github.com/zhuxixi/jfox",
   "repository": "https://github.com/zhuxixi/jfox",
   "license": "MIT",
-  "keywords": ["zettelkasten", "knowledge-management", "cli"],
-  "hooks": "./hooks/hooks.json"
+  "keywords": ["zettelkasten", "knowledge-management", "cli"]
 }


### PR DESCRIPTION
Closes #277

## Problem

Claude Code fails with duplicate-hooks error because plugin.json explicitly declares hooks field, but CC auto-loads hooks/hooks.json by convention.

## Fix

Remove the redundant hooks field. The standard hooks/hooks.json remains and loads automatically.

- 1 file changed, 1 insertion, 2 deletions