### PR TITLE
fix(gem-synth): 剥 claude markdown 代码围栏，修合成全失败 (#283)

### DIFF
--- a/jfox/gem_synth/llm.py
+++ b/jfox/gem_synth/llm.py
@@ -7,7 +7,6 @@
 import json
 import logging
 import os
-import re
 import shutil
 import signal
 import subprocess
@@ -206,26 +205,39 @@ def _invoke_claude(
                 pass
 
 
-def _strip_code_fence(s: str) -> str:
-    """剥 claude 常见的 markdown 代码围栏，返回围栏内文本（用于解析模型 JSON 输出）。
+def _parse_json_lenient(inner: Any) -> Optional[Dict[str, Any]]:
+    """从模型输出解析 JSON 对象，容忍 markdown 围栏 / 前导解释文本 / 尾部噪声。
 
-    模型即使被要求"裸 JSON"也常包代码围栏；不剥会让 json.loads 碰反引号崩。
-    规则：
-    - 首字符是 {（裸 JSON 对象）→ 原样返回。绝不 regex 全文搜索，否则 content 字段里
-      嵌的 ``` 代码示例会被误当外层围栏提取、截断 JSON（kimi R3 issue-4 回归）。
-    - 否则（外层有围栏或前导文本）→ 优先取 ```json 标记块（避免误取前面的非 JSON 代码
-      围栏），取不到才退回第一个围栏。极端嵌套不专门处理（本 prompt 下不会出现）。
+    模型常把 JSON 包在 ```json ... ``` 里，或前后加解释文本。早期用 fence-strip 正则
+    提取，但当 JSON 的 content 字段内部含 ``` 代码示例（代码宝石常见）时，正则会把
+    内部 ``` 当外层围栏终点、截断 JSON（kimi R3/R4 issue-4/5）。正则路径本质脆弱。
+
+    改解析式（JSON 解析器尊重字符串字面量，content 内的 ``` 干扰不了它）：
+    1. 直接 json.loads（裸 JSON：含 content 内代码围栏也安全，因 ``` 在字符串字面量内）
+    2. 失败则定位首个 {，用 raw_decode 容忍前导 ```json/解释文本 + 尾部 ```（围栏场景）
+    3. 都失败返回 None（调用方 mark_failed）
+
+    唯一边界：首个 { 落在 JSON 之前的非 JSON 代码块里（极 contrived）才误取，且仍 graceful
+    （缺 title → mark_failed），不崩。
     """
-    s = s.strip()
-    # 裸 JSON 对象：直接返回，不动内部（content 字段可能含 ``` 代码示例）
-    if s.startswith("{"):
-        return s
-    # 外层有围栏/前导文本：优先 ```json 标记块，无则退回第一个围栏
-    for pattern in (r"```json\s*(.*?)```", r"```(?:\w+)?\s*(.*?)```"):
-        m = re.search(pattern, s, re.DOTALL)
-        if m:
-            return m.group(1).strip()
-    return s
+    if isinstance(inner, dict):
+        return inner
+    if not isinstance(inner, str):
+        return None
+    s = inner.strip()
+    try:
+        obj = json.loads(s)
+        return obj if isinstance(obj, dict) else None
+    except json.JSONDecodeError:
+        pass
+    idx = s.find("{")
+    if idx < 0:
+        return None
+    try:
+        obj, _end = json.JSONDecoder().raw_decode(s[idx:])
+        return obj if isinstance(obj, dict) else None
+    except json.JSONDecodeError:
+        return None
 
 
 def synthesize_with_llm(
@@ -247,10 +259,8 @@ def synthesize_with_llm(
         raw = _invoke_claude(prompt, cfg, stop_event)
         wrapper = json.loads(raw)
         inner = wrapper.get("result", raw) if isinstance(wrapper, dict) else raw
-        # 剥 claude 常给的 markdown 代码围栏（```json ... ```），否则 json.loads 碰反引号崩
-        if isinstance(inner, str):
-            inner = _strip_code_fence(inner)
-        parsed = json.loads(inner) if isinstance(inner, str) else inner
+        # 容忍 markdown 围栏/前导文本：解析式提取 JSON（content 内代码围栏也安全）
+        parsed = _parse_json_lenient(inner)
         if not isinstance(parsed, dict) or "title" not in parsed:
             logger.warning("LLM 输出缺 title: %r", parsed)
             logger.debug("LLM raw output: %r", raw)

--- a/jfox/gem_synth/llm.py
+++ b/jfox/gem_synth/llm.py
@@ -206,19 +206,18 @@ def _invoke_claude(
 
 
 def _parse_json_lenient(inner: Any) -> Optional[Dict[str, Any]]:
-    """从模型输出解析 JSON 对象，容忍 markdown 围栏 / 前导解释文本 / 尾部噪声。
+    """从模型输出解析 JSON 对象，容忍 markdown 围栏 / 前导解释文本 / 前置代码块 / 尾部噪声。
 
-    模型常把 JSON 包在 ```json ... ``` 里，或前后加解释文本。早期用 fence-strip 正则
-    提取，但当 JSON 的 content 字段内部含 ``` 代码示例（代码宝石常见）时，正则会把
+    模型常把 JSON 包在 ```json ... ``` 里，或前后加解释文本/代码示例。早期用 fence-strip
+    正则提取，但当 JSON 的 content 字段内部含 ``` 代码示例（代码宝石常见）时，正则会把
     内部 ``` 当外层围栏终点、截断 JSON（kimi R3/R4 issue-4/5）。正则路径本质脆弱。
 
-    改解析式（JSON 解析器尊重字符串字面量，content 内的 ``` 干扰不了它）：
+    改解析式（JSON 解析器尊重字符串字面量，content 内的 ``` / { 干扰不了它）：
     1. 直接 json.loads（裸 JSON：含 content 内代码围栏也安全，因 ``` 在字符串字面量内）
-    2. 失败则定位首个 {，用 raw_decode 容忍前导 ```json/解释文本 + 尾部 ```（围栏场景）
+    2. 失败则扫描所有 { 位置，各自 raw_decode，取**跨度最大**的有效 JSON 对象——目标 gem
+       比前导文本/代码块里的零散小对象（如 python 字典示例）更长，故胜出；schema 无关，
+       且 content 内的 { 其片段跨度也小于整个 gem（kimi R5 issue-6）
     3. 都失败返回 None（调用方 mark_failed）
-
-    唯一边界：首个 { 落在 JSON 之前的非 JSON 代码块里（极 contrived）才误取，且仍 graceful
-    （缺 title → mark_failed），不崩。
     """
     if isinstance(inner, dict):
         return inner
@@ -230,14 +229,20 @@ def _parse_json_lenient(inner: Any) -> Optional[Dict[str, Any]]:
         return obj if isinstance(obj, dict) else None
     except json.JSONDecodeError:
         pass
-    idx = s.find("{")
-    if idx < 0:
-        return None
-    try:
-        obj, _end = json.JSONDecoder().raw_decode(s[idx:])
-        return obj if isinstance(obj, dict) else None
-    except json.JSONDecodeError:
-        return None
+    # 扫描所有 {，raw_decode 各自尝试，取跨度最大（字符最多）的有效 JSON 对象
+    decoder = json.JSONDecoder()
+    best: Optional[Dict[str, Any]] = None
+    best_end = -1
+    for i, ch in enumerate(s):
+        if ch != "{":
+            continue
+        try:
+            obj, end = decoder.raw_decode(s[i:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and end > best_end:
+            best, best_end = obj, end
+    return best
 
 
 def synthesize_with_llm(

--- a/jfox/gem_synth/llm.py
+++ b/jfox/gem_synth/llm.py
@@ -7,6 +7,7 @@
 import json
 import logging
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -206,21 +207,18 @@ def _invoke_claude(
 
 
 def _strip_code_fence(s: str) -> str:
-    """剥 claude 常见的 markdown 代码围栏（```json ... ``` / ``` ... ```），返回内部文本。
+    """剥 claude 常见的 markdown 代码围栏，返回围栏内文本（用于解析模型 JSON 输出）。
 
-    模型即使被要求"裸 JSON"也常包代码围栏；不剥会让 json.loads 碰首字符反引号崩。
-    无围栏或首字符非 ``` 则原样返回（strip 首尾空白后）。
+    模型即使被要求"裸 JSON"也常包代码围栏；不剥会让 json.loads 碰反引号崩。
+    处理：整体围栏（```json ... ```）、前带解释文本的围栏、裸围栏；无围栏则原样返回。
+    多组围栏取第一个（非贪婪）；极端嵌套不专门处理（本 prompt 下不会出现）。
     """
     s = s.strip()
-    if not s.startswith("```"):
-        return s
-    lines = s.splitlines()
-    # 去首行围栏开头（``` 或 ```json 等）
-    lines = lines[1:]
-    # 去末行 ``` 收尾（若有）
-    if lines and lines[-1].strip() == "```":
-        lines = lines[:-1]
-    return "\n".join(lines).strip()
+    # 非贪婪匹配第一个 ```...``` 围栏块（可选语言标签 json 等），取其内容
+    m = re.search(r"```(?:\w+)?\s*(.*?)```", s, re.DOTALL)
+    if m:
+        return m.group(1).strip()
+    return s
 
 
 def synthesize_with_llm(

--- a/jfox/gem_synth/llm.py
+++ b/jfox/gem_synth/llm.py
@@ -211,13 +211,15 @@ def _strip_code_fence(s: str) -> str:
 
     模型即使被要求"裸 JSON"也常包代码围栏；不剥会让 json.loads 碰反引号崩。
     处理：整体围栏（```json ... ```）、前带解释文本的围栏、裸围栏；无围栏则原样返回。
-    多组围栏取第一个（非贪婪）；极端嵌套不专门处理（本 prompt 下不会出现）。
+    多组围栏时优先取 ```json 标记块，避免前面若有其它代码围栏（如 ```python）时误取；
+    取不到 json 标记才退回第一个围栏。极端嵌套不专门处理（本 prompt 下不会出现）。
     """
     s = s.strip()
-    # 非贪婪匹配第一个 ```...``` 围栏块（可选语言标签 json 等），取其内容
-    m = re.search(r"```(?:\w+)?\s*(.*?)```", s, re.DOTALL)
-    if m:
-        return m.group(1).strip()
+    # 优先 ```json 标记块（避免误取前面的非 JSON 代码块）；无则退回第一个围栏
+    for pattern in (r"```json\s*(.*?)```", r"```(?:\w+)?\s*(.*?)```"):
+        m = re.search(pattern, s, re.DOTALL)
+        if m:
+            return m.group(1).strip()
     return s
 
 

--- a/jfox/gem_synth/llm.py
+++ b/jfox/gem_synth/llm.py
@@ -28,7 +28,8 @@ SYSTEM_PROMPT = """你是知识合成器。给定一段对话上下文和若干�
   "knowledge_type": "factual|procedural|preference|constraint",
   "grounded_by": ["引用的永久笔记标题列表"]
 }
-若上下文不足以合成有效知识，confidence 给低分（<0.3）并简述原因。不要编造基准里没有的事实。"""
+若上下文不足以合成有效知识，confidence 给低分（<0.3）并简述原因。不要编造基准里没有的事实。
+直接输出 JSON 对象本身，不要用 markdown 代码围栏包裹（不要 ```json ... ```）。"""
 
 
 def _resolve_claude_binary(cfg: GemSynthesisConfig) -> str:
@@ -204,6 +205,24 @@ def _invoke_claude(
                 pass
 
 
+def _strip_code_fence(s: str) -> str:
+    """剥 claude 常见的 markdown 代码围栏（```json ... ``` / ``` ... ```），返回内部文本。
+
+    模型即使被要求"裸 JSON"也常包代码围栏；不剥会让 json.loads 碰首字符反引号崩。
+    无围栏或首字符非 ``` 则原样返回（strip 首尾空白后）。
+    """
+    s = s.strip()
+    if not s.startswith("```"):
+        return s
+    lines = s.splitlines()
+    # 去首行围栏开头（``` 或 ```json 等）
+    lines = lines[1:]
+    # 去末行 ``` 收尾（若有）
+    if lines and lines[-1].strip() == "```":
+        lines = lines[:-1]
+    return "\n".join(lines).strip()
+
+
 def synthesize_with_llm(
     turn_context: str,
     grounding: List[Dict[str, Any]],
@@ -223,6 +242,9 @@ def synthesize_with_llm(
         raw = _invoke_claude(prompt, cfg, stop_event)
         wrapper = json.loads(raw)
         inner = wrapper.get("result", raw) if isinstance(wrapper, dict) else raw
+        # 剥 claude 常给的 markdown 代码围栏（```json ... ```），否则 json.loads 碰反引号崩
+        if isinstance(inner, str):
+            inner = _strip_code_fence(inner)
         parsed = json.loads(inner) if isinstance(inner, str) else inner
         if not isinstance(parsed, dict) or "title" not in parsed:
             logger.warning("LLM 输出缺 title: %r", parsed)

--- a/jfox/gem_synth/llm.py
+++ b/jfox/gem_synth/llm.py
@@ -210,12 +210,17 @@ def _strip_code_fence(s: str) -> str:
     """剥 claude 常见的 markdown 代码围栏，返回围栏内文本（用于解析模型 JSON 输出）。
 
     模型即使被要求"裸 JSON"也常包代码围栏；不剥会让 json.loads 碰反引号崩。
-    处理：整体围栏（```json ... ```）、前带解释文本的围栏、裸围栏；无围栏则原样返回。
-    多组围栏时优先取 ```json 标记块，避免前面若有其它代码围栏（如 ```python）时误取；
-    取不到 json 标记才退回第一个围栏。极端嵌套不专门处理（本 prompt 下不会出现）。
+    规则：
+    - 首字符是 {（裸 JSON 对象）→ 原样返回。绝不 regex 全文搜索，否则 content 字段里
+      嵌的 ``` 代码示例会被误当外层围栏提取、截断 JSON（kimi R3 issue-4 回归）。
+    - 否则（外层有围栏或前导文本）→ 优先取 ```json 标记块（避免误取前面的非 JSON 代码
+      围栏），取不到才退回第一个围栏。极端嵌套不专门处理（本 prompt 下不会出现）。
     """
     s = s.strip()
-    # 优先 ```json 标记块（避免误取前面的非 JSON 代码块）；无则退回第一个围栏
+    # 裸 JSON 对象：直接返回，不动内部（content 字段可能含 ``` 代码示例）
+    if s.startswith("{"):
+        return s
+    # 外层有围栏/前导文本：优先 ```json 标记块，无则退回第一个围栏
     for pattern in (r"```json\s*(.*?)```", r"```(?:\w+)?\s*(.*?)```"):
         m = re.search(pattern, s, re.DOTALL)
         if m:

--- a/tests/unit/test_gem_synth_llm.py
+++ b/tests/unit/test_gem_synth_llm.py
@@ -134,6 +134,33 @@ def test_synthesize_preserves_clean_json_with_code_fence_in_content():
     assert "print('hi')" in result["content"]
 
 
+def test_synthesize_fenced_json_with_code_fence_in_content():
+    """模型把 JSON 包在 ```json 围栏里，且 content 字段内又含 ```python 代码示例时，
+    不能把内部代码块当外层围栏终点、截断 JSON（kimi R4 issue-5）。
+
+    这是代码宝石的高频场景（content 常含代码示例）。正则 fence-strip 在此必崩；
+    解析式（raw_decode）尊重字符串字面量，content 内的 ``` 不干扰。
+    """
+    content_with_code = "示例：\n```python\nprint('hi')\n```\n如上"
+    inner_json = json.dumps(
+        {
+            "title": "含代码的宝石",
+            "content": content_with_code,
+            "confidence": 0.8,
+            "knowledge_type": "procedural",
+            "grounded_by": [],
+        }
+    )
+    # 外层 ```json 围栏包裹，content 内又嵌 ```python
+    fenced = f"```json\n{inner_json}\n```"
+    fake_output = json.dumps({"type": "result", "result": fenced})
+    with patch("jfox.gem_synth.llm._invoke_claude", return_value=fake_output):
+        result = synthesize_with_llm(turn_context="x", grounding=[], cfg=MagicMock())
+    assert result is not None
+    assert result["title"] == "含代码的宝石"
+    assert "print('hi')" in result["content"]
+
+
 def test_synthesize_returns_none_on_invalid_json():
     with patch("jfox.gem_synth.llm._invoke_claude", return_value="not json"):
         assert synthesize_with_llm(turn_context="x", grounding=[], cfg=MagicMock()) is None

--- a/tests/unit/test_gem_synth_llm.py
+++ b/tests/unit/test_gem_synth_llm.py
@@ -86,6 +86,17 @@ def test_synthesize_strips_bare_code_fence():
     assert result["title"] == "裸围栏"
 
 
+def test_synthesize_strips_fence_with_preamble():
+    """模型在围栏前加解释文本时（如"这是 JSON:"），也要正确提取围栏内 JSON。"""
+    inner_json = json.dumps({"title": "带前导文本", "content": "x", "confidence": 0.7})
+    fenced = f"这是合成的 JSON：\n```json\n{inner_json}\n```\n（如上）"
+    fake_output = json.dumps({"type": "result", "result": fenced})
+    with patch("jfox.gem_synth.llm._invoke_claude", return_value=fake_output):
+        result = synthesize_with_llm(turn_context="x", grounding=[], cfg=MagicMock())
+    assert result is not None
+    assert result["title"] == "带前导文本"
+
+
 def test_synthesize_returns_none_on_invalid_json():
     with patch("jfox.gem_synth.llm._invoke_claude", return_value="not json"):
         assert synthesize_with_llm(turn_context="x", grounding=[], cfg=MagicMock()) is None

--- a/tests/unit/test_gem_synth_llm.py
+++ b/tests/unit/test_gem_synth_llm.py
@@ -161,6 +161,30 @@ def test_synthesize_fenced_json_with_code_fence_in_content():
     assert "print('hi')" in result["content"]
 
 
+def test_synthesize_picks_largest_json_object_over_earlier_brace_code():
+    """模型在目标 JSON 前还输出含 { 的代码块（如 python 字典示例）时，
+    应取跨度最大的 JSON 对象（gem），不误取前面的小 {...}（kimi R5 issue-6）。
+
+    单 { 版本会取到前面的小字典就停；扫描所有 { 取最大者才对。
+    """
+    inner_json = json.dumps(
+        {
+            "title": "目标宝石",
+            "content": "x",
+            "confidence": 0.7,
+            "knowledge_type": "procedural",
+            "grounded_by": [],
+        }
+    )
+    # 前面有个含 { 的 python 字典示例（恰好是合法 JSON 语法的小对象），后面才是 gem
+    fenced = f'```python\nd = {{"a": 1, "b": 2}}\n```\n```json\n{inner_json}\n```'
+    fake_output = json.dumps({"type": "result", "result": fenced})
+    with patch("jfox.gem_synth.llm._invoke_claude", return_value=fake_output):
+        result = synthesize_with_llm(turn_context="x", grounding=[], cfg=MagicMock())
+    assert result is not None
+    assert result["title"] == "目标宝石"
+
+
 def test_synthesize_returns_none_on_invalid_json():
     with patch("jfox.gem_synth.llm._invoke_claude", return_value="not json"):
         assert synthesize_with_llm(turn_context="x", grounding=[], cfg=MagicMock()) is None

--- a/tests/unit/test_gem_synth_llm.py
+++ b/tests/unit/test_gem_synth_llm.py
@@ -97,6 +97,17 @@ def test_synthesize_strips_fence_with_preamble():
     assert result["title"] == "带前导文本"
 
 
+def test_synthesize_prefers_json_fenced_block_over_earlier_code_fence():
+    """模型在 JSON 围栏前还输出别的代码围栏时，应优先取 ```json 块（不误取前面的）。"""
+    inner_json = json.dumps({"title": "正确的 JSON", "content": "x", "confidence": 0.6})
+    fenced = f"```python\nprint('hi')\n```\n```json\n{inner_json}\n```"
+    fake_output = json.dumps({"type": "result", "result": fenced})
+    with patch("jfox.gem_synth.llm._invoke_claude", return_value=fake_output):
+        result = synthesize_with_llm(turn_context="x", grounding=[], cfg=MagicMock())
+    assert result is not None
+    assert result["title"] == "正确的 JSON"
+
+
 def test_synthesize_returns_none_on_invalid_json():
     with patch("jfox.gem_synth.llm._invoke_claude", return_value="not json"):
         assert synthesize_with_llm(turn_context="x", grounding=[], cfg=MagicMock()) is None

--- a/tests/unit/test_gem_synth_llm.py
+++ b/tests/unit/test_gem_synth_llm.py
@@ -108,6 +108,32 @@ def test_synthesize_prefers_json_fenced_block_over_earlier_code_fence():
     assert result["title"] == "正确的 JSON"
 
 
+def test_synthesize_preserves_clean_json_with_code_fence_in_content():
+    """模型返回裸 JSON（无外层围栏），但其 content 字段含 ``` 代码示例时，
+    不能误把内部代码块当外层围栏提取（会截断 JSON 致 json.loads 失败）。
+
+    回归 kimi R3 issue-4：regex 全文搜索会把 content 内的 ```python...``` 误当外层围栏。
+    修法：首字符 { 的裸 JSON 原样返回，绝不 regex。
+    """
+    content_with_code = "示例：\n```python\nprint('hi')\n```\n如上"
+    inner_json = json.dumps(
+        {
+            "title": "含代码的知识",
+            "content": content_with_code,
+            "confidence": 0.8,
+            "knowledge_type": "procedural",
+            "grounded_by": [],
+        }
+    )
+    # 裸 JSON（无外层围栏），envelope.result 直接是它
+    fake_output = json.dumps({"type": "result", "result": inner_json})
+    with patch("jfox.gem_synth.llm._invoke_claude", return_value=fake_output):
+        result = synthesize_with_llm(turn_context="x", grounding=[], cfg=MagicMock())
+    assert result is not None
+    assert result["title"] == "含代码的知识"
+    assert "print('hi')" in result["content"]
+
+
 def test_synthesize_returns_none_on_invalid_json():
     with patch("jfox.gem_synth.llm._invoke_claude", return_value="not json"):
         assert synthesize_with_llm(turn_context="x", grounding=[], cfg=MagicMock()) is None

--- a/tests/unit/test_gem_synth_llm.py
+++ b/tests/unit/test_gem_synth_llm.py
@@ -49,6 +49,43 @@ def test_synthesize_returns_parsed_dict():
     assert result["knowledge_type"] == "procedural"
 
 
+def test_synthesize_strips_json_code_fence():
+    """claude 把 JSON 包在 ```json ... ``` 围栏里时，必须剥围栏后解析。
+
+    真实 claude --output-format json 返回 envelope，其 result 字段常被模型包在
+    markdown 代码围栏里（即使 SYSTEM_PROMPT 要求裸 JSON）。不剥围栏会让 json.loads
+    碰到首字符反引号直接崩（JSONDecodeError: Expecting value char 0）→ 合成全失败。
+    """
+    inner_json = json.dumps(
+        {
+            "title": "应优先用 patch",
+            "content": "修改文件优先用 patch",
+            "confidence": 0.8,
+            "knowledge_type": "procedural",
+            "grounded_by": [],
+        }
+    )
+    fenced = f"```json\n{inner_json}\n```"
+    # 模拟真实 claude 返回：envelope.result 是带围栏的字符串
+    fake_output = json.dumps({"type": "result", "subtype": "success", "result": fenced})
+    with patch("jfox.gem_synth.llm._invoke_claude", return_value=fake_output):
+        result = synthesize_with_llm(turn_context="x", grounding=[], cfg=MagicMock())
+    assert result is not None
+    assert result["title"] == "应优先用 patch"
+    assert result["confidence"] == 0.8
+
+
+def test_synthesize_strips_bare_code_fence():
+    """围栏无语言标签（``` ... ```）时也要正确剥。"""
+    inner_json = json.dumps({"title": "裸围栏", "content": "x", "confidence": 0.5})
+    fenced = f"```\n{inner_json}\n```"
+    fake_output = json.dumps({"type": "result", "result": fenced})
+    with patch("jfox.gem_synth.llm._invoke_claude", return_value=fake_output):
+        result = synthesize_with_llm(turn_context="x", grounding=[], cfg=MagicMock())
+    assert result is not None
+    assert result["title"] == "裸围栏"
+
+
 def test_synthesize_returns_none_on_invalid_json():
     with patch("jfox.gem_synth.llm._invoke_claude", return_value="not json"):
         assert synthesize_with_llm(turn_context="x", grounding=[], cfg=MagicMock()) is None

--- a/tests/unit/test_gem_synth_loop.py
+++ b/tests/unit/test_gem_synth_loop.py
@@ -72,6 +72,9 @@ def test_tick_synthesize_exception_does_not_crash():
             side_effect=[anchor_once, []],
         ),
         patch("jfox.gem_synth.loop.synthesize_anchor", side_effect=RuntimeError("boom")),
+        # mock SynthesisLog，避免用默认路径写真实 ~/.zettelkasten/synthesis_log.db
+        # （污染用户库：曾把测试的 "unhandled: boom" 写进真实 ledger）
+        patch("jfox.gem_synth.loop.SynthesisLog", return_value=MagicMock()),
     ):
         gm.return_value.get_gem_synthesis_config.return_value = cfg
         msg = _tick_once(threading.Event())  # 不应抛


### PR DESCRIPTION
## 问题
v1.2.1 启用 gem_synth 后，**每个锚点合成都失败**（pending 97 / success 0 / failed 全员）。

根因：claude `--output-format json` 返回 envelope，其 `result` 字段被模型包在 markdown 围栏 ```` ```json ... ``` ```` 里（即使 SYSTEM_PROMPT 要求裸 JSON，模型仍常包）。`synthesize_with_llm` 直接 `json.loads(inner)` 碰首字符反引号 → `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` → 全标 failed。

实测确认（手动跑 gem_synth 风格的 claude 调用）：
```
"result":"```json\n{\"title\":\"测试\",...}\n```"
```

## 修复
- `jfox/gem_synth/llm.py`：加 `_strip_code_fence`，`json.loads(inner)` 前剥 ```` ```json...``` ```` / ```` ```...``` ```` 围栏（无围栏则原样返回）
- `SYSTEM_PROMPT`：明确"直接输出 JSON 对象，不要 markdown 代码围栏"（辅助；解析器防御才是权威）
- 补 2 测试：带 ```` ```json ```` 围栏 + 裸 ```` ``` ```` 围栏，均应正确解析（补 #274 mock 干净 JSON 的覆盖盲区）

## 顺手修测试污染
`test_tick_synthesize_exception_does_not_crash` 之前用默认 `SynthesisLog()`（无 mock），把测试的 `"unhandled: boom"` 写进真实 `~/.zettelkasten/synthesis_log.db`。改 mock `SynthesisLog`。

## 验证
- TDD：先写 2 失败测试（复现 char 0 报错），修复后通过
- 全 gem_synth 单测 67 passed
- `black --check jfox/ tests/`（144 clean）+ `ruff check` clean

Closes #283（gem_synth 可用性的最后一环——开启后真正能合成）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)