### PR TITLE
chore: bump version to 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to jfox-cli will be documented in this file.
 
+## [1.2.2] - 2026-06-28
+
+### Fixes
+- **gem-synth**: 剥 claude markdown 代码围栏，修合成全失败 (#283) (#288)
+- **add**: 创建目标笔记后回填引用方的正向 links (#276)
+
+[1.2.2]: https://github.com/zhuxixi/jfox/compare/v1.2.1...v1.2.2
+
 ## [1.2.1] - 2026-06-26
 
 ### Features

--- a/jfox/__init__.py
+++ b/jfox/__init__.py
@@ -1,5 +1,5 @@
 """JFox - Zettelkasten 知识管理工具"""
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 __author__ = "User"
 __email__ = "user@example.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jfox-cli"
-version = "1.2.1"
+version = "1.2.2"
 description = "JFox - Zettelkasten 知识管理 CLI 工具"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -867,7 +867,7 @@ wheels = [
 
 [[package]]
 name = "jfox-cli"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary
Bump version from 1.2.1 to 1.2.2

## [1.2.2] - 2026-06-28

### Fixes
- **gem-synth**: 剥 claude markdown 代码围栏，修合成全失败 (#283) (#288)
- **add**: 创建目标笔记后回填引用方的正向 links (#276)

[1.2.2]: https://github.com/zhuxixi/jfox/compare/v1.2.1...v1.2.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)