### PR TITLE
feat(gem-synth): time-budget throttle + synthesis ledger + status (#283)

### DIFF
--- a/docs/superpowers/plans/2026-06-25-gem-synth-throttle-ledger.md
+++ b/docs/superpowers/plans/2026-06-25-gem-synth-throttle-ledger.md
@@ -1,0 +1,717 @@
+# gem_synth 限流 + 合成 ledger 实现计划（Issue #283）
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`).
+
+**Goal:** 给 gem_synth 循环加时间预算限流（替代无上限）+ synthesis_log 升级为带 status 的 ledger（失败标记跳过不重试）+ `jfox gem-synth status` 看进度捞失败。
+
+**Architecture:** `_tick_once` 改时间预算（每轮串行处理直到 interval_minutes 用完）；synthesis_log 加 status/fail_reason 列 + migration；synthesize_anchor 各失败路径 mark_failed；新增 gem_synth status 命令。
+
+**Tech Stack:** Python 3.10+ / SQLite3 / Typer。纯逻辑/SQLite 单测自主跑。
+
+**关联文档:** spec `docs/superpowers/specs/2026-06-25-gem-synth-throttle-ledger-design.md`，issue #283。
+
+---
+
+## 文件结构
+
+改动：
+- `jfox/gem_synth/store.py` — schema 加 status/fail_reason + migration；加 mark_failed/status_counts/list_failed
+- `jfox/gem_synth/synthesizer.py` — 各失败路径 mark_failed
+- `jfox/gem_synth/loop.py` — `_tick_once` 时间预算循环
+- `jfox/gem_synth/anchors.py` — 加 `count_anchors`（status 命令算 pending 用）
+- `jfox/gem_synth/cli.py` — 加 `gem_synth_app` + `status` 命令
+- `jfox/cli.py` — 挂载 `gem_synth_app`
+
+测试：`tests/unit/test_gem_synth_store.py`、`test_gem_synth_synthesizer.py`、`test_gem_synth_loop.py`、`test_gem_synth_cli.py`（扩展）。
+
+---
+
+## Task 1: SynthesisLog ledger 扩展（store.py）
+
+**Files:**
+- Modify: `jfox/gem_synth/store.py`
+- Test: `tests/unit/test_gem_synth_store.py`
+
+- [ ] **Step 1: 加测试到 `tests/unit/test_gem_synth_store.py`**
+
+```python
+def test_mark_failed_and_status_counts(tmp_path):
+    from jfox.gem_synth.store import SynthesisLog
+    log = SynthesisLog(db_path=tmp_path / "s.db")
+    log.mark_processed(1, "c1")
+    log.mark_failed(2, "no transcript_path")
+    log.mark_failed(3, "llm failed: 非 JSON")
+    counts = log.status_counts()
+    assert counts == {"success": 1, "failed": 2}
+    log.close()
+
+
+def test_list_failed(tmp_path):
+    from jfox.gem_synth.store import SynthesisLog
+    log = SynthesisLog(db_path=tmp_path / "s.db")
+    log.mark_failed(2, "no transcript_path")
+    log.mark_processed(1, "c1")
+    log.mark_failed(3, "llm failed")
+    failed = log.list_failed()
+    ids = [f["anchor_fragment_id"] for f in failed]
+    assert 2 in ids and 3 in ids and 1 not in ids
+    assert all(f["fail_reason"] for f in failed)
+    log.close()
+
+
+def test_failed_anchor_is_processed_not_retried(tmp_path):
+    """failed 也算已处理 → filter_unprocessed 不返回它"""
+    from jfox.gem_synth.store import SynthesisLog
+    log = SynthesisLog(db_path=tmp_path / "s.db")
+    log.mark_failed(5, "boom")
+    assert log.is_processed(5) is True
+    assert log.filter_unprocessed([5, 6]) == [6]
+    log.close()
+
+
+def test_migration_adds_columns_to_old_table(tmp_path):
+    """旧表（无 status/fail_reason 列）建后 SynthesisLog 能升级"""
+    import sqlite3
+    p = tmp_path / "old.db"
+    # 造一个 1.2.0 之前的旧 schema 表
+    conn = sqlite3.connect(str(p))
+    conn.execute(
+        "CREATE TABLE synthesis_log (anchor_fragment_id INTEGER PRIMARY KEY, "
+        "candidate_note_id TEXT NOT NULL, synthesized_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)"
+    )
+    conn.execute("INSERT INTO synthesis_log (anchor_fragment_id, candidate_note_id) VALUES (1, 'c1')")
+    conn.commit()
+    conn.close()
+    # 用 SynthesisLog 打开 → 应自动 ALTER 加列，旧行 status='success'
+    from jfox.gem_synth.store import SynthesisLog
+    log = SynthesisLog(db_path=p)
+    counts = log.status_counts()
+    assert counts == {"success": 1}  # 旧行迁移后默认 success
+    log.mark_failed(2, "x")  # 新列可用
+    assert log.status_counts() == {"success": 1, "failed": 1}
+    log.close()
+```
+
+- [ ] **Step 2: 跑确认失败**
+
+Run: `uv run pytest tests/unit/test_gem_synth_store.py -v`
+Expected: FAIL（mark_failed / status_counts / list_failed 不存在）
+
+- [ ] **Step 3: 改 `jfox/gem_synth/store.py`**
+
+把 `_SCHEMA` 改为（candidate_note_id 去掉 NOT NULL，加 status/fail_reason）：
+```python
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS synthesis_log (
+    anchor_fragment_id  INTEGER PRIMARY KEY,
+    candidate_note_id   TEXT,
+    status              TEXT NOT NULL DEFAULT 'success',
+    fail_reason         TEXT,
+    synthesized_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+"""
+```
+
+在 `__init__` 里，`self._conn.executescript(_SCHEMA)` + `self._conn.commit()` 之后、`self._closed = False` 之前，加 migration 调用：
+```python
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+        self._maybe_migrate()
+        self._closed: bool = False
+```
+
+在 `__init__` 之后、`is_processed` 之前，加 `_maybe_migrate` 方法：
+```python
+    def _maybe_migrate(self) -> None:
+        """旧表升级：补 status / fail_reason 列（1.2.0 前的表没有）。新表已含，跳过。"""
+        cols = {row["name"] for row in self._conn.execute("PRAGMA table_info(synthesis_log)")}
+        if "status" not in cols:
+            self._conn.execute(
+                "ALTER TABLE synthesis_log ADD COLUMN status TEXT NOT NULL DEFAULT 'success'"
+            )
+        if "fail_reason" not in cols:
+            self._conn.execute("ALTER TABLE synthesis_log ADD COLUMN fail_reason TEXT")
+        self._conn.commit()
+```
+
+把 `mark_processed` 改为显式写 status：
+```python
+    def mark_processed(self, anchor_fragment_id: int, candidate_note_id: str) -> None:
+        with self._lock:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO synthesis_log "
+                "(anchor_fragment_id, candidate_note_id, status) VALUES (?, ?, 'success')",
+                (anchor_fragment_id, candidate_note_id),
+            )
+            self._conn.commit()
+```
+
+在 `mark_processed` 之后加 `mark_failed`、`status_counts`、`list_failed`：
+```python
+    def mark_failed(self, anchor_fragment_id: int, fail_reason: str) -> None:
+        """失败锚点记账：status='failed' + 原因，candidate_note_id 留空。
+        记账后 is_processed 为 True → 不再重试（过夜跑不 thrash）。
+        """
+        with self._lock:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO synthesis_log "
+                "(anchor_fragment_id, candidate_note_id, status, fail_reason) "
+                "VALUES (?, '', 'failed', ?)",
+                (anchor_fragment_id, fail_reason),
+            )
+            self._conn.commit()
+
+    def status_counts(self) -> dict:
+        """返回 {status: count}，如 {'success': 3, 'failed': 1}。"""
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT status, COUNT(*) AS n FROM synthesis_log GROUP BY status"
+            ).fetchall()
+        return {r["status"]: int(r["n"]) for r in rows}
+
+    def list_failed(self, limit: int = 100) -> List[dict]:
+        """返回失败锚点列表（最新在前），供 status --failed 人工复核。"""
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT anchor_fragment_id, fail_reason, synthesized_at "
+                "FROM synthesis_log WHERE status = 'failed' "
+                "ORDER BY synthesized_at DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        return [
+            {
+                "anchor_fragment_id": r["anchor_fragment_id"],
+                "fail_reason": r["fail_reason"],
+                "synthesized_at": r["synthesized_at"],
+            }
+            for r in rows
+        ]
+```
+
+更新 `__all__`：`__all__ = ["SynthesisLog"]`（不变，方法在类内）。
+
+- [ ] **Step 4: 跑确认通过 + 回归**
+
+Run: `uv run pytest tests/unit/test_gem_synth_store.py tests/unit/test_gem_synth_anchors.py -v`
+Expected: PASS（store 新测试 + anchors 不受影响）
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add jfox/gem_synth/store.py tests/unit/test_gem_synth_store.py
+git commit -m "feat(gem-synth): SynthesisLog ledger (status/fail_reason + migration)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: synthesize_anchor 失败路径 mark_failed（synthesizer.py）
+
+**Files:**
+- Modify: `jfox/gem_synth/synthesizer.py`
+- Test: `tests/unit/test_gem_synth_synthesizer.py`
+
+- [ ] **Step 1: 加测试到 `tests/unit/test_gem_synth_synthesizer.py`**
+
+```python
+def test_synthesize_marks_failed_when_no_transcript(tmp_path):
+    """无 transcript_path → mark_failed('no transcript_path')，不重试"""
+    from jfox.gem_synth.synthesizer import synthesize_anchor
+    from jfox.gem_synth.store import SynthesisLog
+    log = SynthesisLog(db_path=tmp_path / "s.db")
+    anchor = {
+        "fragment_id": 44, "session_id": "s", "timestamp": "t",
+        "content": "x", "transcript_path": None, "metadata": {},
+    }
+    result = synthesize_anchor(anchor, log=log, cfg=MagicMock(grounding_top_k=5), stop_event=None)
+    assert result is None
+    assert log.is_processed(44) is True  # failed 也算已处理
+    failed = log.list_failed()
+    assert any(f["anchor_fragment_id"] == 44 and "transcript" in f["fail_reason"] for f in failed)
+    log.close()
+
+
+def test_synthesize_marks_failed_when_llm_none(tmp_path):
+    """LLM 返 None → mark_failed('llm ...')"""
+    from jfox.gem_synth.synthesizer import synthesize_anchor
+    from jfox.gem_synth.store import SynthesisLog
+    log = SynthesisLog(db_path=tmp_path / "s.db")
+    anchor = {
+        "fragment_id": 45, "session_id": "s", "timestamp": "t",
+        "content": "x", "transcript_path": str(tmp_path / "t.jsonl"),
+        "metadata": {},
+    }
+    (tmp_path / "t.jsonl").write_text('{"type":"user","message":{"role":"user","content":"x"},"timestamp":"t","uuid":"u"}', encoding="utf-8")
+    with patch("jfox.gem_synth.synthesizer.extract_turn_around", return_value="上下文"), \
+         patch("jfox.gem_synth.synthesizer.fetch_grounding", return_value=[]), \
+         patch("jfox.gem_synth.synthesizer.synthesize_with_llm", return_value=None):
+        result = synthesize_anchor(anchor, log=log, cfg=MagicMock(grounding_top_k=5), stop_event=None)
+    assert result is None
+    failed = log.list_failed()
+    assert any(f["anchor_fragment_id"] == 45 and "llm" in f["fail_reason"].lower() for f in failed)
+    log.close()
+```
+
+- [ ] **Step 2: 跑确认失败**
+
+Run: `uv run pytest tests/unit/test_gem_synth_synthesizer.py -v`
+Expected: FAIL（失败路径没调 mark_failed，is_processed False）
+
+- [ ] **Step 3: 改 `jfox/gem_synth/synthesizer.py` synthesize_anchor**
+
+Read `synthesize_anchor`（约 line 108-153）。在每个 `return None` 失败路径**之前**插入 `log.mark_failed(anchor["fragment_id"], "<reason>")`。具体 4 处（按当前代码顺序）：
+
+(a) 无 transcript_path 路径（`if not transcript_path:` 分支），在 `return None` 前加：
+```python
+        log.mark_failed(anchor["fragment_id"], "no transcript_path")
+        return None
+```
+
+(b) transcript 上下文为空路径（`if not turn.strip():` 分支），在 `return None` 前加：
+```python
+        log.mark_failed(anchor["fragment_id"], "empty transcript context")
+        return None
+```
+
+(c) LLM 返 None 路径（`if llm_result is None:` 分支），在 `return None` 前加：
+```python
+        log.mark_failed(anchor["fragment_id"], "llm synthesis failed")
+        return None
+```
+
+(d) _save_candidate_note 失败路径（`if note_id is None:` 分支），在 `return None` 前加：
+```python
+        log.mark_failed(anchor["fragment_id"], "save candidate note failed")
+        return None
+```
+
+同时把函数 docstring 里「None → 跳过（不记账，下轮重试）」改为「None → mark_failed 记账（不重试）」。
+
+- [ ] **Step 4: 跑确认通过 + 回归**
+
+Run: `uv run pytest tests/unit/test_gem_synth_synthesizer.py tests/unit/test_gem_synth_loop.py -v`
+Expected: PASS（**注意**：loop 测试若 mock synthesize_anchor 返回 None，现在 None=failed。检查 loop 测试是否需调整计数断言。若 test_gem_synth_loop 有断言 success 计数，确认仍对。）
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add jfox/gem_synth/synthesizer.py tests/unit/test_gem_synth_synthesizer.py
+git commit -m "feat(gem-synth): synthesize_anchor marks failed anchors (no retry)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: _tick_once 时间预算循环（loop.py）
+
+**Files:**
+- Modify: `jfox/gem_synth/loop.py`
+- Test: `tests/unit/test_gem_synth_loop.py`
+
+- [ ] **Step 1: 加测试到 `tests/unit/test_gem_synth_loop.py`**
+
+```python
+def test_tick_time_budget_stops_after_interval():
+    """时间预算：interval_minutes 用完就停，即使还有 pending"""
+    cfg = MagicMock()
+    cfg.enabled = True
+    cfg.anchor_types = ["correction"]
+    cfg.grounding_top_k = 5
+    cfg.target_kb = None
+    cfg.interval_minutes = 0  # 预算 0 → 处理 0 个立即停
+    fake_anchor = {"fragment_id": 1, "session_id": "s", "timestamp": "t", "content": "c", "transcript_path": "/x", "metadata": {}}
+    with patch("jfox.gem_synth.loop.get_global_config_manager") as gm, \
+         patch("jfox.gem_synth.loop.find_anchors", return_value=[fake_anchor]) as fa, \
+         patch("jfox.gem_synth.loop.synthesize_anchor", return_value={"candidate_note_id": "c1"}) as sa:
+        gm.return_value.get_gem_synthesis_config.return_value = cfg
+        msg = _tick_once(threading.Event())
+    # 预算 0 → 不处理任何锚点（时间检查在合成前）
+    sa.assert_not_called()
+    assert isinstance(msg, str)
+
+
+def test_tick_processes_one_at_a_time_within_budget():
+    """预算内逐个处理（limit=1），直到无锚点"""
+    cfg = MagicMock()
+    cfg.enabled = True
+    cfg.anchor_types = ["correction"]
+    cfg.grounding_top_k = 5
+    cfg.target_kb = None
+    cfg.interval_minutes = 30  # 充足预算
+    call_count = {"n": 0}
+    def fake_find(*a, **k):
+        call_count["n"] += 1
+        # 第 1、2 次返回锚点，第 3 次返回空（无积压）
+        return [{"fragment_id": call_count["n"], "session_id": "s", "timestamp": "t", "content": "c", "transcript_path": "/x", "metadata": {}}] if call_count["n"] <= 2 else []
+    with patch("jfox.gem_synth.loop.get_global_config_manager") as gm, \
+         patch("jfox.gem_synth.loop.find_anchors", side_effect=fake_find), \
+         patch("jfox.gem_synth.loop.synthesize_anchor", return_value={"candidate_note_id": "c"}):
+        gm.return_value.get_gem_synthesis_config.return_value = cfg
+        msg = _tick_once(threading.Event())
+    assert "success=2" in msg
+```
+
+- [ ] **Step 2: 跑确认失败**
+
+Run: `uv run pytest tests/unit/test_gem_synth_loop.py -v`
+Expected: FAIL（当前 _tick_once 取 batch 不是 limit=1 循环）
+
+- [ ] **Step 3: 改 `jfox/gem_synth/loop.py`**
+
+Read 顶部 import，确认有 `import threading`（有）。加 `import time`（若没有）。把 `_tick_once` 整个函数体替换为时间预算循环：
+
+```python
+def _tick_once(stop_event: threading.Event) -> str:
+    """同步执行一轮：时间预算内逐个合成锚点。
+
+    每轮跑 cfg.interval_minutes（窗口），串行处理（一次取一个未处理锚点），
+    直到窗口用完或无锚点。窗口跑满则下个 tick 立即接上 → 积压时连续跑。
+    """
+    gm = get_global_config_manager()
+    gm.reload()
+    cfg = gm.get_gem_synthesis_config()
+    if not cfg.enabled:
+        return "gem-synth 已禁用，跳过本轮"
+
+    from jfox.fragment.store import default_db_path
+    from ..config import use_kb
+
+    log = SynthesisLog()
+    tick_start = time.monotonic()
+    budget_seconds = cfg.interval_minutes * 60
+    success = 0
+    failed = 0
+    try:
+        # 整轮只切一次 KB（避免每锚点 use_kb → _reset_singletons 重载模型）
+        with use_kb(cfg.target_kb):
+            while not stop_event.is_set():
+                # 时间预算用完 → 停，留给下个 tick（back-to-back 连续跑）
+                if time.monotonic() - tick_start >= budget_seconds:
+                    break
+                try:
+                    anchors = find_anchors(
+                        fragments_db=default_db_path(),
+                        log=log,
+                        anchor_types=cfg.anchor_types,
+                        limit=1,  # 一次取一个，配合时间预算
+                    )
+                except Exception as e:
+                    logger.exception("gem-synth 找锚点失败: %s", e)
+                    break
+                if not anchors:
+                    break  # 无积压
+                try:
+                    result = synthesize_anchor(
+                        anchors[0], log=log, cfg=cfg, stop_event=stop_event
+                    )
+                    if result is not None:
+                        success += 1
+                    else:
+                        failed += 1
+                except Exception as e:
+                    logger.exception(
+                        "gem-synth 合成锚点 #%s 异常: %s", anchors[0].get("fragment_id"), e
+                    )
+                    failed += 1
+    finally:
+        log.close()
+    return f"本轮 success={success} failed={failed}（预算 {cfg.interval_minutes}min）"
+```
+
+（确保文件顶部 `import time` 存在；`import threading` 已有。）
+
+- [ ] **Step 4: 跑确认通过 + 回归**
+
+Run: `uv run pytest tests/unit/test_gem_synth_loop.py tests/unit/test_gem_synth_synthesizer.py -v`
+Expected: PASS
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add jfox/gem_synth/loop.py tests/unit/test_gem_synth_loop.py
+git commit -m "feat(gem-synth): time-budget tick loop (serial, interval-bounded)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: jfox gem-synth status 命令 + count_anchors（cli.py + anchors.py）
+
+**Files:**
+- Modify: `jfox/gem_synth/anchors.py`（加 count_anchors）
+- Modify: `jfox/gem_synth/cli.py`（加 gem_synth_app + status）
+- Modify: `jfox/cli.py`（挂载 gem_synth_app）
+- Test: `tests/unit/test_gem_synth_cli.py`（扩展）
+
+- [ ] **Step 1: 加 count_anchors 测试 + 实现到 anchors.py**
+
+测试加到 `tests/unit/test_gem_synth_anchors.py`：
+```python
+def test_count_anchors(tmp_path):
+    from jfox.fragment.store import FragmentStore
+    from jfox.gem_synth.anchors import count_anchors
+    from jfox.gem_synth.store import SynthesisLog
+    store = FragmentStore(db_path=tmp_path / "f.db")
+    store.insert("s1", "correction", "UserPromptSubmit", "不对", {})
+    store.insert("s1", "decision", "UserPromptSubmit", "我决定", {})
+    store.insert("s1", "user_input", "UserPromptSubmit", "hi", {})  # 非锚点
+    store.close()
+    log = SynthesisLog(db_path=tmp_path / "syn.db")
+    n = count_anchors(fragments_db=tmp_path / "f.db", anchor_types=["correction", "decision", "ask_user_question"])
+    assert n == 2
+    log.close()
+```
+
+在 `jfox/gem_synth/anchors.py` 加 `count_anchors`（复用 `_anchor_where` 的 WHERE 逻辑）：
+```python
+def count_anchors(fragments_db: Path, anchor_types: List[str]) -> int:
+    """高信号锚点总数（不区分是否已处理）—— status 命令算 pending 用。"""
+    where = _anchor_where(anchor_types)
+    if not where:
+        return 0
+    conn = sqlite3.connect(str(fragments_db))
+    try:
+        row = conn.execute(f"SELECT COUNT(*) FROM session_fragments {where}").fetchone()
+    finally:
+        conn.close()
+    return int(row[0]) if row else 0
+```
+（`_anchor_where`、`sqlite3`、`Path`、`List` 已在 anchors.py 导入。更新 `__all__` 加 `count_anchors`。）
+Run: `uv run pytest tests/unit/test_gem_synth_anchors.py -v` → PASS。
+
+- [ ] **Step 2: 加 status 命令测试到 `tests/unit/test_gem_synth_cli.py`**
+
+```python
+def test_gem_synth_status_shows_counts(tmp_path, monkeypatch):
+    """jfox gem-synth status 显示 pending/success/failed"""
+    from jfox.fragment.store import FragmentStore
+    from jfox.gem_synth.store import SynthesisLog
+    # 造 3 个锚点 + 处理 2 个（1 success 1 failed）→ pending 1
+    fdb = tmp_path / "f.db"
+    FragmentStore(db_path=fdb).insert  # 确保 default_db_path 指向临时
+    # 用环境变量把两个 db 都指向临时
+    monkeypatch.setenv("JFOX_FRAGMENTS_DB", str(fdb))
+    sdb = tmp_path / "syn.db"
+    monkeypatch.setenv("JFOX_SYNTHESIS_DB", str(sdb))
+    store = FragmentStore(db_path=fdb)
+    store.insert("s", "correction", "UserPromptSubmit", "不对", {})
+    store.insert("s", "correction", "UserPromptSubmit", "错了", {})
+    store.insert("s", "correction", "UserPromptSubmit", "应该", {})
+    store.close()
+    log = SynthesisLog(db_path=sdb)
+    log.mark_processed(1, "c1")
+    log.mark_failed(2, "boom")
+    log.close()
+    result = CliRunner().invoke(gem_synth_app, ["status", "--format", "json"])
+    assert result.exit_code == 0
+    import json as _j
+    data = _j.loads(result.output)
+    assert data["pending"] == 1
+    assert data["success"] == 1
+    assert data["failed"] == 1
+```
+
+- [ ] **Step 3: 跑确认失败**
+
+Run: `uv run pytest tests/unit/test_gem_synth_cli.py -v`
+Expected: FAIL（gem_synth_app / status 不存在）
+
+- [ ] **Step 4: 加 gem_synth_app + status 到 `jfox/gem_synth/cli.py`**
+
+Read `jfox/gem_synth/cli.py`（现有 candidates_app + list/show）。在文件末尾加 `gem_synth_app`（新的 Typer 子命令组）+ status 命令：
+
+```python
+gem_synth_app = typer.Typer(
+    name="gem-synth",
+    help="L3 宝石合成进度查看（pending/success/failed + 失败复核）",
+    no_args_is_help=True,
+)
+
+
+@gem_synth_app.command("status")
+def gem_synth_status(
+    failed_only: bool = typer.Option(False, "--failed", help="只列失败锚点（人工复核）"),
+    output_format: str = typer.Option("table", "--format", "-f", help="table, json"),
+) -> None:
+    """查看合成进度：待处理/成功/失败；--failed 列失败锚点"""
+    from .store import SynthesisLog
+    from .anchors import count_anchors
+    from ..global_config import get_gem_config if False else None  # placeholder 删除
+    from jfox.fragment.store import default_db_path
+
+    log = SynthesisLog()
+    try:
+        counts = log.status_counts()
+        success = counts.get("success", 0)
+        failed = counts.get("failed", 0)
+        # 高信号锚点总数 → pending = total - (success + failed)
+        cfg = get_gem_synthesis_config_for_status()
+        total = count_anchors(default_db_path(), anchor_types=cfg.anchor_types)
+        pending = max(0, total - success - failed)
+
+        if failed_only:
+            failed_list = log.list_failed()
+            if output_format == "json":
+                _json_console_print({"failed": failed_list})
+            else:
+                t = Table(title=f"失败锚点（共 {len(failed_list)} 条，人工复核）")
+                for c in ("碎片ID", "失败原因", "时间"):
+                    t.add_column(c)
+                for f in failed_list:
+                    t.add_row(str(f["anchor_fragment_id"]), f["fail_reason"] or "", str(f["synthesized_at"]))
+                console.print(t)
+            return
+
+        if output_format == "json":
+            _json_console_print({"pending": pending, "success": success, "failed": failed, "total": total})
+        else:
+            console.print(f"[bold]合成进度[/bold]")
+            console.print(f"  待处理（pending）:  {pending}")
+            console.print(f"  成功（success）:    {success}")
+            console.print(f"  失败（failed）:     {failed}")
+            if failed:
+                console.print(f"[dim]用 `jfox gem-synth status --failed` 查看失败锚点[/dim]")
+    finally:
+        log.close()
+```
+
+**重要**：上面有两处占位需替换为真实实现（Read cli.py 看 candidates_app 怎么用 `_json_console`/`console`，复用同款；`get_gem_synthesis_config_for_status()` 改为真实取配置）：
+- `_json_console_print` → 复用 cli.py 已有的 `_json_console.print(_json.dumps(...))`（或 candidates_app 里的 typer.echo JSON 模式，**为一致用 candidates_app 同款**）。
+- `get_gem_synthesis_config_for_status()` → `from ..global_config import get_global_config_manager` 然后 `get_global_config_manager().get_gem_synthesis_config()`。`count_anchors` 需要 `cfg.anchor_types`。
+
+**最终 status 命令应该是**（替换上面占位后，无 `if False else None`、无 placeholder）：
+```python
+@gem_synth_app.command("status")
+def gem_synth_status(
+    failed_only: bool = typer.Option(False, "--failed", help="只列失败锚点（人工复核）"),
+    output_format: str = typer.Option("table", "--format", "-f", help="table, json"),
+) -> None:
+    """查看合成进度：待处理/成功/失败；--failed 列失败锚点"""
+    import json as _json_module
+    from .store import SynthesisLog
+    from .anchors import count_anchors
+    from ..global_config import get_global_config_manager
+    from jfox.fragment.store import default_db_path
+
+    cfg = get_global_config_manager().get_gem_synthesis_config()
+    log = SynthesisLog()
+    try:
+        counts = log.status_counts()
+        success = counts.get("success", 0)
+        failed = counts.get("failed", 0)
+        total = count_anchors(default_db_path(), anchor_types=cfg.anchor_types)
+        pending = max(0, total - success - failed)
+
+        if failed_only:
+            failed_list = log.list_failed()
+            if output_format == "json":
+                typer.echo(_json_module.dumps({"failed": failed_list}, ensure_ascii=False, indent=2))
+            else:
+                t = Table(title=f"失败锚点（共 {len(failed_list)} 条，人工复核）")
+                for c in ("碎片ID", "失败原因", "时间"):
+                    t.add_column(c)
+                for f in failed_list:
+                    t.add_row(str(f["anchor_fragment_id"]), f["fail_reason"] or "", str(f["synthesized_at"]))
+                console.print(t)
+            return
+
+        if output_format == "json":
+            typer.echo(_json_module.dumps({"pending": pending, "success": success, "failed": failed, "total": total}, ensure_ascii=False, indent=2))
+        else:
+            console.print("[bold]合成进度[/bold]")
+            console.print(f"  待处理（pending）:  {pending}")
+            console.print(f"  成功（success）:    {success}")
+            console.print(f"  失败（failed）:     {failed}")
+            if failed:
+                console.print("[dim]用 `jfox gem-synth status --failed` 查看失败锚点[/dim]")
+    except Exception as e:
+        if output_format == "json":
+            typer.echo(_json_module.dumps({"success": False, "error": str(e)}, ensure_ascii=False))
+        else:
+            console.print(f"[red]读取合成进度失败：{e}[/red]")
+        raise typer.Exit(code=1)
+    finally:
+        log.close()
+
+
+__all__ = ["candidates_app", "gem_synth_app"]
+```
+（用 `typer.echo` 输出 JSON，与 candidates show 一致，避免 Rich 二次转义。`console`/`Table`/`typer` 已在 cli.py 导入。）
+
+- [ ] **Step 5: 挂载 gem_synth_app 到 `jfox/cli.py`**
+
+在 `candidates_app` 挂载旁边（`from .gem_synth.cli import candidates_app` 那行附近）加：
+```python
+from .gem_synth.cli import gem_synth_app  # noqa: E402
+```
+和
+```python
+app.add_typer(gem_synth_app, name="gem-synth", help="L3 宝石合成进度查看")
+```
+
+- [ ] **Step 6: 跑测试 + 验证挂载**
+
+Run:
+```bash
+uv run pytest tests/unit/test_gem_synth_cli.py tests/unit/test_gem_synth_anchors.py -v
+uv run jfox gem-synth --help
+```
+Expected: 测试 PASS；help 显示 `status` 子命令。
+
+- [ ] **Step 7: 提交**
+
+```bash
+git add jfox/gem_synth/anchors.py jfox/gem_synth/cli.py jfox/cli.py tests/unit/test_gem_synth_cli.py tests/unit/test_gem_synth_anchors.py
+git commit -m "feat(cli): jfox gem-synth status (progress + failed review) + count_anchors
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: 收尾 — 回归 + lint + PR
+
+- [ ] **Step 1: 全部 gem_synth 单测**
+
+Run: `uv run pytest tests/unit/test_gem_synth_store.py tests/unit/test_gem_synth_anchors.py tests/unit/test_gem_synth_synthesizer.py tests/unit/test_gem_synth_loop.py tests/unit/test_gem_synth_cli.py -v`
+Expected: PASS
+
+- [ ] **Step 2: CI lint（jfox/ + tests/ 全量，别再像 #274 漏 tests/）**
+
+Run:
+```bash
+uv run ruff check jfox/ tests/
+uv run black jfox/gem_synth/ jfox/cli.py tests/unit/test_gem_synth_*.py
+```
+
+- [ ] **Step 3: 推送 + 开 PR**
+
+```bash
+git push -u origin feat/283-gem-synth-throttle-ledger
+gh pr create --title "feat(gem-synth): time-budget throttle + synthesis ledger + status (#283)" \
+  --body "实现 #283：① _tick_once 改时间预算循环（串行，interval 窗口自适应，去掉无上限）② synthesis_log 加 status/fail_reason + migration ③ 失败 mark_failed 跳过不重试 ④ jfox gem-synth status（进度 + --failed 捞失败）。设计见 docs/superpowers/specs/2026-06-25-gem-synth-throttle-ledger-design.md。Closes #283。"
+```
+
+---
+
+## Self-Review 结果
+
+**1. Spec 覆盖：**
+- 时间预算限流（§1）→ Task 3 ✅
+- synthesis_log ledger（§2）→ Task 1 ✅
+- 失败标记不重试（§3）→ Task 2 ✅
+- jfox gem-synth status（§4）→ Task 4 ✅
+- schema migration（§5）→ Task 1（_maybe_migrate + test_migration）✅
+- 范围（§6：不做 retry-failed / max_per_tick 计数 / 退避）→ 未含 ✅
+
+**2. 占位符扫描：** Task 4 Step 4 有一个"占位需替换"的中间版本 —— 但紧接给了**最终无占位版本**（用 typer.echo + get_global_config_manager）。实现时用最终版本，忽略中间占位草稿。其余步骤完整代码。
+
+**3. 签名一致性：**
+- `SynthesisLog.mark_failed(anchor_id, fail_reason)` / `status_counts()` / `list_failed()` — Task 1 定义，Task 2/4 调用一致 ✅
+- `synthesize_anchor` 各失败路径调 `log.mark_failed(anchor["fragment_id"], reason)` — Task 2，reason 字符串固定 ✅
+- `find_anchors(limit=1)` — Task 3 调用，anchors.py 已有 limit 参数 ✅
+- `count_anchors(fragments_db, anchor_types)` — Task 4 定义 + 调用一致 ✅
+- `gem_synth_app` / `gem_synth_status` — Task 4 定义，cli.py 挂载一致 ✅

--- a/docs/superpowers/specs/2026-06-25-gem-synth-throttle-ledger-design.md
+++ b/docs/superpowers/specs/2026-06-25-gem-synth-throttle-ledger-design.md
@@ -1,0 +1,174 @@
+# gem_synth 限流 + 合成进度 ledger 设计（Issue #283）
+
+- **关联 Issue**: #283（gem_synth 缺 max_per_tick 限流 + 合成进度 ledger）
+- **前置**: #274（L3 宝石合成，1.2.0）、#261（碎片采集）
+- **父**: #249（Loop Engineering）
+- **日期**: 2026-06-25
+- **状态**: 设计已确认
+
+## 0. 目标
+
+给 L3 gem_synth 循环加三个东西，使其能**安全、可观测地**消化碎片积压：
+1. **时间预算限流** —— 每个 tick（= `interval_minutes` 窗口）串行处理锚点直到时间用完，自适应、429 零风险
+2. **合成 ledger** —— `synthesis_log` 升级为带 status（success/failed）+ fail_reason 的记账表
+3. **失败 = 标记跳过（不重试）** + **`jfox gem-synth status`** 看进度 + 捞失败
+
+**阻塞**：启用 `gem_synthesis.enabled=true` 之前应先解决（当前无上限会一次跑 ~100 调用 + 失败无限重试）。
+
+## 1. 时间预算限流（替代 max_per_tick 计数）
+
+**用户决策**：不用计数上限（`max_per_tick`），改用**时间预算**。每个 tick 串行处理锚点，一直跑到 `interval_minutes`（窗口）用完或无锚点。
+
+**理由**（用户）：
+- 每次合成 ~5min（模型推理 + 整理），30min 窗口自然 ~5-6 个（30÷5），无需硬计数
+- 自适应：合成快就多跑、慢就少跑，填满窗口不浪费
+- 积压时连续跑：tick 跑满 30min → 下个 tick 立即接上（back-to-back）→ 一直跑到清完（过夜连续 ~11h 清 ~107 个）；清完后 tick 空转、30min 巡一次
+- 429 零风险（串行 ~5min/次，~12 次/h）
+
+**实现**（`gem_synth/loop.py _tick_once`）：
+```python
+def _tick_once(stop_event):
+    cfg = reload + get_gem_synthesis_config()
+    if not cfg.enabled: return "disabled"
+    log = SynthesisLog()
+    tick_start = monotonic()
+    success = failed = 0
+    try:
+        while not stop_event.is_set():
+            # 时间预算用完 → 停（留给下个 tick）
+            if monotonic() - tick_start >= cfg.interval_minutes * 60:
+                break
+            anchors = find_anchors(limit=1)   # 取下一个未处理
+            if not anchors: break              # 无积压
+            result = synthesize_anchor(anchors[0], log, cfg, stop_event)
+            if result is not None: success += 1
+            else: failed += 1                  # synthesize_anchor 内部已 mark_failed
+    finally:
+        log.close()
+    return f"本轮 success={success} failed={failed}"
+```
+
+- `interval_minutes`（现有配置，默认 30）即时间预算，**不新增 config**
+- `find_anchors(limit=1)` 每次取一个未处理锚点（含 pending，不含 success/failed）
+- async loop 仍按 `interval_minutes` 调度；tick 跑满则 back-to-back，空转则等满
+
+## 2. synthesis_log → 合成 ledger（扩展现有表）
+
+当前 schema（仅去重）：
+```sql
+CREATE TABLE synthesis_log (
+    anchor_fragment_id  INTEGER PRIMARY KEY,
+    candidate_note_id   TEXT NOT NULL,
+    synthesized_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+**扩展**为带 status + fail_reason：
+```sql
+CREATE TABLE synthesis_log (
+    anchor_fragment_id  INTEGER PRIMARY KEY,
+    candidate_note_id   TEXT,           -- success 时有；failed 时 NULL
+    status              TEXT NOT NULL DEFAULT 'success',  -- success | failed
+    fail_reason         TEXT,           -- failed 时记原因
+    synthesized_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+**Migration**：建表 SQL 加新列；对已存在的表用 `ALTER TABLE ADD COLUMN`（status 默认 'success'，fail_reason NULL）。`SynthesisLog.__init__` 建表时 `CREATE TABLE IF NOT EXISTS` 不触发改列 —— 需要 schema 版本检测 + ALTER 升级（见 §5）。
+
+**`SynthesisLog` 方法变更**：
+- `mark_processed(anchor_id, candidate_note_id)` → 保持（记 success）
+- 新增 `mark_failed(anchor_id, fail_reason)` → 记 status='failed' + fail_reason，candidate_note_id=NULL
+- `is_processed(anchor_id)` → 保持（任意 status 行 = 已处理，不重试）
+- `filter_unprocessed(ids)` → 保持
+- 新增 `status_counts()` → `{success: N, failed: M}`
+- 新增 `list_failed(limit)` → `[{anchor_fragment_id, fail_reason, synthesized_at}]`（供 status 命令捞失败）
+
+## 3. 失败 = 标记跳过（不重试）
+
+**用户决策**：失败**不重试**，直接标记 `failed` + 原因，跳过。用户过夜跑完后人工捞一遍 failed 的。
+
+**改动**（`gem_synth/synthesizer.py synthesize_anchor`）：当前所有失败路径 `return None`（不记账 → 下轮重试）。改为每条失败路径**先 `log.mark_failed(anchor_id, reason)` 再 return None**：
+
+| 失败路径 | fail_reason |
+|---------|-------------|
+| 无 transcript_path | `no transcript_path` |
+| transcript 提取不到上下文（空） | `empty transcript context` |
+| LLM 返 None（解析失败/超时/非 JSON） | `llm failed: {简短原因}` |
+| _save_candidate_note 失败（写盘/构造异常） | `save failed: {e}` |
+
+（synthesize_anchor 内部 try/except 已有；把 mark_failed 接入各路径。成功路径不变：mark_processed。）
+
+**后果**：失败锚点被隔离（不重试、不浪费配额），ledger 可查。偶发 429 也会被标 failed —— 用户接受（人工捞重跑）。**未来**可选加 `jfox gem-synth retry-failed`（清 failed 状态重新入队），本阶段不做（YAGNI）。
+
+## 4. `jfox gem-synth status` 命令
+
+新增 `gem_synth_app`（Typer 子命令组，仿 `auto_summary_app`），挂 `status` 命令：
+
+```bash
+$ jfox gem-synth status
+合成进度：
+  待处理（pending）:  103
+  成功（success）:      2
+  失败（failed）:       2
+
+$ jfox gem-synth status --failed
+失败的锚点（人工复核）：
+  #42  no transcript_path
+  #58  llm failed: 返回非 JSON
+```
+
+- `pending` = 高信号锚点总数（fragments.db 里 correction/decision/AskUserQuestion）− ledger 里已处理（success+failed）
+- `success/failed` 来自 `log.status_counts()`
+- `--failed` 列出 `log.list_failed()`（fragment_id + fail_reason）
+- `--format json` 支持（结构化输出）
+
+**子命令组挂载**：`jfox/cli.py` 加 `from .gem_synth.cli import gem_synth_app` + `app.add_typer(gem_synth_app, name="gem-synth")`（与现有 `candidates_app` 共存于 `gem_synth/cli.py`）。
+
+## 5. Schema 迁移（synthesis_log）
+
+`SynthesisLog.__init__` 现在直接 `CREATE TABLE IF NOT EXISTS`（不改已存在表）。需加**版本化升级**：
+
+```python
+def _maybe_migrate(self):
+    cols = {row["name"] for row in self._conn.execute("PRAGMA table_info(synthesis_log)")}
+    if "status" not in cols:
+        self._conn.execute("ALTER TABLE synthesis_log ADD COLUMN status TEXT NOT NULL DEFAULT 'success'")
+    if "fail_reason" not in cols:
+        self._conn.execute("ALTER TABLE synthesis_log ADD COLUMN fail_reason TEXT")
+    self._conn.commit()
+```
+
+（`__init__` 建表后调 `_maybe_migrate`。新表 schema 直接含 status/fail_reason；旧表 ALTER 升级。简单 robust，无需 schema_version 表。）
+
+## 6. 范围
+
+**本 issue 做：**
+- `_tick_once` 时间预算循环（去掉隐式 limit=100，改 limit=1 + 时间检查）
+- `synthesis_log` 加 status + fail_reason 列 + migration
+- `SynthesisLog.mark_failed` / `status_counts` / `list_failed`
+- `synthesize_anchor` 失败路径全部 mark_failed
+- `jfox gem-synth status`（含 `--failed`、`--format json`）
+
+**不做：**
+- `retry-failed` 命令（YAGNI，用户暂手动捞）
+- max_per_tick 计数（用时间预算替代）
+- 429 退避（失败即标 failed 跳过，不做退避重试）
+- ledger 的 pending 队列表（pending = 算出来的，不持久化）
+
+## 7. 模块改动
+
+| 文件 | 改动 |
+|------|------|
+| `jfox/gem_synth/store.py` | schema 加 status/fail_reason + `_maybe_migrate`；加 `mark_failed`/`status_counts`/`list_failed` |
+| `jfox/gem_synth/synthesizer.py` | 各失败路径 mark_failed；返回值可带 reason |
+| `jfox/gem_synth/loop.py` | `_tick_once` 改时间预算循环（limit=1 + 时间检查） |
+| `jfox/gem_synth/cli.py` | 新增 `gem_synth_app` + `status` 命令（含 `--failed`） |
+| `jfox/cli.py` | 挂载 `gem_synth_app`（name="gem-synth"） |
+
+## 8. 测试
+
+- `store.py`：mark_failed / status_counts / list_failed / migration（旧表升级）—— 纯 SQLite 单测
+- `synthesizer.py`：各失败路径 → mark_failed 被调（mock log）
+- `loop.py`：时间预算循环 —— mock monotonic 验证超时停 + limit=1 逐个 + success/failed 计数
+- `cli.py`：`status` / `status --failed` 输出格式 —— temp KB + ledger

--- a/jfox/cli.py
+++ b/jfox/cli.py
@@ -113,6 +113,11 @@ from .gem_synth.cli import candidates_app  # noqa: E402
 
 app.add_typer(candidates_app, name="candidates", help="查看 L3 合成的候选知识宝石")
 
+# gem-synth 子命令组（查看 L3 合成进度：pending/success/failed + 失败复核）
+from .gem_synth.cli import gem_synth_app  # noqa: E402
+
+app.add_typer(gem_synth_app, name="gem-synth", help="L3 宝石合成进度查看")
+
 console = Console(legacy_windows=False)
 
 

--- a/jfox/gem_synth/anchors.py
+++ b/jfox/gem_synth/anchors.py
@@ -82,4 +82,21 @@ def find_anchors(
     return result
 
 
-__all__ = ["find_anchors"]
+def count_anchors(fragments_db: Path, anchor_types: List[str]) -> int:
+    """高信号锚点总数（不区分是否已处理）—— status 命令算 pending 用。
+
+    复用 _anchor_where 构造 WHERE 子句；空 anchor_types 直接返回 0，
+    避免空 WHERE 拉全表（find_anchors 同样的早退约定）。
+    """
+    where = _anchor_where(anchor_types)
+    if not where:
+        return 0
+    conn = sqlite3.connect(str(fragments_db))
+    try:
+        row = conn.execute(f"SELECT COUNT(*) FROM session_fragments WHERE {where}").fetchone()
+    finally:
+        conn.close()
+    return int(row[0]) if row else 0
+
+
+__all__ = ["find_anchors", "count_anchors"]

--- a/jfox/gem_synth/anchors.py
+++ b/jfox/gem_synth/anchors.py
@@ -21,9 +21,14 @@ def _anchor_where(anchor_types: List[str]) -> str:
     if "ask_user_question" in anchor_types:
         # AskUserQuestion 走 PostToolUse；用 json_extract 精确匹配 tool_name
         # （SQL 层精确 → count_anchors 与 find_anchors 过滤一致；find_anchors 的
-        # Python 二次确认保留为无害冗余检查）
+        # Python 二次确认保留为无害冗余检查）。
+        # CASE WHEN json_valid 守卫：json_extract 对非法 JSON 抛 OperationalError（实测
+        # SQLite 3.45），WHERE 中只要结果集任一行 metadata_json 非法整查询即崩 →
+        # count_anchors(status) 崩 / find_anchors(daemon) 每 tick 抛。json_valid 不抛，
+        # CASE 只在 JSON 合法时才求值 json_extract；历史脏数据/写入中断的非法行被跳过。
         clauses.append(
-            "(source_event = 'PostToolUse' AND json_extract(metadata_json, '$.tool_name') = 'AskUserQuestion')"
+            "(source_event = 'PostToolUse' AND CASE WHEN json_valid(metadata_json) "
+            "THEN json_extract(metadata_json, '$.tool_name') = 'AskUserQuestion' END)"
         )
     return "(" + " OR ".join(clauses) + ")" if clauses else ""
 
@@ -66,7 +71,12 @@ def find_anchors(
     for r in rows:
         if r["fragment_id"] not in unprocessed:
             continue
-        md = json.loads(r["metadata_json"] or "{}")
+        try:
+            md = json.loads(r["metadata_json"] or "{}")
+        except (json.JSONDecodeError, TypeError, ValueError):
+            # 历史脏数据/写入中断的非法 metadata_json（correction/decision 行不走
+            # json_valid 守卫）：降级为空 metadata，不崩整查询（cc R2#1 同类健壮性）
+            md = {}
         # ask_user_question 精确二次确认（避免 LIKE 误命中正文）
         is_ask = md.get("tool_name") == "AskUserQuestion"
         if r["fragment_type"] not in ("correction", "decision") and not is_ask:

--- a/jfox/gem_synth/anchors.py
+++ b/jfox/gem_synth/anchors.py
@@ -19,8 +19,12 @@ def _anchor_where(anchor_types: List[str]) -> str:
     if "decision" in anchor_types:
         clauses.append("fragment_type = 'decision'")
     if "ask_user_question" in anchor_types:
-        # AskUserQuestion 走 PostToolUse；用 metadata_json LIKE 粗筛，Python 里二次确认
-        clauses.append("(source_event = 'PostToolUse' AND metadata_json LIKE '%AskUserQuestion%')")
+        # AskUserQuestion 走 PostToolUse；用 json_extract 精确匹配 tool_name
+        # （SQL 层精确 → count_anchors 与 find_anchors 过滤一致；find_anchors 的
+        # Python 二次确认保留为无害冗余检查）
+        clauses.append(
+            "(source_event = 'PostToolUse' AND json_extract(metadata_json, '$.tool_name') = 'AskUserQuestion')"
+        )
     return "(" + " OR ".join(clauses) + ")" if clauses else ""
 
 

--- a/jfox/gem_synth/cli.py
+++ b/jfox/gem_synth/cli.py
@@ -186,9 +186,10 @@ def gem_synth_status(
     from .anchors import count_anchors
     from .store import SynthesisLog
 
-    cfg = get_global_config_manager().get_gem_synthesis_config()
-    log = SynthesisLog()
+    log = None  # 先声明，finally 安全引用（SynthesisLog 构造失败时仍要 close 守卫）
     try:
+        cfg = get_global_config_manager().get_gem_synthesis_config()
+        log = SynthesisLog()
         counts = log.status_counts()
         success = counts.get("success", 0)
         failed = counts.get("failed", 0)
@@ -230,10 +231,13 @@ def gem_synth_status(
             if failed:
                 console.print("[dim]用 `jfox gem-synth status --failed` 查看失败锚点[/dim]")
     except Exception as e:
+        # 错误响应用 ok（bool），与正常响应里的 success（int 计数）区分，避免语义冲突
         if output_format == "json":
-            typer.echo(_json_module.dumps({"success": False, "error": str(e)}, ensure_ascii=False))
+            typer.echo(_json_module.dumps({"ok": False, "error": str(e)}, ensure_ascii=False))
         else:
             console.print(f"[red]读取合成进度失败：{e}[/red]")
         raise typer.Exit(code=1)
     finally:
-        log.close()
+        # log 可能为 None（构造时抛异常 → 上面 log = SynthesisLog() 未赋值成功）
+        if log is not None:
+            log.close()

--- a/jfox/gem_synth/cli.py
+++ b/jfox/gem_synth/cli.py
@@ -150,4 +150,90 @@ def list_cmd(
         console.print(table)
 
 
-__all__ = ["candidates_app"]
+__all__ = ["candidates_app", "gem_synth_app"]
+
+
+# ---------------------------------------------------------------------------
+# gem-synth status 子命令组：合成进度（pending/success/failed）+ 失败复核
+# ---------------------------------------------------------------------------
+
+gem_synth_app = typer.Typer(
+    name="gem-synth",
+    help="L3 宝石合成进度查看（pending/success/failed + 失败复核）",
+    no_args_is_help=True,
+)
+
+
+# 强制走子命令分发：单命令 Typer app 默认会被压平（直接当成单命令调用），
+# 导致 `gem-synth status` 把 status 当成命令的额外参数。空 callback 让 Typer
+# 始终在命令名这一层先解析，子命令（status 等）才能被识别。
+@gem_synth_app.callback()
+def _gem_synth_callback() -> None:
+    """L3 宝石合成进度查看（子命令分发入口）。"""
+    return None
+
+
+@gem_synth_app.command("status")
+def gem_synth_status(
+    failed_only: bool = typer.Option(False, "--failed", help="只列失败锚点（人工复核）"),
+    output_format: str = typer.Option("table", "--format", "-f", help="table, json"),
+) -> None:
+    """查看合成进度：待处理/成功/失败；--failed 列失败锚点"""
+    import json as _json_module
+
+    from ..fragment.store import default_db_path
+    from ..global_config import get_global_config_manager
+    from .anchors import count_anchors
+    from .store import SynthesisLog
+
+    cfg = get_global_config_manager().get_gem_synthesis_config()
+    log = SynthesisLog()
+    try:
+        counts = log.status_counts()
+        success = counts.get("success", 0)
+        failed = counts.get("failed", 0)
+        total = count_anchors(default_db_path(), anchor_types=cfg.anchor_types)
+        pending = max(0, total - success - failed)
+
+        if failed_only:
+            failed_list = log.list_failed()
+            if output_format == "json":
+                typer.echo(
+                    _json_module.dumps({"failed": failed_list}, ensure_ascii=False, indent=2)
+                )
+            else:
+                t = Table(title=f"失败锚点（共 {len(failed_list)} 条，人工复核）")
+                for c in ("碎片ID", "失败原因", "时间"):
+                    t.add_column(c)
+                for f in failed_list:
+                    t.add_row(
+                        str(f["anchor_fragment_id"]),
+                        f["fail_reason"] or "",
+                        str(f["synthesized_at"]),
+                    )
+                console.print(t)
+            return
+
+        if output_format == "json":
+            typer.echo(
+                _json_module.dumps(
+                    {"pending": pending, "success": success, "failed": failed, "total": total},
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+        else:
+            console.print("[bold]合成进度[/bold]")
+            console.print(f"  待处理（pending）:  {pending}")
+            console.print(f"  成功（success）:    {success}")
+            console.print(f"  失败（failed）:     {failed}")
+            if failed:
+                console.print("[dim]用 `jfox gem-synth status --failed` 查看失败锚点[/dim]")
+    except Exception as e:
+        if output_format == "json":
+            typer.echo(_json_module.dumps({"success": False, "error": str(e)}, ensure_ascii=False))
+        else:
+            console.print(f"[red]读取合成进度失败：{e}[/red]")
+        raise typer.Exit(code=1)
+    finally:
+        log.close()

--- a/jfox/gem_synth/loop.py
+++ b/jfox/gem_synth/loop.py
@@ -40,6 +40,7 @@ def _tick_once(stop_event: threading.Event) -> str:
     budget_seconds = cfg.interval_minutes * 60
     success = 0
     failed = 0
+    find_error = False  # find_anchors 抛异常 → 与"无锚点"区分（return msg 不同）
     try:
         # 整轮只切一次 KB（避免每锚点 use_kb → _reset_singletons 重载模型）
         with use_kb(cfg.target_kb):
@@ -56,13 +57,12 @@ def _tick_once(stop_event: threading.Event) -> str:
                     )
                 except Exception as e:
                     logger.exception("gem-synth 找锚点失败: %s", e)
+                    find_error = True
                     break
                 if not anchors:
                     break  # 无积压
                 try:
-                    result = synthesize_anchor(
-                        anchors[0], log=log, cfg=cfg, stop_event=stop_event
-                    )
+                    result = synthesize_anchor(anchors[0], log=log, cfg=cfg, stop_event=stop_event)
                     if result is not None:
                         success += 1
                     else:
@@ -71,9 +71,16 @@ def _tick_once(stop_event: threading.Event) -> str:
                     logger.exception(
                         "gem-synth 合成锚点 #%s 异常: %s", anchors[0].get("fragment_id"), e
                     )
+                    # 防止抛异常的锚点被反复取回 busy-loop：mark_failed 隔离它
+                    try:
+                        log.mark_failed(anchors[0]["fragment_id"], f"unhandled: {e}")
+                    except Exception:
+                        pass
                     failed += 1
     finally:
         log.close()
+    if find_error:
+        return f"find_anchors 异常提前终止（已处理 success={success} failed={failed}）"
     return f"本轮 success={success} failed={failed}（预算 {cfg.interval_minutes}min）"
 
 

--- a/jfox/gem_synth/loop.py
+++ b/jfox/gem_synth/loop.py
@@ -74,8 +74,14 @@ def _tick_once(stop_event: threading.Event) -> str:
                     # 防止抛异常的锚点被反复取回 busy-loop：mark_failed 隔离它
                     try:
                         log.mark_failed(anchors[0]["fragment_id"], f"unhandled: {e}")
-                    except Exception:
-                        pass
+                    except Exception as me:
+                        # mark_failed 自身失败（database locked / disk full / conn closed）
+                        # → busy-loop 防护实际未生效。记 warning 便于排查，不再静默吞（cc R2#2）
+                        logger.warning(
+                            "gem-synth mark_failed 失败，锚点 #%s 可能被重试: %s",
+                            anchors[0].get("fragment_id"),
+                            me,
+                        )
                     failed += 1
     finally:
         log.close()

--- a/jfox/gem_synth/loop.py
+++ b/jfox/gem_synth/loop.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
+import time
 
 from ..config import use_kb
 from ..global_config import get_global_config_manager
@@ -21,54 +22,59 @@ logger = logging.getLogger(__name__)
 
 
 def _tick_once(stop_event: threading.Event) -> str:
-    """同步执行一轮：找未处理锚点 → 逐个合成。返回简短日志行。"""
+    """同步执行一轮：时间预算内逐个合成锚点。
+
+    每轮跑 cfg.interval_minutes（窗口），串行处理（一次取一个未处理锚点），
+    直到窗口用完或无锚点。窗口跑满则下个 tick 立即接上 → 积压时连续跑。
+    """
     gm = get_global_config_manager()
     gm.reload()
     cfg = gm.get_gem_synthesis_config()
     if not cfg.enabled:
         return "gem-synth 已禁用，跳过本轮"
 
+    from jfox.fragment.store import default_db_path
+
     log = SynthesisLog()
+    tick_start = time.monotonic()
+    budget_seconds = cfg.interval_minutes * 60
+    success = 0
+    failed = 0
     try:
-        try:
-            from jfox.fragment.store import default_db_path
-
-            anchors = find_anchors(
-                fragments_db=default_db_path(),
-                log=log,
-                anchor_types=cfg.anchor_types,
-            )
-        except Exception as e:
-            logger.exception("gem-synth 找锚点失败: %s", e)
-            return f"找锚点异常: {e}"
-
-        if not anchors:
-            return "无待合成锚点"
-
-        success = 0
-        # 整轮只切一次 KB，避免每锚点都 use_kb → _reset_singletons 重载 embedding 模型
-        # （use_kb(None) 会早退出，target_kb 未设时无副作用）
+        # 整轮只切一次 KB（避免每锚点 use_kb → _reset_singletons 重载模型）
         with use_kb(cfg.target_kb):
-            for anchor in anchors:
-                if stop_event.is_set():
+            while not stop_event.is_set():
+                # 时间预算用完 → 停，留给下个 tick（back-to-back 连续跑）
+                if time.monotonic() - tick_start >= budget_seconds:
                     break
                 try:
-                    result = synthesize_anchor(
-                        anchor,
+                    anchors = find_anchors(
+                        fragments_db=default_db_path(),
                         log=log,
-                        cfg=cfg,
-                        stop_event=stop_event,
+                        anchor_types=cfg.anchor_types,
+                        limit=1,  # 一次取一个，配合时间预算
+                    )
+                except Exception as e:
+                    logger.exception("gem-synth 找锚点失败: %s", e)
+                    break
+                if not anchors:
+                    break  # 无积压
+                try:
+                    result = synthesize_anchor(
+                        anchors[0], log=log, cfg=cfg, stop_event=stop_event
                     )
                     if result is not None:
                         success += 1
+                    else:
+                        failed += 1
                 except Exception as e:
                     logger.exception(
-                        "gem-synth 合成锚点 #%s 异常: %s", anchor.get("fragment_id"), e
+                        "gem-synth 合成锚点 #%s 异常: %s", anchors[0].get("fragment_id"), e
                     )
-
-        return f"待合成 {len(anchors)}, 成功 {success}"
+                    failed += 1
     finally:
         log.close()
+    return f"本轮 success={success} failed={failed}（预算 {cfg.interval_minutes}min）"
 
 
 async def gem_synth_loop(stop_event: threading.Event, interval_minutes: int = 30) -> None:

--- a/jfox/gem_synth/store.py
+++ b/jfox/gem_synth/store.py
@@ -10,7 +10,9 @@ from .paths import default_synthesis_db_path
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS synthesis_log (
     anchor_fragment_id  INTEGER PRIMARY KEY,
-    candidate_note_id   TEXT NOT NULL,
+    candidate_note_id   TEXT,
+    status              TEXT NOT NULL DEFAULT 'success',
+    fail_reason         TEXT,
     synthesized_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 """
@@ -25,11 +27,26 @@ class SynthesisLog:
         # 同一进程内多线程读写的锁（sqlite3 连接默认 check_same_thread=True）
         self._lock = threading.Lock()
         self._conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
+        # row_factory=Row 让结果行可用 r["col"] 访问；旧代码用 r[0] 仍兼容
+        self._conn.row_factory = sqlite3.Row
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA synchronous=NORMAL")
         self._conn.executescript(_SCHEMA)
         self._conn.commit()
+        self._maybe_migrate()
         self._closed: bool = False
+
+    def _maybe_migrate(self) -> None:
+        """旧表升级：补 status / fail_reason 列（1.2.0 前的表没有）。新表已含，跳过。"""
+        # PRAGMA table_info 行：cid, name, type, notnull, dflt_value, pk → name 在第 1 列
+        cols = {row[1] for row in self._conn.execute("PRAGMA table_info(synthesis_log)")}
+        if "status" not in cols:
+            self._conn.execute(
+                "ALTER TABLE synthesis_log ADD COLUMN status TEXT NOT NULL DEFAULT 'success'"
+            )
+        if "fail_reason" not in cols:
+            self._conn.execute("ALTER TABLE synthesis_log ADD COLUMN fail_reason TEXT")
+        self._conn.commit()
 
     def is_processed(self, anchor_fragment_id: int) -> bool:
         with self._lock:
@@ -56,10 +73,49 @@ class SynthesisLog:
         with self._lock:
             self._conn.execute(
                 "INSERT OR REPLACE INTO synthesis_log "
-                "(anchor_fragment_id, candidate_note_id) VALUES (?, ?)",
+                "(anchor_fragment_id, candidate_note_id, status) VALUES (?, ?, 'success')",
                 (anchor_fragment_id, candidate_note_id),
             )
             self._conn.commit()
+
+    def mark_failed(self, anchor_fragment_id: int, fail_reason: str) -> None:
+        """失败锚点记账：status='failed' + 原因，candidate_note_id 留空。
+        记账后 is_processed 为 True → 不再重试（过夜跑不 thrash）。
+        """
+        with self._lock:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO synthesis_log "
+                "(anchor_fragment_id, candidate_note_id, status, fail_reason) "
+                "VALUES (?, '', 'failed', ?)",
+                (anchor_fragment_id, fail_reason),
+            )
+            self._conn.commit()
+
+    def status_counts(self) -> dict:
+        """返回 {status: count}，如 {'success': 3, 'failed': 1}。"""
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT status, COUNT(*) AS n FROM synthesis_log GROUP BY status"
+            ).fetchall()
+        return {r["status"]: int(r["n"]) for r in rows}
+
+    def list_failed(self, limit: int = 100) -> List[dict]:
+        """返回失败锚点列表（最新在前），供 status --failed 人工复核。"""
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT anchor_fragment_id, fail_reason, synthesized_at "
+                "FROM synthesis_log WHERE status = 'failed' "
+                "ORDER BY synthesized_at DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        return [
+            {
+                "anchor_fragment_id": r["anchor_fragment_id"],
+                "fail_reason": r["fail_reason"],
+                "synthesized_at": r["synthesized_at"],
+            }
+            for r in rows
+        ]
 
     def close(self) -> None:
         with self._lock:

