### PR TITLE
docs: fix stale cc-plugin versioning note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ JFox ships as a Claude Code plugin. Two-tier structure:
 - `packages/cc-plugin/.claude-plugin/plugin.json` — plugin source metadata
 - `packages/cc-plugin/skills/` — 5 skills: `search`, `ingest`, `manage`, `organize`, `session-summary`
 
-**Plugin versioning**: bump version in both `plugin.json` AND `marketplace.json` together. Current: 0.2.0.
+**Plugin versioning**: bump version in **three** places together — `packages/cc-plugin/.claude-plugin/plugin.json` (`version`) and both version fields in `.claude-plugin/marketplace.json` (`metadata.version` + `plugins[0].version`). 漏改任一处都会导致 marketplace 与 plugin 版本不一致。Current: 0.4.0.
 **Skill rename history**: `kb` → `manage` (v0.2.0) — "manage" is the canonical KB lifecycle + CRUD skill.
 
 ## Branch Rules


### PR DESCRIPTION
## Summary

修正 CLAUDE.md 里 cc-plugin 版本号 bump 的过时说明。

原说明写的是「bump version in **both** `plugin.json` AND `marketplace.json`... Current: 0.2.0」，实际有两处问题：

1. **不是两处，是三处**：`marketplace.json` 里有**两个** version 字段（`metadata.version` + `plugins[0].version`），再加 `plugin.json` 的 `version`，共三处。原说明容易让人只改一处 marketplace 字段。
2. **版本号过时**：标注的 `Current: 0.2.0` 早已落后（#272 升到 0.3.0，PR #280 再升到 0.4.0）。

改为明确列出三处路径 + 字段名，并把 Current 更新为 0.4.0。

> 注：本 PR 仅改文档；实际把 0.3.0 → 0.4.0 的三处版本字段在 PR #280 里。合并顺序无所谓，两边都落地后即一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)