### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to jfox-cli will be documented in this file.
 
+## [1.2.0] - 2026-06-24
+
+### Features
+- L3 宝石合成（碎裂→破损 candidate 笔记，#249 Layer 3） (#274)
+
+### Fixes
+- **cc-plugin**: remove redundant hooks field from plugin.json (#280)
+
+### Changes
+- fix stale cc-plugin versioning note (3 places, current 0.4.0) (#281)
+
+[1.2.0]: https://github.com/zhuxixi/jfox/compare/v1.1.1...v1.2.0
+
 ## [1.1.1] - 2026-06-21
 
 ### Features

--- a/jfox/__init__.py
+++ b/jfox/__init__.py
@@ -1,5 +1,5 @@
 """JFox - Zettelkasten 知识管理工具"""
 
-__version__ = "1.1.1"
+__version__ = "1.2.0"
 __author__ = "User"
 __email__ = "user@example.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jfox-cli"
-version = "1.1.1"
+version = "1.2.0"
 description = "JFox - Zettelkasten 知识管理 CLI 工具"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -867,7 +867,7 @@ wheels = [
 
 [[package]]
 name = "jfox-cli"
-version = "1.1.1"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary
Bump version from 1.1.1 to 1.2.0

## [1.2.0] - 2026-06-24

### Features
- L3 宝石合成（碎裂→破损 candidate 笔记，#249 Layer 3） (#274)

### Fixes
- **cc-plugin**: remove redundant hooks field from plugin.json (#280)

### Changes
- fix stale cc-plugin versioning note (3 places, current 0.4.0) (#281)

🤖 Generated with [Claude Code](https://claude.com/claude-code)