--- a/jfox/gem_synth/store.py
+++ b/jfox/gem_synth/store.py
@@ -37,15 +37,28 @@ class SynthesisLog:
         self._closed: bool = False
 
     def _maybe_migrate(self) -> None:
-        """旧表升级：补 status / fail_reason 列（1.2.0 前的表没有）。新表已含，跳过。"""
+        """旧表升级：补 status / fail_reason 列（1.2.0 前的表没有）。新表已含，跳过。
+
+        每个 ALTER 都包 try/except：daemon 与 status CLI 可能同时迁移同一库，
+        PRAGMA 看到列不存在 → 两进程都尝试 ALTER → 后者拿到 "duplicate column name"。
+        该错误视为已迁移完成（幂等），其余异常向上抛。
+        """
         # PRAGMA table_info 行：cid, name, type, notnull, dflt_value, pk → name 在第 1 列
         cols = {row[1] for row in self._conn.execute("PRAGMA table_info(synthesis_log)")}
         if "status" not in cols:
-            self._conn.execute(
-                "ALTER TABLE synthesis_log ADD COLUMN status TEXT NOT NULL DEFAULT 'success'"
-            )
+            try:
+                self._conn.execute(
+                    "ALTER TABLE synthesis_log ADD COLUMN status TEXT NOT NULL DEFAULT 'success'"
+                )
+            except Exception as e:
+                if "duplicate column" not in str(e).lower():
+                    raise
         if "fail_reason" not in cols:
-            self._conn.execute("ALTER TABLE synthesis_log ADD COLUMN fail_reason TEXT")
+            try:
+                self._conn.execute("ALTER TABLE synthesis_log ADD COLUMN fail_reason TEXT")
+            except Exception as e:
+                if "duplicate column" not in str(e).lower():
+                    raise
         self._conn.commit()
 
     def is_processed(self, anchor_fragment_id: int) -> bool:

--- a/jfox/gem_synth/synthesizer.py
+++ b/jfox/gem_synth/synthesizer.py
@@ -114,23 +114,26 @@ def synthesize_anchor(
     """合成单个锚点。成功返回 {candidate_note_id, title, confidence}，跳过/失败返回 None。
 
     流程：
-      1. 无 transcript_path → 跳过
-      2. extract_turn_around 抽不到上下文 → 跳过
+      1. 无 transcript_path → mark_failed 记账（不重试）
+      2. extract_turn_around 抽不到上下文 → mark_failed 记账（不重试）
       3. fetch_grounding 检索 permanent 基准
-      4. synthesize_with_llm 调 LLM；None → 跳过（不记账，下轮重试）
+      4. synthesize_with_llm 调 LLM；None → mark_failed 记账（不重试）
       5. _save_candidate_note 落盘 + log.mark_processed 记账
 
+    每条失败路径都调 log.mark_failed，使 daemon 过夜跑不会对坏锚点无限重试。
     stop_event 透传给 synthesize_with_llm → _invoke_claude，使 daemon shutdown /
     任务中断能在 claude 调用进行中触发（而非等满 timeout）。
     """
     transcript_path = anchor.get("transcript_path")
     if not transcript_path:
-        logger.info("锚点 #%s 无 transcript_path，跳过", anchor["fragment_id"])
+        logger.info("锚点 #%s 无 transcript_path，mark_failed", anchor["fragment_id"])
+        log.mark_failed(anchor["fragment_id"], "no transcript_path")
         return None
 
     turn = extract_turn_around(Path(transcript_path), anchor.get("content") or "")
     if not turn.strip():
-        logger.info("锚点 #%s 提取不到上下文，跳过", anchor["fragment_id"])
+        logger.info("锚点 #%s 提取不到上下文，mark_failed", anchor["fragment_id"])
+        log.mark_failed(anchor["fragment_id"], "empty transcript context")
         return None
 
     grounding = fetch_grounding(anchor.get("content") or "", top_k=cfg.grounding_top_k)
@@ -140,13 +143,15 @@ def synthesize_anchor(
     )
     if llm_result is None:
         logger.info(
-            "锚点 #%s LLM 合成失败/无效，跳过（不记账，下轮重试）",
+            "锚点 #%s LLM 合成失败/无效，mark_failed（不重试）",
             anchor["fragment_id"],
         )
+        log.mark_failed(anchor["fragment_id"], "llm synthesis failed")
         return None
 
     note_id = _save_candidate_note(llm_result, anchor)
     if note_id is None:
+        log.mark_failed(anchor["fragment_id"], "save candidate note failed")
         return None
 
     log.mark_processed(anchor_fragment_id=anchor["fragment_id"], candidate_note_id=note_id)

--- a/tests/unit/test_gem_synth_anchors.py
+++ b/tests/unit/test_gem_synth_anchors.py
@@ -1,7 +1,7 @@
 """锚点查询：从 fragments.db 取高信号未处理锚点。"""
 
 from jfox.fragment.store import FragmentStore
-from jfox.gem_synth.anchors import find_anchors
+from jfox.gem_synth.anchors import count_anchors, find_anchors
 from jfox.gem_synth.store import SynthesisLog
 
 
@@ -67,3 +67,27 @@ def test_find_anchors_has_transcript_path(tmp_path):
         fragments_db=tmp_path / "fragments.db", log=log, anchor_types=["correction"]
     )
     assert any(a.get("transcript_path") for a in anchors)
+
+
+def test_count_anchors(tmp_path):
+    """count_anchors 返回锚点总数（不区分是否已处理）。"""
+    store = FragmentStore(db_path=tmp_path / "f.db")
+    store.insert("s1", "correction", "UserPromptSubmit", "不对", {})
+    store.insert("s1", "decision", "UserPromptSubmit", "我决定", {})
+    store.insert("s1", "user_input", "UserPromptSubmit", "hi", {})  # 非锚点
+    store.close()
+    log = SynthesisLog(db_path=tmp_path / "syn.db")
+    n = count_anchors(
+        fragments_db=tmp_path / "f.db",
+        anchor_types=["correction", "decision", "ask_user_question"],
+    )
+    assert n == 2
+    log.close()
+
+
+def test_count_anchors_empty_anchor_types(tmp_path):
+    """空 anchor_types 应回退为 0，不发 SQL（避免空 WHERE 拉全表）。"""
+    store = FragmentStore(db_path=tmp_path / "f.db")
+    store.insert("s1", "correction", "UserPromptSubmit", "不对", {})
+    store.close()
+    assert count_anchors(fragments_db=tmp_path / "f.db", anchor_types=[]) == 0

--- a/tests/unit/test_gem_synth_anchors.py
+++ b/tests/unit/test_gem_synth_anchors.py
@@ -1,8 +1,21 @@
 """锚点查询：从 fragments.db 取高信号未处理锚点。"""
 
+import sqlite3
+
 from jfox.fragment.store import FragmentStore
 from jfox.gem_synth.anchors import count_anchors, find_anchors
 from jfox.gem_synth.store import SynthesisLog
+
+
+def _corrupt_metadata(db_path, fragment_id, bad_value="this is NOT valid json"):
+    """直接把某行的 metadata_json 改成非法 JSON（模拟历史脏数据/写入中断）。"""
+    con = sqlite3.connect(str(db_path))
+    con.execute(
+        "UPDATE session_fragments SET metadata_json = ? WHERE fragment_id = ?",
+        (bad_value, fragment_id),
+    )
+    con.commit()
+    con.close()
 
 
 def _seed_fragments(tmp_path):
@@ -91,3 +104,53 @@ def test_count_anchors_empty_anchor_types(tmp_path):
     store.insert("s1", "correction", "UserPromptSubmit", "不对", {})
     store.close()
     assert count_anchors(fragments_db=tmp_path / "f.db", anchor_types=[]) == 0
+
+
+def test_find_anchors_tolerates_malformed_metadata_json(tmp_path):
+    """session_fragments 含非法 JSON 的 metadata_json 行时，find_anchors/count_anchors
+    都不应崩——坏行跳过、合法 ask_user_question 照常返回/计数。
+
+    回归 cc R2#1：ask_user_question 筛选从 LIKE 改 json_extract 后，json_extract 对非法
+    JSON 抛 OperationalError，WHERE 中任一行非法即整查询崩 → status 崩 / daemon 静默阻塞。
+    """
+    store = FragmentStore(db_path=tmp_path / "fragments.db")
+    ask = store.insert(
+        "s1", "user_input", "PostToolUse", "AskUserQuestion", {"tool_name": "AskUserQuestion"}
+    )
+    bad_ask = store.insert("s1", "user_input", "PostToolUse", "x", {"tool_name": "AskUserQuestion"})
+    store.close()
+    _corrupt_metadata(tmp_path / "fragments.db", bad_ask)
+
+    log = SynthesisLog(db_path=tmp_path / "syn.db")
+    # find_anchors 不应抛 OperationalError；坏行跳过，合法 ask 返回
+    ids = [
+        a["fragment_id"]
+        for a in find_anchors(
+            fragments_db=tmp_path / "fragments.db", log=log, anchor_types=["ask_user_question"]
+        )
+    ]
+    assert ask in ids
+    assert bad_ask not in ids
+    # count_anchors 也不应抛（status 命令用）
+    assert count_anchors(tmp_path / "fragments.db", ["ask_user_question"]) == 1
+    log.close()
+
+
+def test_find_anchors_tolerates_malformed_metadata_on_correction(tmp_path):
+    """correction 行的 metadata_json 非法时，find_anchors 不应崩（json.loads 降级 {}）。
+
+    correction/decision 行不走 json_valid 守卫（按 fragment_type 选），故 line 69 的
+    json.loads 需独立容忍，否则坏 metadata 同样让整查询崩。
+    """
+    store = FragmentStore(db_path=tmp_path / "fragments.db")
+    corr = store.insert("s1", "correction", "UserPromptSubmit", "不对", {"ok": 1})
+    store.close()
+    _corrupt_metadata(tmp_path / "fragments.db", corr, bad_value="bad json")
+
+    log = SynthesisLog(db_path=tmp_path / "syn.db")
+    # 不应抛 json.JSONDecodeError；降级 {} 后 correction 仍返回（transcript_path=None）
+    anchors = find_anchors(
+        fragments_db=tmp_path / "fragments.db", log=log, anchor_types=["correction"]
+    )
+    assert corr in [a["fragment_id"] for a in anchors]
+    log.close()

--- a/tests/unit/test_gem_synth_cli.py
+++ b/tests/unit/test_gem_synth_cli.py
@@ -147,3 +147,97 @@ def test_list_json_error_structure():
         assert "boom-for-test" in data["error"]
     finally:
         note_mod.list_notes = orig_list_notes
+
+
+# ----------------------------------------------------------------------------
+# jfox gem-synth status 命令（进度 pending/success/failed + 失败复核）
+# ----------------------------------------------------------------------------
+
+
+def test_gem_synth_status_shows_counts(tmp_path, monkeypatch):
+    """jfox gem-synth status 显示 pending/success/failed。
+
+    通过 JFOX_FRAGMENTS_DB / JFOX_SYNTHESIS_DB 环境变量隔离测试 DB。
+    """
+    from jfox.fragment.store import FragmentStore
+    from jfox.gem_synth.cli import gem_synth_app
+    from jfox.gem_synth.store import SynthesisLog
+
+    fdb = tmp_path / "f.db"
+    sdb = tmp_path / "syn.db"
+    monkeypatch.setenv("JFOX_FRAGMENTS_DB", str(fdb))
+    monkeypatch.setenv("JFOX_SYNTHESIS_DB", str(sdb))
+
+    store = FragmentStore(db_path=fdb)
+    store.insert("s", "correction", "UserPromptSubmit", "不对", {})
+    store.insert("s", "correction", "UserPromptSubmit", "错了", {})
+    store.insert("s", "correction", "UserPromptSubmit", "应该", {})
+    store.close()
+
+    log = SynthesisLog(db_path=sdb)
+    log.mark_processed(1, "c1")
+    log.mark_failed(2, "boom")
+    log.close()
+
+    result = CliRunner().invoke(gem_synth_app, ["status", "--format", "json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["pending"] == 1
+    assert data["success"] == 1
+    assert data["failed"] == 1
+
+
+def test_gem_synth_status_table_runs(tmp_path, monkeypatch):
+    """status 默认 table 输出应 exit 0 不崩（空库场景）。"""
+    from jfox.gem_synth.cli import gem_synth_app
+
+    fdb = tmp_path / "f.db"
+    sdb = tmp_path / "syn.db"
+    monkeypatch.setenv("JFOX_FRAGMENTS_DB", str(fdb))
+    monkeypatch.setenv("JFOX_SYNTHESIS_DB", str(sdb))
+
+    # 触发 default_db_path() 建表（count_anchors 否则要 fragments 表存在）
+    from jfox.fragment.store import FragmentStore
+
+    store = FragmentStore(db_path=fdb)
+    store.close()
+
+    result = CliRunner().invoke(gem_synth_app, ["status"])
+    assert result.exit_code == 0
+    assert "合成进度" in result.output
+
+
+def test_gem_synth_status_failed_only(tmp_path, monkeypatch):
+    """status --failed 应列失败锚点（json）。"""
+    from jfox.fragment.store import FragmentStore
+    from jfox.gem_synth.cli import gem_synth_app
+    from jfox.gem_synth.store import SynthesisLog
+
+    fdb = tmp_path / "f.db"
+    sdb = tmp_path / "syn.db"
+    monkeypatch.setenv("JFOX_FRAGMENTS_DB", str(fdb))
+    monkeypatch.setenv("JFOX_SYNTHESIS_DB", str(sdb))
+
+    store = FragmentStore(db_path=fdb)
+    store.insert("s", "correction", "UserPromptSubmit", "不对", {})
+    store.close()
+
+    log = SynthesisLog(db_path=sdb)
+    log.mark_failed(1, "boom")
+    log.close()
+
+    result = CliRunner().invoke(gem_synth_app, ["status", "--failed", "--format", "json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert len(data["failed"]) == 1
+    assert data["failed"][0]["anchor_fragment_id"] == 1
+    assert data["failed"][0]["fail_reason"] == "boom"
+
+
+def test_gem_synth_status_help_lists_command():
+    """gem_synth_app --help 应列出 status 子命令。"""
+    from jfox.gem_synth.cli import gem_synth_app
+
+    result = CliRunner().invoke(gem_synth_app, ["--help"])
+    assert result.exit_code == 0
+    assert "status" in result.output

--- a/tests/unit/test_gem_synth_loop.py
+++ b/tests/unit/test_gem_synth_loop.py
@@ -94,7 +94,7 @@ def test_tick_time_budget_stops_immediately_when_zero():
     }
     with (
         patch("jfox.gem_synth.loop.get_global_config_manager") as gm,
-        patch("jfox.gem_synth.loop.find_anchors", return_value=[fake_anchor]) as fa,
+        patch("jfox.gem_synth.loop.find_anchors", return_value=[fake_anchor]),
         patch(
             "jfox.gem_synth.loop.synthesize_anchor",
             return_value={"candidate_note_id": "c1"},

--- a/tests/unit/test_gem_synth_loop.py
+++ b/tests/unit/test_gem_synth_loop.py
@@ -21,21 +21,19 @@ def test_tick_enabled_processes_anchors():
     cfg.anchor_types = ["correction"]
     cfg.grounding_top_k = 5
     cfg.target_kb = None
+    cfg.interval_minutes = 30
+    anchor = {
+        "fragment_id": 1,
+        "session_id": "s",
+        "timestamp": "t",
+        "content": "c",
+        "transcript_path": "/x",
+        "metadata": {},
+    }
+    # limit=1 循环：第一次返回一个锚点，第二次返回空（无积压）
     with (
         patch("jfox.gem_synth.loop.get_global_config_manager") as gm,
-        patch(
-            "jfox.gem_synth.loop.find_anchors",
-            return_value=[
-                {
-                    "fragment_id": 1,
-                    "session_id": "s",
-                    "timestamp": "t",
-                    "content": "c",
-                    "transcript_path": "/x",
-                    "metadata": {},
-                }
-            ],
-        ),
+        patch("jfox.gem_synth.loop.find_anchors", side_effect=[[anchor], []]),
         patch(
             "jfox.gem_synth.loop.synthesize_anchor",
             return_value={"candidate_note_id": "c1", "title": "T", "confidence": 0.8},
@@ -43,7 +41,7 @@ def test_tick_enabled_processes_anchors():
     ):
         gm.return_value.get_gem_synthesis_config.return_value = cfg
         msg = _tick_once(threading.Event())
-    assert "1" in msg  # 处理了 1 个
+    assert "success=1" in msg  # 处理了 1 个
     sa.assert_called_once()
 
 
@@ -53,23 +51,95 @@ def test_tick_synthesize_exception_does_not_crash():
     cfg.anchor_types = ["correction"]
     cfg.grounding_top_k = 5
     cfg.target_kb = None
+    cfg.interval_minutes = 30
+    # limit=1 循环：第一次返回一个锚点，之后返回空（避免无限重试同一锚点）
+    anchor_once = [
+        {
+            "fragment_id": 1,
+            "session_id": "s",
+            "timestamp": "t",
+            "content": "c",
+            "transcript_path": "/x",
+            "metadata": {},
+        }
+    ]
     with (
         patch("jfox.gem_synth.loop.get_global_config_manager") as gm,
         patch(
             "jfox.gem_synth.loop.find_anchors",
-            return_value=[
-                {
-                    "fragment_id": 1,
-                    "session_id": "s",
-                    "timestamp": "t",
-                    "content": "c",
-                    "transcript_path": "/x",
-                    "metadata": {},
-                }
-            ],
+            side_effect=[anchor_once, []],
         ),
         patch("jfox.gem_synth.loop.synthesize_anchor", side_effect=RuntimeError("boom")),
     ):
         gm.return_value.get_gem_synthesis_config.return_value = cfg
         msg = _tick_once(threading.Event())  # 不应抛
     assert isinstance(msg, str)
+
+
+def test_tick_time_budget_stops_immediately_when_zero():
+    """interval_minutes=0 → 预算 0，不处理任何锚点（时间检查在合成前）"""
+    cfg = MagicMock()
+    cfg.enabled = True
+    cfg.anchor_types = ["correction"]
+    cfg.grounding_top_k = 5
+    cfg.target_kb = None
+    cfg.interval_minutes = 0  # 预算 0
+    fake_anchor = {
+        "fragment_id": 1,
+        "session_id": "s",
+        "timestamp": "t",
+        "content": "c",
+        "transcript_path": "/x",
+        "metadata": {},
+    }
+    with (
+        patch("jfox.gem_synth.loop.get_global_config_manager") as gm,
+        patch("jfox.gem_synth.loop.find_anchors", return_value=[fake_anchor]) as fa,
+        patch(
+            "jfox.gem_synth.loop.synthesize_anchor",
+            return_value={"candidate_note_id": "c1"},
+        ) as sa,
+    ):
+        gm.return_value.get_gem_synthesis_config.return_value = cfg
+        msg = _tick_once(threading.Event())
+    sa.assert_not_called()  # 预算 0 → 一个都不处理
+    assert isinstance(msg, str)
+
+
+def test_tick_processes_one_at_a_time_until_empty():
+    """预算内逐个处理（limit=1），直到无锚点"""
+    cfg = MagicMock()
+    cfg.enabled = True
+    cfg.anchor_types = ["correction"]
+    cfg.grounding_top_k = 5
+    cfg.target_kb = None
+    cfg.interval_minutes = 30  # 充足预算
+    call_count = {"n": 0}
+
+    def fake_find(*a, **k):
+        call_count["n"] += 1
+        # 前 2 次返回锚点，第 3 次返回空（无积压）
+        if call_count["n"] <= 2:
+            return [
+                {
+                    "fragment_id": call_count["n"],
+                    "session_id": "s",
+                    "timestamp": "t",
+                    "content": "c",
+                    "transcript_path": "/x",
+                    "metadata": {},
+                }
+            ]
+        return []
+
+    with (
+        patch("jfox.gem_synth.loop.get_global_config_manager") as gm,
+        patch("jfox.gem_synth.loop.find_anchors", side_effect=fake_find),
+        patch(
+            "jfox.gem_synth.loop.synthesize_anchor",
+            return_value={"candidate_note_id": "c"},
+        ),
+    ):
+        gm.return_value.get_gem_synthesis_config.return_value = cfg
+        msg = _tick_once(threading.Event())
+    assert "success=2" in msg

--- a/tests/unit/test_gem_synth_loop.py
+++ b/tests/unit/test_gem_synth_loop.py
@@ -1,5 +1,7 @@
 """gem_synth 循环：_tick_once 编排（mock 各组件）。"""
 
+import logging
+import sqlite3
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -143,6 +145,59 @@ def test_tick_find_anchors_exception_distinct_message():
         msg = _tick_once(threading.Event())
     assert "find_anchors" in msg
     assert "异常" in msg
+
+
+def test_tick_mark_failed_failure_logs_warning(caplog):
+    """mark_failed 自身失败时不应静默吞 → 记 warning 便于排查（cc R2#2）。
+
+    mark_failed 持续失败会让 busy-loop 防护静默失效且无日志。修复：except 记 warning。
+    """
+    from jfox.gem_synth.loop import _tick_once
+
+    cfg = MagicMock(
+        enabled=True,
+        anchor_types=["correction"],
+        grounding_top_k=5,
+        target_kb=None,
+        interval_minutes=30,
+    )
+    mock_log = MagicMock()
+    # mark_failed 自身抛（database locked / disk full 等）
+    mock_log.mark_failed = MagicMock(side_effect=sqlite3.OperationalError("database is locked"))
+    call_count = {"n": 0}
+
+    def fake_find(*a, **k):
+        call_count["n"] += 1
+        # 第1次返回锚点（触发 synthesize_anchor 抛异常 → 进 mark_failed 失败路径），之后空
+        return (
+            [
+                {
+                    "fragment_id": 7,
+                    "session_id": "s",
+                    "timestamp": "t",
+                    "content": "c",
+                    "transcript_path": "/x",
+                    "metadata": {},
+                }
+            ]
+            if call_count["n"] == 1
+            else []
+        )
+
+    with (
+        patch("jfox.gem_synth.loop.get_global_config_manager") as gm,
+        patch("jfox.gem_synth.loop.find_anchors", side_effect=fake_find),
+        patch("jfox.gem_synth.loop.synthesize_anchor", side_effect=RuntimeError("boom")),
+        patch("jfox.gem_synth.loop.SynthesisLog", return_value=mock_log),
+    ):
+        gm.return_value.get_gem_synthesis_config.return_value = cfg
+        with caplog.at_level(logging.WARNING, logger="jfox.gem_synth.loop"):
+            msg = _tick_once(threading.Event())
+    # mark_failed 被尝试调用（隔离坏锚点）
+    mock_log.mark_failed.assert_called()
+    # 失败被记 warning（不再静默吞）
+    assert any("mark_failed" in r.message for r in caplog.records)
+    assert "failed=1" in msg
 
 
 def test_tick_time_budget_stops_immediately_when_zero():

--- a/tests/unit/test_gem_synth_loop.py
+++ b/tests/unit/test_gem_synth_loop.py
@@ -76,6 +76,75 @@ def test_tick_synthesize_exception_does_not_crash():
     assert isinstance(msg, str)
 
 
+def test_tick_exception_marks_failed_no_busy_loop():
+    """synthesize_anchor 抛异常时，loop 必须 mark_failed 隔离坏锚点（不 busy-loop）"""
+    from jfox.gem_synth.loop import _tick_once
+
+    cfg = MagicMock(
+        enabled=True,
+        anchor_types=["correction"],
+        grounding_top_k=5,
+        target_kb=None,
+        interval_minutes=30,
+    )
+    call_count = {"n": 0}
+
+    def fake_find(*a, **k):
+        call_count["n"] += 1
+        # 第1次返回锚点，第2次+返回空（若没 mark_failed 会一直返回同一锚点 → 死循环）
+        return (
+            [
+                {
+                    "fragment_id": 99,
+                    "session_id": "s",
+                    "timestamp": "t",
+                    "content": "c",
+                    "transcript_path": "/x",
+                    "metadata": {},
+                }
+            ]
+            if call_count["n"] == 1
+            else []
+        )
+
+    mock_log = MagicMock()
+    mock_log.mark_failed = MagicMock()
+    with (
+        patch("jfox.gem_synth.loop.get_global_config_manager") as gm,
+        patch("jfox.gem_synth.loop.find_anchors", side_effect=fake_find),
+        patch("jfox.gem_synth.loop.synthesize_anchor", side_effect=RuntimeError("boom")),
+        patch("jfox.gem_synth.loop.SynthesisLog", return_value=mock_log),
+    ):
+        gm.return_value.get_gem_synthesis_config.return_value = cfg
+        msg = _tick_once(threading.Event())
+    # mark_failed 被调（坏锚点被隔离）
+    mock_log.mark_failed.assert_called()
+    assert "failed=1" in msg
+
+
+def test_tick_find_anchors_exception_distinct_message():
+    """find_anchors 抛异常时，返回 msg 应与'无锚点'区分（含 find_anchors 字样）"""
+    from jfox.gem_synth.loop import _tick_once
+
+    cfg = MagicMock(
+        enabled=True,
+        anchor_types=["correction"],
+        grounding_top_k=5,
+        target_kb=None,
+        interval_minutes=30,
+    )
+    mock_log = MagicMock()
+    with (
+        patch("jfox.gem_synth.loop.get_global_config_manager") as gm,
+        patch("jfox.gem_synth.loop.find_anchors", side_effect=RuntimeError("db locked")),
+        patch("jfox.gem_synth.loop.SynthesisLog", return_value=mock_log),
+    ):
+        gm.return_value.get_gem_synthesis_config.return_value = cfg
+        msg = _tick_once(threading.Event())
+    assert "find_anchors" in msg
+    assert "异常" in msg
+
+
 def test_tick_time_budget_stops_immediately_when_zero():
     """interval_minutes=0 → 预算 0，不处理任何锚点（时间检查在合成前）"""
     cfg = MagicMock()

--- a/tests/unit/test_gem_synth_store.py
+++ b/tests/unit/test_gem_synth_store.py
@@ -91,3 +91,15 @@ def test_migration_adds_columns_to_old_table(tmp_path):
     log.mark_failed(2, "x")
     assert log.status_counts() == {"success": 1, "failed": 1}
     log.close()
+
+
+def test_migration_idempotent_when_columns_exist(tmp_path):
+    """列已存在时 _maybe_migrate 不应抛 duplicate column（多进程同时迁移场景）"""
+    from jfox.gem_synth.store import SynthesisLog
+
+    log = SynthesisLog(db_path=tmp_path / "s.db")  # 首次建表已含列
+    # 再开一次 → _maybe_migrate 看到 status/fail_reason 已存在 → 跳过，不抛
+    log2 = SynthesisLog(db_path=tmp_path / "s.db")
+    log2.status_counts()  # 不抛即通过
+    log.close()
+    log2.close()

--- a/tests/unit/test_gem_synth_store.py
+++ b/tests/unit/test_gem_synth_store.py
@@ -29,3 +29,65 @@ def test_idempotent_mark(tmp_path):
     log.mark_processed(1, "c1")
     log.mark_processed(1, "c1b")  # 重复不应崩
     assert log.is_processed(1) is True
+
+
+def test_mark_failed_and_status_counts(tmp_path):
+    from jfox.gem_synth.store import SynthesisLog
+
+    log = SynthesisLog(db_path=tmp_path / "s.db")
+    log.mark_processed(1, "c1")
+    log.mark_failed(2, "no transcript_path")
+    log.mark_failed(3, "llm failed: 非 JSON")
+    counts = log.status_counts()
+    assert counts == {"success": 1, "failed": 2}
+    log.close()
+
+
+def test_list_failed(tmp_path):
+    from jfox.gem_synth.store import SynthesisLog
+
+    log = SynthesisLog(db_path=tmp_path / "s.db")
+    log.mark_failed(2, "no transcript_path")
+    log.mark_processed(1, "c1")
+    log.mark_failed(3, "llm failed")
+    failed = log.list_failed()
+    ids = [f["anchor_fragment_id"] for f in failed]
+    assert 2 in ids and 3 in ids and 1 not in ids
+    assert all(f["fail_reason"] for f in failed)
+    log.close()
+
+
+def test_failed_anchor_is_processed_not_retried(tmp_path):
+    """failed 也算已处理 → filter_unprocessed 不返回它"""
+    from jfox.gem_synth.store import SynthesisLog
+
+    log = SynthesisLog(db_path=tmp_path / "s.db")
+    log.mark_failed(5, "boom")
+    assert log.is_processed(5) is True
+    assert log.filter_unprocessed([5, 6]) == [6]
+    log.close()
+
+
+def test_migration_adds_columns_to_old_table(tmp_path):
+    """旧表（无 status/fail_reason 列）建后 SynthesisLog 能升级"""
+    import sqlite3
+
+    p = tmp_path / "old.db"
+    conn = sqlite3.connect(str(p))
+    conn.execute(
+        "CREATE TABLE synthesis_log (anchor_fragment_id INTEGER PRIMARY KEY, "
+        "candidate_note_id TEXT NOT NULL, synthesized_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)"
+    )
+    conn.execute(
+        "INSERT INTO synthesis_log (anchor_fragment_id, candidate_note_id) VALUES (1, 'c1')"
+    )
+    conn.commit()
+    conn.close()
+    from jfox.gem_synth.store import SynthesisLog
+
+    log = SynthesisLog(db_path=p)
+    counts = log.status_counts()
+    assert counts == {"success": 1}
+    log.mark_failed(2, "x")
+    assert log.status_counts() == {"success": 1, "failed": 1}
+    log.close()

--- a/tests/unit/test_gem_synth_synthesizer.py
+++ b/tests/unit/test_gem_synth_synthesizer.py
@@ -46,6 +46,7 @@ def test_synthesize_anchor_produces_candidate_note(tmp_path):
 
 
 def test_synthesize_anchor_skips_when_llm_returns_none(tmp_path):
+    """LLM 返 None → mark_failed('llm synthesis failed')，is_processed=True（不重试）"""
     log = SynthesisLog(db_path=tmp_path / "syn.db")
     with (
         patch("jfox.gem_synth.synthesizer.extract_turn_around", return_value="上下文"),
@@ -54,14 +55,78 @@ def test_synthesize_anchor_skips_when_llm_returns_none(tmp_path):
     ):
         result = synthesize_anchor(_anchor(43, tmp_path), log=log, cfg=MagicMock(grounding_top_k=5))
     assert result is None
-    assert log.is_processed(43) is False  # 失败不记账，下轮可重试
+    assert log.is_processed(43) is True  # 失败也记账，下轮不重试
+    failed = log.list_failed()
+    assert any(
+        f["anchor_fragment_id"] == 43 and "llm" in f["fail_reason"].lower() for f in failed
+    )
 
 
 def test_synthesize_anchor_skips_when_no_transcript(tmp_path):
+    """无 transcript_path → mark_failed('no transcript_path')"""
     log = SynthesisLog(db_path=tmp_path / "syn.db")
     a = _anchor(44, tmp_path)
     a["transcript_path"] = None
     assert synthesize_anchor(a, log=log, cfg=MagicMock(grounding_top_k=5)) is None
+    assert log.is_processed(44) is True
+    failed = log.list_failed()
+    assert any(
+        f["anchor_fragment_id"] == 44 and "transcript" in f["fail_reason"] for f in failed
+    )
+
+
+def test_synthesize_marks_failed_when_no_transcript(tmp_path):
+    """无 transcript_path → mark_failed，不重试"""
+    log = SynthesisLog(db_path=tmp_path / "s.db")
+    anchor = {
+        "fragment_id": 44,
+        "session_id": "s",
+        "timestamp": "t",
+        "content": "x",
+        "transcript_path": None,
+        "metadata": {},
+    }
+    result = synthesize_anchor(
+        anchor, log=log, cfg=MagicMock(grounding_top_k=5), stop_event=None
+    )
+    assert result is None
+    assert log.is_processed(44) is True  # failed 也算已处理
+    failed = log.list_failed()
+    assert any(
+        f["anchor_fragment_id"] == 44 and "transcript" in f["fail_reason"] for f in failed
+    )
+    log.close()
+
+
+def test_synthesize_marks_failed_when_llm_none(tmp_path):
+    """LLM 返 None → mark_failed('llm ...')"""
+    log = SynthesisLog(db_path=tmp_path / "s.db")
+    anchor = {
+        "fragment_id": 45,
+        "session_id": "s",
+        "timestamp": "t",
+        "content": "x",
+        "transcript_path": str(tmp_path / "t.jsonl"),
+        "metadata": {},
+    }
+    (tmp_path / "t.jsonl").write_text(
+        '{"type":"user","message":{"role":"user","content":"x"},"timestamp":"t","uuid":"u"}',
+        encoding="utf-8",
+    )
+    with (
+        patch("jfox.gem_synth.synthesizer.extract_turn_around", return_value="上下文"),
+        patch("jfox.gem_synth.synthesizer.fetch_grounding", return_value=[]),
+        patch("jfox.gem_synth.synthesizer.synthesize_with_llm", return_value=None),
+    ):
+        result = synthesize_anchor(
+            anchor, log=log, cfg=MagicMock(grounding_top_k=5), stop_event=None
+        )
+    assert result is None
+    failed = log.list_failed()
+    assert any(
+        f["anchor_fragment_id"] == 45 and "llm" in f["fail_reason"].lower() for f in failed
+    )
+    log.close()
 
 
 def test_synthesize_handles_non_numeric_confidence(tmp_path):

--- a/tests/unit/test_gem_synth_synthesizer.py
+++ b/tests/unit/test_gem_synth_synthesizer.py
@@ -57,9 +57,7 @@ def test_synthesize_anchor_skips_when_llm_returns_none(tmp_path):
     assert result is None
     assert log.is_processed(43) is True  # 失败也记账，下轮不重试
     failed = log.list_failed()
-    assert any(
-        f["anchor_fragment_id"] == 43 and "llm" in f["fail_reason"].lower() for f in failed
-    )
+    assert any(f["anchor_fragment_id"] == 43 and "llm" in f["fail_reason"].lower() for f in failed)
 
 
 def test_synthesize_anchor_skips_when_no_transcript(tmp_path):
@@ -70,9 +68,7 @@ def test_synthesize_anchor_skips_when_no_transcript(tmp_path):
     assert synthesize_anchor(a, log=log, cfg=MagicMock(grounding_top_k=5)) is None
     assert log.is_processed(44) is True
     failed = log.list_failed()
-    assert any(
-        f["anchor_fragment_id"] == 44 and "transcript" in f["fail_reason"] for f in failed
-    )
+    assert any(f["anchor_fragment_id"] == 44 and "transcript" in f["fail_reason"] for f in failed)
 
 
 def test_synthesize_marks_failed_when_no_transcript(tmp_path):
@@ -86,15 +82,11 @@ def test_synthesize_marks_failed_when_no_transcript(tmp_path):
         "transcript_path": None,
         "metadata": {},
     }
-    result = synthesize_anchor(
-        anchor, log=log, cfg=MagicMock(grounding_top_k=5), stop_event=None
-    )
+    result = synthesize_anchor(anchor, log=log, cfg=MagicMock(grounding_top_k=5), stop_event=None)
     assert result is None
     assert log.is_processed(44) is True  # failed 也算已处理
     failed = log.list_failed()
-    assert any(
-        f["anchor_fragment_id"] == 44 and "transcript" in f["fail_reason"] for f in failed
-    )
+    assert any(f["anchor_fragment_id"] == 44 and "transcript" in f["fail_reason"] for f in failed)
     log.close()
 
 
@@ -123,9 +115,7 @@ def test_synthesize_marks_failed_when_llm_none(tmp_path):
         )
     assert result is None
     failed = log.list_failed()
-    assert any(
-        f["anchor_fragment_id"] == 45 and "llm" in f["fail_reason"].lower() for f in failed
-    )
+    assert any(f["anchor_fragment_id"] == 45 and "llm" in f["fail_reason"].lower() for f in failed)
     log.close()
 
 


### PR DESCRIPTION
## Summary

实现 #283：给 gem_synth 循环加安全限流 + 合成进度可观测性，**解除安全启用 gem_synth 的阻塞**。

**三个改动：**
1. **时间预算限流** —— `_tick_once` 改串行时间预算循环（每轮跑 `interval_minutes` 窗口，一次取一个锚点），替代无上限 batch。~5min/次合成 → 30min 窗口自然 ~5-6 个，429 零风险，积压时 back-to-back 连续跑
2. **合成 ledger** —— `synthesis_log` 加 `status`(success/failed) + `fail_reason` 列 + migration；失败锚点 `mark_failed` 记账（**不重试**，过夜跑不 thrash）
3. **`jfox gem-synth status`** —— 看进度（pending/success/failed）+ `--failed` 捞失败锚点人工复核

设计：`docs/superpowers/specs/2026-06-25-gem-synth-throttle-ledger-design.md`

## Test Plan
- [x] SynthesisLog: mark_failed/status_counts/list_failed/migration（4 测试）
- [x] synthesize_anchor: 各失败路径 mark_failed（2 测试）
- [x] loop: 时间预算循环 + limit=1（2 新测试，2 既有适配）
- [x] status 命令 + count_anchors（5 测试）
- [x] CI lint `jfox/ tests/` 全绿
- [ ] Zima CR（打标签后）

Closes #283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)